### PR TITLE
Increase stall interval for queue uploads

### DIFF
--- a/pages/deployment/[uuid].tsx
+++ b/pages/deployment/[uuid].tsx
@@ -123,7 +123,7 @@ export default function Deployment() {
   const error = MultipleErrorWrapper(`Unable to load deployment page`, {
     isDeploymentError,
     isUiConfigError,
-    isCurrentUserError
+    isCurrentUserError,
   })
   if (error) return error
 

--- a/server/utils/queues.ts
+++ b/server/utils/queues.ts
@@ -4,7 +4,7 @@ import config from 'config'
 export const uploadQueue = new Queue('UPLOAD_QUEUE', {
   redis: config.get('redis'),
 
-  // model building may take a minutes, especially when the cache is cold
+  // model building may take a few minutes, especially when the cache is cold
   stallInterval: 120000,
 })
 

--- a/server/utils/queues.ts
+++ b/server/utils/queues.ts
@@ -6,7 +6,6 @@ export const uploadQueue = new Queue('UPLOAD_QUEUE', {
 
   // model building may take a minutes, especially when the cache is cold
   stallInterval: 120000,
-  
 })
 
 export const deploymentQueue = new Queue('DEPLOYMENT_QUEUE', {

--- a/server/utils/queues.ts
+++ b/server/utils/queues.ts
@@ -3,6 +3,10 @@ import config from 'config'
 
 export const uploadQueue = new Queue('UPLOAD_QUEUE', {
   redis: config.get('redis'),
+
+  // model building may take a minutes, especially when the cache is cold
+  stallInterval: 120000,
+  
 })
 
 export const deploymentQueue = new Queue('DEPLOYMENT_QUEUE', {


### PR DESCRIPTION
When images are built the 'pull' length might be long, exceeding the default time period.  This sometimes causes jobs to be retried.  This pull request increases the stall interval to 120 seconds.

This was dodgy in the past because generally our image pulls are very fast, taking less than a second.  The issue arose when the docker cache was empty resulting in a long pull from Dockerhub.

I found I could reproduce the issue with:

```
docker rmi $(docker images -a --filter=dangling=true -q)
docker rm $(docker ps --filter=status=exited --filter=status=created -q)
```