### PR TITLE
Separate secret creation & installing of helm chart steps

### DIFF
--- a/helm/README.md
+++ b/helm/README.md
@@ -11,6 +11,10 @@ All commands assume they are run in the `helm/bailo` directory with the right co
 
 1. `kubectl config set-context --current --namespace=bailo`
 
+All commands also assume that the namespace is already created, a namespace can be created with:
+
+1. `kubectl create namespace bailo`
+
 #### Configuration
 
 Deployment options can be overridden by including a `--values <file containing overrides>` to a Helm command, or by using `--set <option>=<value>`.
@@ -29,16 +33,13 @@ This image can be built with `docker build -t bailo .` in the root directory. Th
 #### Install Bailo
 
 1. `helm dependency update`
-2. `helm install --create-namespace --values ./local.yaml bailo .`
-3. `helm list # list current deployments`
+2. `ts-node --project ../../tsconfig.server.json createSecrets.ts`
+3. `helm install --values ./local.yaml bailo .`
+4. `helm list # list current deployments`
 
 #### Upgrade Bailo
 
-Initially get the existing secrets used for the cluster. These are needed to bring up the new containers.
-
-1. `export ROOT_USER=$(kubectl get secret bailo-minio -o jsonpath="{.data.root-user}" | base64 --decode)`
-2. `export ROOT_PASSWORD=$(kubectl get secret bailo-minio -o jsonpath="{.data.root-password}" | base64 --decode)`
-3. `helm upgrade --values ./local.yaml bailo . --set minio.auth.rootUser=$ROOT_USER --set minio.auth.rootPassword=$ROOT_PASSWORD`
+1. `helm upgrade --values ./local.yaml bailo .`
 
 #### Removing Bailo
 

--- a/helm/bailo/createSecrets.ts
+++ b/helm/bailo/createSecrets.ts
@@ -7,7 +7,7 @@ export default async function createSecrets() {
   // minio secrets
   const rootUser = uuidv4()
   const rootPassword = uuidv4()
-  
+
   exec(`kubectl create secret generic ${prefix}-minio \
     --from-literal=root-user='${rootUser}' \
     --from-literal=root-password='${rootPassword}'

--- a/helm/bailo/createSecrets.ts
+++ b/helm/bailo/createSecrets.ts
@@ -1,0 +1,35 @@
+import { exec } from 'shelljs'
+import { v4 as uuidv4 } from 'uuid'
+
+const prefix = 'bailo'
+
+export default async function createSecrets() {
+  // minio secrets
+  const rootUser = uuidv4()
+  const rootPassword = uuidv4()
+  
+  exec(`kubectl create secret generic ${prefix}-minio \
+    --from-literal=root-user='${rootUser}' \
+    --from-literal=root-password='${rootPassword}'
+  `)
+
+  // mongo secrets
+  const mongodbPassword = uuidv4()
+  const mongodbRootPassword = uuidv4()
+  const mongodbReplicaSetKey = uuidv4()
+
+  exec(`kubectl create secret generic ${prefix}-mongodb \
+    --from-literal=mongodb-passwords='${mongodbPassword}' \
+    --from-literal=mongodb-root-password='${mongodbRootPassword}' \
+    --from-literal=mongodb-replica-set-key='${mongodbReplicaSetKey}'
+  `)
+
+  // redis secrets
+  const redisPassword = uuidv4()
+
+  exec(`kubectl create secret generic ${prefix}-redis \
+    --from-literal=redis-password='${redisPassword}'
+  `)
+}
+
+createSecrets()

--- a/helm/bailo/values.yaml
+++ b/helm/bailo/values.yaml
@@ -74,6 +74,7 @@ mongodb:
     enabled: true
     rootUser: ""
     rootPassword: ""
+    existingSecret: "bailo-mongodb"
     usernames:
       - mongodb
     passwords: []
@@ -89,7 +90,7 @@ minio:
   auth:
     rootUser: ""
     rootPassword: ""
-    existingSecret: ""
+    existingSecret: "bailo-minio"
   defaultBuckets: "uploads,registry"
   uploadBucket: uploads
   registryBucket: registry
@@ -105,8 +106,8 @@ redis:
   auth:
     enabled: true
     password: ""
-    existingSecret: ""
-    existingSecretPasswordKey: ""
+    existingSecret: "bailo-redis"
+    existingSecretPasswordKey: "redis-password"
   host: ""
   master:
     service:


### PR DESCRIPTION
This allows the secret creation to only be run the first time.  Otherwise, secrets get out of sync when `helm update` is run in the future.