### PR TITLE
Feature/bai 233 add tests for utils

### DIFF
--- a/lib/python/bailoclient/client.py
+++ b/lib/python/bailoclient/client.py
@@ -21,6 +21,7 @@ from .models import Model, User
 from .utils.exceptions import (
     CannotIncrementVersion,
     DataInvalid,
+    InvalidFilePath,
     InvalidMetadata,
     UnconnectedClient,
 )
@@ -312,7 +313,10 @@ class Client:
             # TODO check that it's some compressed format supported by Patool
             # (used in workflow-extract-files-from-minio)
             if file_path and not os.path.exists(file_path):
-                raise DataInvalid(f"{file_path} does not exist")
+                raise InvalidFilePath(f"{file_path} does not exist")
+
+            if file_path and os.path.isdir(file_path):
+                raise InvalidFilePath(f"{file_path} is a directory")
 
     def __validate_metadata(self, model_metadata: dict):
         """Validate user metadata against the minimal metadata required to

--- a/lib/python/bailoclient/utils/exceptions.py
+++ b/lib/python/bailoclient/utils/exceptions.py
@@ -25,6 +25,10 @@ class DataInvalid(Exception):
     """Model data is invalid"""
 
 
+class InvalidFilePath(Exception):
+    """Filepath does not exist or is otherwise invalid"""
+
+
 class InvalidMetadata(Exception):
     """Metadata does not meet the minimal requirement"""
 

--- a/lib/python/tests/test_client.py
+++ b/lib/python/tests/test_client.py
@@ -11,6 +11,7 @@ from bailoclient.models.model import ValidationError, ValidationResult
 from bailoclient.utils.exceptions import (
     CannotIncrementVersion,
     DataInvalid,
+    InvalidFilePath,
     InvalidMetadata,
 )
 
@@ -79,11 +80,25 @@ def test_validate_uploads_raises_error_if_filepath_does_not_exist(mock_client):
     model_card = Model(_schema={"key": "value"})
 
     with pytest.raises(
-        DataInvalid, match=re.escape("this/path/does/not/exist does not exist")
+        InvalidFilePath, match=re.escape("this/path/does/not/exist does not exist")
     ):
         mock_client._validate_uploads(
             card=model_card,
             binary_file="this/path/does/not/exist",
+            code_file="../../__tests__/example_models/minimal_model/minimal_code.zip",
+        )
+
+
+def test_validate_uploads_raises_error_if_a_directory_is_uploaded(mock_client):
+    model_card = Model(_schema={"key": "value"})
+
+    with pytest.raises(
+        InvalidFilePath,
+        match=re.escape("../../__tests__/example_models/minimal_model is a directory"),
+    ):
+        mock_client._validate_uploads(
+            card=model_card,
+            binary_file="../../__tests__/example_models/minimal_model",
             code_file="../../__tests__/example_models/minimal_model/minimal_code.zip",
         )
 

--- a/lib/python/tests/test_utils.py
+++ b/lib/python/tests/test_utils.py
@@ -1,0 +1,15 @@
+from bailoclient.utils import utils
+
+
+def test_get_filename_and_mimetype_correctly_identifies_json_name_and_mimetype():
+    filename, m_type = utils.get_filename_and_mimetype("tests/data/responses.json")
+
+    assert filename == "responses.json"
+    assert m_type == "application/json"
+
+
+def test_get_filename_and_mimetype_returns_mimetype_of_none_if_path_is_directory():
+    filename, m_type = utils.get_filename_and_mimetype("tests/data")
+
+    assert filename == "data"
+    assert m_type is None

--- a/lib/python/tests/test_utils.py
+++ b/lib/python/tests/test_utils.py
@@ -13,3 +13,54 @@ def test_get_filename_and_mimetype_returns_mimetype_of_none_if_path_is_directory
 
     assert filename == "data"
     assert m_type is None
+
+
+def test_minimal_keys_in_dict_returns_valid_result_if_both_dictionaries_are_empty():
+    result = utils.minimal_keys_in_dictionary({}, {})
+
+    assert result == {"valid": True}
+
+
+def test_minimal_keys_in_dict_returns_error_if_dict2_does_not_include_key_from_minimal_dict():
+    result = utils.minimal_keys_in_dictionary({"key1": "value1"}, {})
+
+    assert not result["valid"]
+    assert result["error_message"] == "must contain 'key1'"
+
+
+def test_minimal_keys_in_dict_returns_error_if_dict2_has_empty_value_for_key_from_minimal_dict():
+    result = utils.minimal_keys_in_dictionary({"key1": "value1"}, {"key1": None})
+
+    assert not result["valid"]
+    assert result["error_message"] == "'key1' cannot be empty"
+
+
+def test_minimal_keys_in_dict_returns_error_if_dict2_is_missing_subkeys_from_minimal_dict():
+    result = utils.minimal_keys_in_dictionary(
+        {"key1": {"key2": "value1"}}, {"key1": "value1"}
+    )
+
+    assert not result["valid"]
+    assert result["error_message"] == "missing data under 'key1'"
+
+
+def test_minimal_keys_in_dict_validates_if_minimal_dict_is_empty():
+    result = utils.minimal_keys_in_dictionary({}, {"key1": "value1"})
+
+    assert result["valid"]
+
+
+def test_minimal_keys_in_dict_ignores_extra_keys_in_dict2():
+    result = utils.minimal_keys_in_dictionary(
+        {"key1": "value"}, {"key1": "value1", "key2": "value2"}
+    )
+
+    assert result["valid"]
+
+
+def test_minimal_keys_in_dict_validates_multilevel_dictionaries():
+    result = utils.minimal_keys_in_dictionary(
+        {"key1": {"key2": {"key3": "value"}}}, {"key1": {"key2": {"key3": "value"}}}
+    )
+
+    assert result["valid"]

--- a/lib/python/tests/test_utils.py
+++ b/lib/python/tests/test_utils.py
@@ -15,6 +15,15 @@ def test_get_filename_and_mimetype_returns_mimetype_of_none_if_path_is_directory
     assert m_type is None
 
 
+def test_get_filename_and_mimetype_guesses_name_and_type_even_if_the_file_does_not_exist():
+    filename, m_type = utils.get_filename_and_mimetype(
+        "path/does/not/exist/responses.json"
+    )
+
+    assert filename == "responses.json"
+    assert m_type == "application/json"
+
+
 def test_minimal_keys_in_dict_returns_valid_result_if_both_dictionaries_are_empty():
     result = utils.minimal_keys_in_dictionary({}, {})
 


### PR DESCRIPTION
Added in some extra validation for whether a filepath is a directory in the client. Was debating adding this to the utils function for detecting name and mimetype but I don't think we care at that stage? Could be wrong though. Have just added a test to document the behaviour when it's given a path to a directory.