### PR TITLE
reset approvals button now shows snackbar with status and message, an…

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -59,6 +59,7 @@
         "next": "~12.1.6",
         "nodemailer": "^6.7.2",
         "nodemon": "^2.0.15",
+        "notistack": "^2.0.8",
         "open": "^8.4.0",
         "openshift-rest-client": "^7.0.0",
         "pako": "^2.0.4",
@@ -18439,6 +18440,34 @@
       "integrity": "sha512-9UZCFRHQdNrfTpGg8+1INIg93B6zE0aXMVFkw1WFwvO4SlZywU6aLg5Of0Ap/PgcbSw4LNxvMWXMeugwMCX0AA==",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/notistack": {
+      "version": "2.0.8",
+      "resolved": "https://registry.npmjs.org/notistack/-/notistack-2.0.8.tgz",
+      "integrity": "sha512-/IY14wkFp5qjPgKNvAdfL5Jp6q90+MjgKTPh4c81r/lW70KeuX6b9pE/4f8L4FG31cNudbN9siiFS5ql1aSLRw==",
+      "dependencies": {
+        "clsx": "^1.1.0",
+        "hoist-non-react-statics": "^3.3.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/notistack"
+      },
+      "peerDependencies": {
+        "@emotion/react": "^11.4.1",
+        "@emotion/styled": "^11.3.0",
+        "@mui/material": "^5.0.0",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@emotion/react": {
+          "optional": true
+        },
+        "@emotion/styled": {
+          "optional": true
+        }
       }
     },
     "node_modules/npm-run-path": {
@@ -38563,6 +38592,15 @@
       "version": "4.5.1",
       "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-4.5.1.tgz",
       "integrity": "sha512-9UZCFRHQdNrfTpGg8+1INIg93B6zE0aXMVFkw1WFwvO4SlZywU6aLg5Of0Ap/PgcbSw4LNxvMWXMeugwMCX0AA=="
+    },
+    "notistack": {
+      "version": "2.0.8",
+      "resolved": "https://registry.npmjs.org/notistack/-/notistack-2.0.8.tgz",
+      "integrity": "sha512-/IY14wkFp5qjPgKNvAdfL5Jp6q90+MjgKTPh4c81r/lW70KeuX6b9pE/4f8L4FG31cNudbN9siiFS5ql1aSLRw==",
+      "requires": {
+        "clsx": "^1.1.0",
+        "hoist-non-react-statics": "^3.3.0"
+      }
     },
     "npm-run-path": {
       "version": "4.0.1",

--- a/package.json
+++ b/package.json
@@ -71,6 +71,7 @@
     "next": "~12.1.6",
     "nodemailer": "^6.7.2",
     "nodemon": "^2.0.15",
+    "notistack": "^2.0.8",
     "open": "^8.4.0",
     "openshift-rest-client": "^7.0.0",
     "pako": "^2.0.4",

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -13,6 +13,7 @@ import '../public/css/layouting.css'
 import '../public/css/table.css'
 import '../public/css/terminal.css'
 import '../public/css/highlight.css'
+import { SnackbarProvider } from 'notistack'
 import createEmotionCache from '../src/createEmotionCache'
 
 // Client-side cache, shared for the whole session of the user in the browser.
@@ -43,10 +44,12 @@ export default function MyApp(props: MyAppProps) {
       {mounted && (
         <ThemeProvider theme={themeModeValue.theme}>
           <ThemeModeContext.Provider value={themeModeValue}>
-            <DocsMenuContext.Provider value={docsMenuValue}>
-              <CssBaseline />
-              <Component {...pageProps} />
-            </DocsMenuContext.Provider>
+            <SnackbarProvider>
+              <DocsMenuContext.Provider value={docsMenuValue}>
+                <CssBaseline />
+                <Component {...pageProps} />
+              </DocsMenuContext.Provider>
+            </SnackbarProvider>
           </ThemeModeContext.Provider>
         </ThemeProvider>
       )}

--- a/pages/deployment/[uuid].tsx
+++ b/pages/deployment/[uuid].tsx
@@ -2,7 +2,7 @@ import Info from '@mui/icons-material/Info'
 import DownArrow from '@mui/icons-material/KeyboardArrowDownTwoTone'
 import UpArrow from '@mui/icons-material/KeyboardArrowUpTwoTone'
 import RestartAlt from '@mui/icons-material/RestartAltTwoTone'
-import Alert, { AlertColor } from '@mui/material/Alert'
+import Alert from '@mui/material/Alert'
 import Box from '@mui/material/Box'
 import Button from '@mui/material/Button'
 import Dialog from '@mui/material/Dialog'
@@ -48,6 +48,7 @@ import DisabledElementTooltip from '../../src/common/DisabledElementTooltip'
 import { ModelUploadType } from '../../types/interfaces'
 import { VersionDoc } from '../../server/models/Version'
 import { getErrorMessage } from '../../utils/fetcher'
+import useNotification from '../../src/common/Snackbar'
 
 const ComplianceFlow = dynamic(() => import('../../src/ComplianceFlow'))
 
@@ -104,9 +105,6 @@ export default function Deployment() {
   const [tag, setTag] = useState<string>('')
   const [anchorEl, setAnchorEl] = useState<HTMLDivElement | null>(null)
   const [copyDeploymentCardSnackbarOpen, setCopyDeploymentCardSnackbarOpen] = useState(false)
-  const [resetSnackbarOpen, setResetSnackbarOpen] = useState(false)
-  const [resetSnackbarStatus, setResetSnackbarStatus] = useState<AlertColor>('info')
-  const [resetSnackbarMessage, setResetSnackbarMessage] = useState('')
   const actionOpen = anchorEl !== null
 
   const { currentUser, isCurrentUserLoading, isCurrentUserError } = useGetCurrentUser()
@@ -114,6 +112,7 @@ export default function Deployment() {
   const { uiConfig, isUiConfigLoading, isUiConfigError } = useGetUiConfig()
 
   const theme = useTheme()
+  const sendNotification = useNotification()
 
   const initialVersionRequested: Partial<VersionDoc> | undefined = useMemo(() => {
     if (!deployment) return undefined
@@ -194,18 +193,11 @@ export default function Deployment() {
     const response = await postEndpoint(`/api/v1/deployment/${deployment?.uuid}/reset-approvals`, {})
 
     if (response.ok) {
-      setResetSnackbarStatus('success')
-      setResetSnackbarMessage('Approvals reset')
+      sendNotification({ variant: 'success', msg: 'Approvals reset' })
       mutateDeployment()
     } else {
-      setResetSnackbarStatus('error')
-      setResetSnackbarMessage(await getErrorMessage(response))
+      sendNotification({ variant: 'error', msg: await getErrorMessage(response) })
     }
-    setResetSnackbarOpen(true)
-  }
-
-  const handleResetSnackbarClose = () => {
-    setResetSnackbarOpen(false)
   }
 
   return (
@@ -310,11 +302,6 @@ export default function Deployment() {
               </DisabledElementTooltip>
             </MenuList>
           </Menu>
-          <Snackbar open={resetSnackbarOpen} autoHideDuration={6000} onClose={handleResetSnackbarClose}>
-            <Alert onClose={handleResetSnackbarClose} severity={resetSnackbarStatus} sx={{ width: '100%' }}>
-              {resetSnackbarMessage}
-            </Alert>
-          </Snackbar>
           <Box sx={{ borderBottom: 1, marginTop: 1, borderColor: 'divider' }}>
             <Tabs
               textColor={theme.palette.mode === 'light' ? 'primary' : 'secondary'}

--- a/pages/deployment/[uuid].tsx
+++ b/pages/deployment/[uuid].tsx
@@ -192,7 +192,6 @@ export default function Deployment() {
 
   const requestApprovalReset = async () => {
     const response = await postEndpoint(`/api/v1/deployment/${deployment?.uuid}/reset-approvals`, {})
-    // response = await deleteEndpoint(`/api/v1/version/${version._id}`)
 
     if (response.ok) {
       setResetSnackbarStatus('success')

--- a/src/common/Snackbar.tsx
+++ b/src/common/Snackbar.tsx
@@ -1,0 +1,38 @@
+import { useSnackbar, VariantType } from 'notistack'
+import IconButton from '@mui/material/IconButton'
+import CloseIcon from '@mui/icons-material/Close'
+import React, { useEffect, useState } from 'react'
+
+interface SnackbarConfig {
+  msg: string
+  variant?: VariantType
+}
+
+const useNotification = () => {
+  const [conf, setConf] = useState<SnackbarConfig | undefined>(undefined)
+  console.log(useSnackbar())
+  const { enqueueSnackbar, closeSnackbar } = useSnackbar()
+
+  useEffect(() => {
+    const action = (key: string) => (
+      <IconButton
+        onClick={() => {
+          closeSnackbar(key)
+        }}
+      >
+        <CloseIcon />
+      </IconButton>
+    )
+    if (conf) {
+      enqueueSnackbar(conf.msg, {
+        variant: conf.variant ?? 'info',
+        autoHideDuration: 5000,
+        action,
+      })
+    }
+  }, [conf, enqueueSnackbar, closeSnackbar])
+
+  return setConf
+}
+
+export default useNotification


### PR DESCRIPTION
…d reloads approvals

Reset approvals success notification:
<img width="399" alt="reset-approvals-success" src="https://user-images.githubusercontent.com/107941007/199303256-6f21bdba-fe25-4f13-ac82-00177d387167.PNG">

Reset approvals error notification:
<img width="415" alt="reset-approvals-error" src="https://user-images.githubusercontent.com/107941007/199303325-4652731a-0705-41cf-b839-411d851171b8.PNG">
