### PR TITLE
Split out some steps from the main CI workflow to reduce processing time

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -29,16 +29,9 @@ jobs:
       # Install dependencies
       - run: npm ci
 
-      # Linting
-      - run: npm run check-style
-      - run: npm run lint
-
       # Create certs
       - run: sudo chown -R runner:docker certs
       - run: npm run certs
-
-      # Run unit tests
-      - run: npm run test
 
       # Setup dependencies
       - name: Build the stack

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -1,4 +1,4 @@
-name: App Test / Build
+name: App E2E Tests
 
 on:
   push:

--- a/.github/workflows/style.js.yml
+++ b/.github/workflows/style.js.yml
@@ -1,0 +1,32 @@
+name: App Style Checks
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    timeout-minutes: 2
+
+    strategy:
+      matrix:
+        node-version: [16.x]
+
+    steps:
+      # Initial setup
+      - uses: actions/checkout@v2
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v2
+        with:
+          node-version: ${{ matrix.node-version }}
+          cache: 'npm'
+
+      # Install dependencies
+      - run: npm ci
+
+      # Linting
+      - run: npm run check-style
+      - run: npm run lint

--- a/.github/workflows/unit.js.yml
+++ b/.github/workflows/unit.js.yml
@@ -1,0 +1,31 @@
+name: App Style Checks
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    timeout-minutes: 3
+
+    strategy:
+      matrix:
+        node-version: [16.x]
+
+    steps:
+      # Initial setup
+      - uses: actions/checkout@v2
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v2
+        with:
+          node-version: ${{ matrix.node-version }}
+          cache: 'npm'
+
+      # Install dependencies
+      - run: npm ci
+
+      # Run unit tests
+      - run: npm run test

--- a/.github/workflows/unit.js.yml
+++ b/.github/workflows/unit.js.yml
@@ -1,4 +1,4 @@
-name: App Style Checks
+name: App Unit Tests
 
 on:
   push:

--- a/.github/workflows/unit.js.yml
+++ b/.github/workflows/unit.js.yml
@@ -27,5 +27,9 @@ jobs:
       # Install dependencies
       - run: npm ci
 
+      # Create certs
+      - run: sudo chown -R runner:docker certs
+      - run: npm run certs
+
       # Run unit tests
       - run: npm run test

--- a/.github/workflows/web.yml
+++ b/.github/workflows/web.yml
@@ -96,6 +96,7 @@ jobs:
       url: ${{ steps.deployment.outputs.page_url }}
     runs-on: ubuntu-latest
     needs: build
+    if: github.ref == 'refs/heads/main'
     steps:
       - name: Deploy to GitHub Pages
         id: deployment


### PR DESCRIPTION
Splits out style & unit tests from the E2E tests we run.  Saves ~2 minutes from runtime.  Also, doesn't break the unit / e2e tests if the style tests fail!