### PR TITLE
Fix 400 issue when getting logs from loading pages.

### DIFF
--- a/data/admin.ts
+++ b/data/admin.ts
@@ -41,7 +41,7 @@ export function useGetAppLogs({
   if (requestId) group = `/request/${requestId}`
 
   const { data, error, mutate } = useSWR<{ logs: Array<LogEntry> }>(
-    disabled ? null : `/api/v1/admin/logs${group}?${qs.stringify(query)}`,
+    disabled ? null : `/api/v1/admin/logs${group}?${qs.stringify(query, { indices: false })}`,
     fetcher
   )
 


### PR DESCRIPTION
Array was previously defined as `filter[0]=misc&filter[1]=another&filter[2]=different`, but Express expects `filter=misc&filter=another&filter=different`.  This parameter changes how qs handles arrays.