### PR TITLE
Deep clone deployment data so deployment can be submitted twice

### DIFF
--- a/frontend/pages/model/[uuid]/deploy.tsx
+++ b/frontend/pages/model/[uuid]/deploy.tsx
@@ -3,7 +3,6 @@ import Grid from '@mui/material/Grid'
 import Paper from '@mui/material/Paper'
 import { useRouter } from 'next/router'
 import React, { useEffect, useState } from 'react'
-import { cloneDeep } from 'lodash-es'
 import { postEndpoint } from '../../../data/api'
 import { useGetModel } from '../../../data/model'
 import { useGetDefaultSchema, useGetSchemas } from '../../../data/schema'
@@ -85,7 +84,7 @@ export default function Deploy() {
   const onSubmit = async () => {
     setError(undefined)
 
-    const data = cloneDeep(getStepsData(splitSchema))
+    const data = getStepsData(splitSchema)
 
     data.highLevelDetails.modelID = modelUuid
     data.schemaRef = currentSchema?.reference

--- a/frontend/pages/model/[uuid]/deploy.tsx
+++ b/frontend/pages/model/[uuid]/deploy.tsx
@@ -3,6 +3,7 @@ import Grid from '@mui/material/Grid'
 import Paper from '@mui/material/Paper'
 import { useRouter } from 'next/router'
 import React, { useEffect, useState } from 'react'
+import { cloneDeep } from 'lodash-es'
 import { postEndpoint } from '../../../data/api'
 import { useGetModel } from '../../../data/model'
 import { useGetDefaultSchema, useGetSchemas } from '../../../data/schema'
@@ -84,7 +85,7 @@ export default function Deploy() {
   const onSubmit = async () => {
     setError(undefined)
 
-    const data = getStepsData(splitSchema)
+    const data = cloneDeep(getStepsData(splitSchema))
 
     data.highLevelDetails.modelID = modelUuid
     data.schemaRef = currentSchema?.reference

--- a/frontend/utils/formUtils.ts
+++ b/frontend/utils/formUtils.ts
@@ -8,6 +8,7 @@ import RenderButtons, { RenderButtonsInterface } from '../src/Form/RenderButtons
 import RenderForm from '../src/Form/RenderForm'
 import { RenderInterface, SplitSchema, Step, StepType } from '../types/interfaces'
 import { createUiSchema } from './uiSchemaUtils'
+import { cloneDeep } from 'lodash-es'
 
 export function createStep({
   schema,
@@ -150,7 +151,8 @@ export function getStepsData(splitSchema: SplitSchema, includeAll = false) {
     data[step.section] = step.state
   })
 
-  return data
+  // Make sure not to return a weak reference to the underlying steps
+  return cloneDeep(data)
 }
 
 export function setStepsData(


### PR DESCRIPTION
Before it would add misc data to the highLevelDetails field due to it being a reference clone.  With clone deep we prevent that from happening.