### PR TITLE
corrected position of error notification

### DIFF
--- a/frontend/src/Form/RenderButtons.tsx
+++ b/frontend/src/Form/RenderButtons.tsx
@@ -39,7 +39,11 @@ export default function RenderButtons({
 
     if (!isValid) {
       setStepValidate(splitSchema, setSplitSchema, step, true)
-      sendNotification({ variant: 'error', msg: 'This tab is not complete.' })
+      sendNotification({
+        variant: 'error',
+        msg: 'This tab is not complete.',
+        anchorOrigin: { horizontal: 'center', vertical: 'bottom' },
+      })
       return
     }
     document.getElementById('form-page-stepper')?.scrollIntoView({ behavior: 'smooth' })

--- a/frontend/src/common/Snackbar.tsx
+++ b/frontend/src/common/Snackbar.tsx
@@ -8,12 +8,13 @@
 
 import CloseIcon from '@mui/icons-material/Close'
 import IconButton from '@mui/material/IconButton'
-import { SnackbarKey, useSnackbar, VariantType } from 'notistack'
+import { SnackbarKey, SnackbarOrigin, useSnackbar, VariantType } from 'notistack'
 import React, { useEffect, useState } from 'react'
 
 interface SnackbarConfig {
   msg: string
   variant?: VariantType
+  anchorOrigin?: SnackbarOrigin
 }
 
 const useNotification = () => {
@@ -35,6 +36,7 @@ const useNotification = () => {
         variant: conf.variant ?? 'info',
         autoHideDuration: 5000,
         action,
+        anchorOrigin: conf.anchorOrigin,
       })
     }
   }, [conf, enqueueSnackbar, closeSnackbar])


### PR DESCRIPTION
The error notification originally appeared from the bottom left. This has now been adjusted to appear at the bottom center, to be consistent with how server errors are presented.