### PR TITLE
Bai 551 approve reject directly from model

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -93,6 +93,7 @@
         "ts-jest": "^29.1.0",
         "ts-node": "^10.9.1",
         "typescript": "^5.1.3",
+        "vite-tsconfig-paths": "^4.2.0",
         "vitest": "^0.31.1"
       }
     },
@@ -7048,6 +7049,12 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/globrex": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/globrex/-/globrex-0.1.2.tgz",
+      "integrity": "sha512-uHJgbwAMwNFf5mLst7IWLNg14x1CkeqglJb/K3doi4dw6q2IvAAmM/Y81kevy83wP+Sst+nutFTYOGg3d1lsxg==",
+      "dev": true
+    },
     "node_modules/gopd": {
       "version": "1.0.1",
       "license": "MIT",
@@ -12900,6 +12907,26 @@
         }
       }
     },
+    "node_modules/tsconfck": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/tsconfck/-/tsconfck-2.1.1.tgz",
+      "integrity": "sha512-ZPCkJBKASZBmBUNqGHmRhdhM8pJYDdOXp4nRgj/O0JwUwsMq50lCDRQP/M5GBNAA0elPrq4gAeu4dkaVCuKWww==",
+      "dev": true,
+      "bin": {
+        "tsconfck": "bin/tsconfck.js"
+      },
+      "engines": {
+        "node": "^14.13.1 || ^16 || >=18"
+      },
+      "peerDependencies": {
+        "typescript": "^4.3.5 || ^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/tslib": {
       "version": "2.5.3",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.3.tgz",
@@ -13304,6 +13331,25 @@
       },
       "funding": {
         "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/vite-tsconfig-paths": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/vite-tsconfig-paths/-/vite-tsconfig-paths-4.2.0.tgz",
+      "integrity": "sha512-jGpus0eUy5qbbMVGiTxCL1iB9ZGN6Bd37VGLJU39kTDD6ZfULTTb1bcc5IeTWqWJKiWV5YihCaibeASPiGi8kw==",
+      "dev": true,
+      "dependencies": {
+        "debug": "^4.1.1",
+        "globrex": "^0.1.2",
+        "tsconfck": "^2.1.0"
+      },
+      "peerDependencies": {
+        "vite": "*"
+      },
+      "peerDependenciesMeta": {
+        "vite": {
+          "optional": true
+        }
       }
     },
     "node_modules/vitest": {
@@ -18696,6 +18742,12 @@
         "slash": "^3.0.0"
       }
     },
+    "globrex": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/globrex/-/globrex-0.1.2.tgz",
+      "integrity": "sha512-uHJgbwAMwNFf5mLst7IWLNg14x1CkeqglJb/K3doi4dw6q2IvAAmM/Y81kevy83wP+Sst+nutFTYOGg3d1lsxg==",
+      "dev": true
+    },
     "gopd": {
       "version": "1.0.1",
       "requires": {
@@ -22522,6 +22574,13 @@
         "yn": "3.1.1"
       }
     },
+    "tsconfck": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/tsconfck/-/tsconfck-2.1.1.tgz",
+      "integrity": "sha512-ZPCkJBKASZBmBUNqGHmRhdhM8pJYDdOXp4nRgj/O0JwUwsMq50lCDRQP/M5GBNAA0elPrq4gAeu4dkaVCuKWww==",
+      "dev": true,
+      "requires": {}
+    },
     "tslib": {
       "version": "2.5.3",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.3.tgz",
@@ -22764,6 +22823,17 @@
         "pathe": "^1.1.0",
         "picocolors": "^1.0.0",
         "vite": "^3.0.0 || ^4.0.0"
+      }
+    },
+    "vite-tsconfig-paths": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/vite-tsconfig-paths/-/vite-tsconfig-paths-4.2.0.tgz",
+      "integrity": "sha512-jGpus0eUy5qbbMVGiTxCL1iB9ZGN6Bd37VGLJU39kTDD6ZfULTTb1bcc5IeTWqWJKiWV5YihCaibeASPiGi8kw==",
+      "dev": true,
+      "requires": {
+        "debug": "^4.1.1",
+        "globrex": "^0.1.2",
+        "tsconfck": "^2.1.0"
       }
     },
     "vitest": {

--- a/backend/package.json
+++ b/backend/package.json
@@ -111,6 +111,7 @@
     "ts-jest": "^29.1.0",
     "ts-node": "^10.9.1",
     "typescript": "^5.1.3",
+    "vite-tsconfig-paths": "^4.2.0",
     "vitest": "^0.31.1"
   }
 }

--- a/backend/src/routes.ts
+++ b/backend/src/routes.ts
@@ -10,6 +10,7 @@ import {
   fetchRawModelFiles,
   getDeployment,
   getDeploymentAccess,
+  getDeploymentApprovals,
   getExportModelVersion,
   getUserDeployments,
   postDeployment,
@@ -36,6 +37,7 @@ import {
   deleteVersion,
   getVersion,
   getVersionAccess,
+  getVersionApprovals,
   getVersionFile,
   getVersionFileList,
   postRebuildModel,
@@ -95,6 +97,7 @@ server.get('/api/v1/model/:uuid/access', ...getModelAccess)
 server.post('/api/v1/deployment', ...postDeployment)
 server.post('/api/v1/deployment/ungoverned', ...postUngovernedDeployment)
 server.get('/api/v1/deployment/:uuid', ...getDeployment)
+server.get('/api/v1/deployment/:id/approvals', ...getDeploymentApprovals)
 server.get('/api/v1/deployment/user/:id', ...getUserDeployments)
 server.post('/api/v1/deployment/:uuid/reset-approvals', ...resetDeploymentApprovals)
 server.get('/api/v1/deployment/:uuid/access', ...getDeploymentAccess)
@@ -104,8 +107,9 @@ server.get('/api/v1/deployment/:uuid/version/:version/export', ...getExportModel
 server.get('/api/v1/version/:id', ...getVersion)
 server.get('/api/v1/version/:id/contents/:file/list', ...getVersionFileList)
 server.get('/api/v1/version/:id/contents/:file', ...getVersionFile)
-server.put('/api/v1/version/:id', ...putVersion)
 server.get('/api/v1/version/:id/access', ...getVersionAccess)
+server.get('/api/v1/version/:id/approvals', ...getVersionApprovals)
+server.put('/api/v1/version/:id', ...putVersion)
 server.delete('/api/v1/version/:id', ...deleteVersion)
 server.post('/api/v1/version/:id/reset-approvals', ...postResetVersionApprovals)
 server.post('/api/v1/version/:id/rebuild', ...postRebuildModel)

--- a/backend/src/routes/v1/approvals.ts
+++ b/backend/src/routes/v1/approvals.ts
@@ -43,7 +43,6 @@ export const getApprovals = [
         )
       }
     } else {
-      // TODO: Update translations
       req.log.info({ code: 'fetching_user_approvals' }, 'Getting approvals for user')
     }
 

--- a/backend/src/routes/v1/approvals.ts
+++ b/backend/src/routes/v1/approvals.ts
@@ -27,8 +27,6 @@ export const getApprovals = [
   async (req: Request, res: Response) => {
     const approvalCategory = req.query.approvalCategory as string
     const filter = req.query.filter as string
-    // TODO - Remove this ID from backend getApprovals logic
-    const versionOrDeploymentId = req.query.versionOrDeploymentId as string | undefined
 
     if (!['Upload', 'Deployment'].includes(approvalCategory)) {
       return res.error(400, [
@@ -46,14 +44,13 @@ export const getApprovals = [
       }
     } else {
       // TODO: Update translations
-      req.log.info({ code: 'fetching_user_approvals', versionOrDeploymentId }, 'Getting approvals for user')
+      req.log.info({ code: 'fetching_user_approvals' }, 'Getting approvals for user')
     }
 
     const approvals = await readApprovals({
       approvalCategory: approvalCategory as ApprovalCategory,
       filter: filter === 'all' ? undefined : req.user._id,
       archived: filter === 'archived',
-      versionOrDeploymentId,
     })
 
     req.log.info({ code: 'fetching_approvals', approvals }, 'User fetching approvals')

--- a/backend/src/routes/v1/approvals.ts
+++ b/backend/src/routes/v1/approvals.ts
@@ -27,6 +27,7 @@ export const getApprovals = [
   async (req: Request, res: Response) => {
     const approvalCategory = req.query.approvalCategory as string
     const filter = req.query.filter as string
+    // TODO - Remove this ID from backend getApprovals logic
     const versionOrDeploymentId = req.query.versionOrDeploymentId as string | undefined
 
     if (!['Upload', 'Deployment'].includes(approvalCategory)) {

--- a/backend/src/routes/v1/approvals.ts
+++ b/backend/src/routes/v1/approvals.ts
@@ -27,6 +27,7 @@ export const getApprovals = [
   async (req: Request, res: Response) => {
     const approvalCategory = req.query.approvalCategory as string
     const filter = req.query.filter as string
+    const versionOrDeploymentId = req.query.versionOrDeploymentId as string | undefined
 
     if (!['Upload', 'Deployment'].includes(approvalCategory)) {
       return res.error(400, [
@@ -43,13 +44,15 @@ export const getApprovals = [
         )
       }
     } else {
-      req.log.info({ code: 'fetching_user_approvals' }, 'Getting approvals for user')
+      // TODO: Update translations
+      req.log.info({ code: 'fetching_user_approvals', versionOrDeploymentId }, 'Getting approvals for user')
     }
 
     const approvals = await readApprovals({
       approvalCategory: approvalCategory as ApprovalCategory,
       filter: filter === 'all' ? undefined : req.user._id,
       archived: filter === 'archived',
+      versionOrDeploymentId,
     })
 
     req.log.info({ code: 'fetching_approvals', approvals }, 'User fetching approvals')

--- a/backend/src/routes/v1/deployment.ts
+++ b/backend/src/routes/v1/deployment.ts
@@ -3,7 +3,11 @@ import bodyParser from 'body-parser'
 import { Request, Response } from 'express'
 import { customAlphabet } from 'nanoid'
 
-import { createDeploymentApprovals, requestDeploymentsForModelVersions } from '../../services/approval.js'
+import {
+  createDeploymentApprovals,
+  findApprovalsByDeploymentId,
+  requestDeploymentsForModelVersions,
+} from '../../services/approval.js'
 import { createDeployment, findDeploymentByUuid, findDeployments } from '../../services/deployment.js'
 import { findModelByUuid } from '../../services/model.js'
 import { findSchemaByRef } from '../../services/schema.js'
@@ -21,7 +25,7 @@ import {
   getModelSchema,
 } from '../../utils/exportModel.js'
 import { getClient } from '../../utils/minio.js'
-import { BadReq, Forbidden, InternalServer, NotFound, Unauthorised } from '../../utils/result.js'
+import { BadReq, Forbidden, InternalServer, NotFound } from '../../utils/result.js'
 import { ensureUserRole } from '../../utils/user.js'
 import { validateSchema } from '../../utils/validateSchema.js'
 
@@ -329,6 +333,22 @@ export const getDeploymentAccess = [
 
     return res.json({
       owner,
+    })
+  },
+]
+
+export const getDeploymentApprovals = [
+  ensureUserRole('user'),
+  async (req: Request, res: Response) => {
+    const { id } = req.params
+
+    // TODO: Update translations
+    req.log.info({ code: 'fetching_deployment_approvals', id }, 'Getting approvals for deployment')
+
+    const approvals = await findApprovalsByDeploymentId(id)
+
+    return res.json({
+      approvals,
     })
   },
 ]

--- a/backend/src/routes/v1/version.ts
+++ b/backend/src/routes/v1/version.ts
@@ -5,7 +5,7 @@ import { basename } from 'path'
 import audit from '../../external/Audit.js'
 import ApprovalModel from '../../models/Approval.js'
 import ModelModel from '../../models/Model.js'
-import { createVersionApprovals, deleteApprovalsByVersion } from '../../services/approval.js'
+import { createVersionApprovals, deleteApprovalsByVersion, findApprovalsByVersionId } from '../../services/approval.js'
 import { emailDeploymentOwnersOnVersionDeletion, findDeploymentsByModel } from '../../services/deployment.js'
 import { removeVersionFromModel } from '../../services/model.js'
 import {
@@ -374,6 +374,22 @@ export const getVersionAccess = [
       uploader,
       reviewer,
       manager,
+    })
+  },
+]
+
+export const getVersionApprovals = [
+  ensureUserRole('user'),
+  async (req: Request, res: Response) => {
+    const { id } = req.params
+
+    // TODO: Update translations
+    req.log.info({ code: 'fetching_version_approvals', id }, 'Getting approvals for version')
+
+    const approvals = await findApprovalsByVersionId(id)
+
+    return res.json({
+      approvals,
     })
   },
 ]

--- a/backend/src/services/approval.ts
+++ b/backend/src/services/approval.ts
@@ -200,14 +200,19 @@ export async function readApprovals({
   approvalCategory,
   filter,
   archived,
+  versionOrDeploymentId,
 }: {
   approvalCategory: ApprovalCategory
   filter: ApprovalFilter
   archived: boolean
+  versionOrDeploymentId?: string
 }) {
   const query: any = {
     status: 'No Response',
     approvalCategory,
+    ...(versionOrDeploymentId && approvalCategory === ApprovalCategory.Upload && { version: versionOrDeploymentId }),
+    ...(versionOrDeploymentId &&
+      approvalCategory === ApprovalCategory.Deployment && { deployment: versionOrDeploymentId }),
   }
 
   if (filter) {

--- a/backend/src/services/approval.ts
+++ b/backend/src/services/approval.ts
@@ -255,6 +255,42 @@ export async function readApprovals({
     .sort({ updatedAt: -1 })
 }
 
+export async function findApprovalsByDeploymentId(deploymentId: DeploymentDoc['_id']) {
+  const approvals = await ApprovalModel.find({ deployment: deploymentId }).populate({
+    path: 'deployment',
+    populate: {
+      path: 'model',
+      populate: {
+        path: 'latestVersion',
+      },
+    },
+  })
+
+  if (!approvals) {
+    throw BadReq({ deploymentId }, `Unable to find approvals for deployment '${deploymentId}'`)
+  }
+
+  return approvals
+}
+
+export async function findApprovalsByVersionId(versionId: VersionDoc['_id']) {
+  const approvals = await ApprovalModel.find({ version: versionId }).populate({
+    path: 'version',
+    populate: {
+      path: 'model',
+      populate: {
+        path: 'latestVersion',
+      },
+    },
+  })
+
+  if (!approvals) {
+    throw BadReq({ versionId }, `Unable to find approvals for version '${versionId}'`)
+  }
+
+  return approvals
+}
+
 export async function getApproval({ approvalId }: { approvalId: string | Types.ObjectId }) {
   const approval = await ApprovalModel.findById(approvalId)
 

--- a/backend/src/services/approval.ts
+++ b/backend/src/services/approval.ts
@@ -200,19 +200,14 @@ export async function readApprovals({
   approvalCategory,
   filter,
   archived,
-  versionOrDeploymentId,
 }: {
   approvalCategory: ApprovalCategory
   filter: ApprovalFilter
   archived: boolean
-  versionOrDeploymentId?: string
 }) {
   const query: any = {
     status: 'No Response',
     approvalCategory,
-    ...(versionOrDeploymentId && approvalCategory === ApprovalCategory.Upload && { version: versionOrDeploymentId }),
-    ...(versionOrDeploymentId &&
-      approvalCategory === ApprovalCategory.Deployment && { deployment: versionOrDeploymentId }),
   }
 
   if (filter) {

--- a/backend/vitest.config.ts
+++ b/backend/vitest.config.ts
@@ -1,6 +1,8 @@
+import tsconfigPaths from 'vite-tsconfig-paths'
 import { defineConfig } from 'vitest/config'
 
 export default defineConfig({
+  plugins: [tsconfigPaths()],
   test: {
     restoreMocks: true,
   },

--- a/frontend/components/wrapper/Wrapper.tsx
+++ b/frontend/components/wrapper/Wrapper.tsx
@@ -9,7 +9,7 @@ import * as React from 'react'
 import { UiConfig } from '../../types/types'
 import WrapperIcon from './WrapperIcon'
 
-const drawerWidth: number = 240
+const drawerWidth = 240
 
 interface AppBarProps extends MuiAppBarProps {
   open?: boolean

--- a/frontend/components/wrapper/WrapperIcon.tsx
+++ b/frontend/components/wrapper/WrapperIcon.tsx
@@ -16,7 +16,7 @@ interface Props {
 
 export default function WrapperIcon({ selected, expanded, href, title, badge, children }: Props) {
   const badgedIcon = badge ? (
-    <Badge badgeContent={badge} color='secondary'>
+    <Badge badgeContent={badge} color='primary'>
       {children}
     </Badge>
   ) : (

--- a/frontend/data/approvals.ts
+++ b/frontend/data/approvals.ts
@@ -2,7 +2,7 @@ import qs from 'qs'
 import useSWR from 'swr'
 
 import { Approval, Deployment, Version } from '../types/types'
-import { fetcher } from '../utils/fetcher'
+import { ErrorInfo, fetcher } from '../utils/fetcher'
 
 export type ApprovalCategory = 'Upload' | 'Deployment'
 export type ApprovalFilterType = 'user' | 'archived'
@@ -11,9 +11,12 @@ export function useListApprovals(
   filter: ApprovalFilterType,
   versionOrDeploymentId?: Version['_id'] | Deployment['_id']
 ) {
-  const { data, error, mutate } = useSWR<{
-    approvals: Approval[]
-  }>(
+  const { data, error, mutate } = useSWR<
+    {
+      approvals: Approval[]
+    },
+    ErrorInfo
+  >(
     `/api/v1/approvals?${qs.stringify({
       approvalCategory,
       filter,
@@ -30,10 +33,32 @@ export function useListApprovals(
   }
 }
 
+export function useGetVersionOrDeploymentApprovals(
+  approvalCategory: ApprovalCategory,
+  versionOrDeploymentId: Version['_id'] | Deployment['_id']
+) {
+  const { data, error, mutate } = useSWR<
+    {
+      approvals: Approval[]
+    },
+    ErrorInfo
+  >(`/api/v1/${approvalCategory === 'Upload' ? 'version' : 'deployment'}/${versionOrDeploymentId}/approvals`, fetcher)
+
+  return {
+    mutateApprovals: mutate,
+    approvals: data?.approvals,
+    isApprovalsLoading: !error && !data,
+    isApprovalsError: error,
+  }
+}
+
 export function useGetNumApprovals() {
-  const { data, error, mutate } = useSWR<{
-    count: number
-  }>(`/api/v1/approvals/count`, fetcher)
+  const { data, error, mutate } = useSWR<
+    {
+      count: number
+    },
+    ErrorInfo
+  >(`/api/v1/approvals/count`, fetcher)
 
   return {
     mutateNumApprovals: mutate,

--- a/frontend/data/approvals.ts
+++ b/frontend/data/approvals.ts
@@ -6,11 +6,7 @@ import { ErrorInfo, fetcher } from '../utils/fetcher'
 
 export type ApprovalCategory = 'Upload' | 'Deployment'
 export type ApprovalFilterType = 'user' | 'archived'
-export function useListApprovals(
-  approvalCategory: ApprovalCategory,
-  filter: ApprovalFilterType,
-  versionOrDeploymentId?: Version['_id'] | Deployment['_id']
-) {
+export function useListApprovals(approvalCategory: ApprovalCategory, filter: ApprovalFilterType) {
   const { data, error, mutate } = useSWR<
     {
       approvals: Approval[]
@@ -20,7 +16,6 @@ export function useListApprovals(
     `/api/v1/approvals?${qs.stringify({
       approvalCategory,
       filter,
-      versionOrDeploymentId,
     })}`,
     fetcher
   )

--- a/frontend/data/approvals.ts
+++ b/frontend/data/approvals.ts
@@ -1,18 +1,23 @@
 import qs from 'qs'
 import useSWR from 'swr'
 
-import { Approval } from '../types/types'
+import { Approval, Deployment, Version } from '../types/types'
 import { fetcher } from '../utils/fetcher'
 
 export type ApprovalCategory = 'Upload' | 'Deployment'
 export type ApprovalFilterType = 'user' | 'archived'
-export function useListApprovals(approvalCategory: ApprovalCategory, filter: ApprovalFilterType) {
+export function useListApprovals(
+  approvalCategory: ApprovalCategory,
+  filter: ApprovalFilterType,
+  versionOrDeploymentId?: Version['_id'] | Deployment['_id']
+) {
   const { data, error, mutate } = useSWR<{
-    approvals: Array<Approval>
+    approvals: Approval[]
   }>(
     `/api/v1/approvals?${qs.stringify({
       approvalCategory,
       filter,
+      versionOrDeploymentId,
     })}`,
     fetcher
   )

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -70,6 +70,7 @@
         "jest-environment-jsdom": "^29.5.0",
         "jsdom": "^22.0.0",
         "next-router-mock": "^0.9.3",
+        "vite-tsconfig-paths": "^4.2.0",
         "vitest": "^0.30.1"
       }
     },
@@ -7397,6 +7398,12 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/globrex": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/globrex/-/globrex-0.1.2.tgz",
+      "integrity": "sha512-uHJgbwAMwNFf5mLst7IWLNg14x1CkeqglJb/K3doi4dw6q2IvAAmM/Y81kevy83wP+Sst+nutFTYOGg3d1lsxg==",
+      "dev": true
+    },
     "node_modules/goober": {
       "version": "2.1.13",
       "license": "MIT",
@@ -14556,6 +14563,26 @@
       "resolved": "https://registry.npmjs.org/ts-toolbelt/-/ts-toolbelt-9.6.0.tgz",
       "integrity": "sha512-nsZd8ZeNUzukXPlJmTBwUAuABDe/9qtVDelJeT/qW0ow3ZS3BsQJtNkan1802aM9Uf68/Y8ljw86Hu0h5IUW3w=="
     },
+    "node_modules/tsconfck": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/tsconfck/-/tsconfck-2.1.1.tgz",
+      "integrity": "sha512-ZPCkJBKASZBmBUNqGHmRhdhM8pJYDdOXp4nRgj/O0JwUwsMq50lCDRQP/M5GBNAA0elPrq4gAeu4dkaVCuKWww==",
+      "dev": true,
+      "bin": {
+        "tsconfck": "bin/tsconfck.js"
+      },
+      "engines": {
+        "node": "^14.13.1 || ^16 || >=18"
+      },
+      "peerDependencies": {
+        "typescript": "^4.3.5 || ^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/tsconfig-paths": {
       "version": "3.14.2",
       "dev": true,
@@ -15127,6 +15154,25 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/vite-tsconfig-paths": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/vite-tsconfig-paths/-/vite-tsconfig-paths-4.2.0.tgz",
+      "integrity": "sha512-jGpus0eUy5qbbMVGiTxCL1iB9ZGN6Bd37VGLJU39kTDD6ZfULTTb1bcc5IeTWqWJKiWV5YihCaibeASPiGi8kw==",
+      "dev": true,
+      "dependencies": {
+        "debug": "^4.1.1",
+        "globrex": "^0.1.2",
+        "tsconfck": "^2.1.0"
+      },
+      "peerDependencies": {
+        "vite": "*"
+      },
+      "peerDependenciesMeta": {
+        "vite": {
+          "optional": true
+        }
       }
     },
     "node_modules/vite/node_modules/postcss": {
@@ -20708,6 +20754,12 @@
         "slash": "^3.0.0"
       }
     },
+    "globrex": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/globrex/-/globrex-0.1.2.tgz",
+      "integrity": "sha512-uHJgbwAMwNFf5mLst7IWLNg14x1CkeqglJb/K3doi4dw6q2IvAAmM/Y81kevy83wP+Sst+nutFTYOGg3d1lsxg==",
+      "dev": true
+    },
     "goober": {
       "version": "2.1.13",
       "requires": {}
@@ -25075,6 +25127,13 @@
       "resolved": "https://registry.npmjs.org/ts-toolbelt/-/ts-toolbelt-9.6.0.tgz",
       "integrity": "sha512-nsZd8ZeNUzukXPlJmTBwUAuABDe/9qtVDelJeT/qW0ow3ZS3BsQJtNkan1802aM9Uf68/Y8ljw86Hu0h5IUW3w=="
     },
+    "tsconfck": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/tsconfck/-/tsconfck-2.1.1.tgz",
+      "integrity": "sha512-ZPCkJBKASZBmBUNqGHmRhdhM8pJYDdOXp4nRgj/O0JwUwsMq50lCDRQP/M5GBNAA0elPrq4gAeu4dkaVCuKWww==",
+      "dev": true,
+      "requires": {}
+    },
     "tsconfig-paths": {
       "version": "3.14.2",
       "dev": true,
@@ -25438,6 +25497,17 @@
         "pathe": "^1.1.0",
         "picocolors": "^1.0.0",
         "vite": "^3.0.0 || ^4.0.0"
+      }
+    },
+    "vite-tsconfig-paths": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/vite-tsconfig-paths/-/vite-tsconfig-paths-4.2.0.tgz",
+      "integrity": "sha512-jGpus0eUy5qbbMVGiTxCL1iB9ZGN6Bd37VGLJU39kTDD6ZfULTTb1bcc5IeTWqWJKiWV5YihCaibeASPiGi8kw==",
+      "dev": true,
+      "requires": {
+        "debug": "^4.1.1",
+        "globrex": "^0.1.2",
+        "tsconfck": "^2.1.0"
       }
     },
     "vitest": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -84,6 +84,7 @@
     "jest-environment-jsdom": "^29.5.0",
     "jsdom": "^22.0.0",
     "next-router-mock": "^0.9.3",
+    "vite-tsconfig-paths": "^4.2.0",
     "vitest": "^0.30.1"
   }
 }

--- a/frontend/pages/deployment/[uuid].tsx
+++ b/frontend/pages/deployment/[uuid].tsx
@@ -46,7 +46,7 @@ import MultipleErrorWrapper from '../../src/errors/MultipleErrorWrapper'
 import RawModelExportList from '../../src/RawModelExportList'
 import TerminalLog from '../../src/TerminalLog'
 import Wrapper from '../../src/Wrapper'
-import { Model, ModelUploadType } from '../../types/types'
+import { ApprovalCategory, Model, ModelUploadType } from '../../types/types'
 import { createDeploymentComplianceFlow } from '../../utils/complianceFlow'
 import { getErrorMessage } from '../../utils/fetcher'
 
@@ -236,7 +236,9 @@ export default function Deployment() {
         <Paper sx={{ p: 3 }}>
           <Stack direction='row' spacing={2}>
             <ApprovalsChip
-              approvals={[{ reviewers: deployment.metadata.contacts.owner, status: deployment.managerApproved }]}
+              versionOrDeploymentId={deployment._id}
+              approvalCategory={ApprovalCategory.Deployment}
+              currentUser={currentUser}
             />
             <Divider orientation='vertical' flexItem />
             <Button

--- a/frontend/pages/model/[uuid].tsx
+++ b/frontend/pages/model/[uuid].tsx
@@ -43,10 +43,9 @@ import Settings from 'src/model/Settings'
 
 import ApprovalsChip from '../../src/common/ApprovalsChip'
 import DisabledElementTooltip from '../../src/common/DisabledElementTooltip'
-import useNotification from '../../src/common/Snackbar'
 import MultipleErrorWrapper from '../../src/errors/MultipleErrorWrapper'
 import Wrapper from '../../src/Wrapper'
-import { DateString, ModelUploadType, User, Version } from '../../types/types'
+import { ApprovalCategory, DateString, ModelUploadType, User, Version } from '../../types/types'
 
 type TabOptions = 'overview' | 'compliance' | 'build' | 'deployments' | 'code' | 'settings'
 
@@ -87,7 +86,6 @@ function Model() {
   const { versionAccess } = useGetVersionAccess(version?._id)
 
   const hasUploadType = useMemo(() => version !== undefined && !!version.metadata.buildOptions?.uploadType, [version])
-  const sendNotification = useNotification()
 
   // isPotentialUploader stores whether an uploader could plausibly have access to privileged functions.
   // It defaults to true, until it hears false from the network access check.
@@ -272,10 +270,9 @@ function Model() {
           <Grid container justifyContent='space-between' alignItems='center'>
             <Stack direction='row' spacing={2}>
               <ApprovalsChip
-                approvals={[
-                  { reviewers: version.metadata.contacts.manager, status: version.managerApproved },
-                  { reviewers: version.metadata.contacts.reviewer, status: version.reviewerApproved },
-                ]}
+                versionOrDeploymentId={version._id}
+                approvalCategory={ApprovalCategory.Upload}
+                currentUser={currentUser}
               />
               <Divider orientation='vertical' flexItem />
               <Button

--- a/frontend/src/Form/DeploymentSubmission.spec.tsx
+++ b/frontend/src/Form/DeploymentSubmission.spec.tsx
@@ -2,7 +2,7 @@ import { render, screen, waitFor } from '@testing-library/react'
 import { describe, expect, vi } from 'vitest'
 
 import { useGetUiConfig } from '../../data/uiConfig'
-import { doNothing } from '../../utils/testUtils'
+import { doNothing } from '../../utils/test/testUtils'
 import DeploymentSubmission from './DeploymentSubmission'
 
 vi.mock('../../data/uiConfig', () => ({

--- a/frontend/src/Form/Form.spec.tsx
+++ b/frontend/src/Form/Form.spec.tsx
@@ -1,7 +1,7 @@
 import { fireEvent, getByText, render, screen, waitFor } from '@testing-library/react'
 import { describe, expect } from 'vitest'
 
-import { doNothing } from '../../utils/testUtils'
+import { doNothing } from '../../utils/test/testUtils'
 import Form from './Form'
 
 describe('Form', () => {

--- a/frontend/src/Form/ModelEditSubmission.spec.tsx
+++ b/frontend/src/Form/ModelEditSubmission.spec.tsx
@@ -2,7 +2,7 @@ import { render, screen, waitFor } from '@testing-library/react'
 import { expect, vi } from 'vitest'
 
 import { useGetUiConfig } from '../../data/uiConfig'
-import { doNothing } from '../../utils/testUtils'
+import { doNothing } from '../../utils/test/testUtils'
 import ModelEditSubmission from './ModelEditSubmission'
 
 vi.mock('../../data/uiConfig', () => ({

--- a/frontend/src/Form/ModelExportAndSubmission.spec.tsx
+++ b/frontend/src/Form/ModelExportAndSubmission.spec.tsx
@@ -2,7 +2,7 @@ import { render, screen, waitFor } from '@testing-library/react'
 import { describe, expect, it, vi } from 'vitest'
 
 import { useGetUiConfig } from '../../data/uiConfig'
-import { doNothing } from '../../utils/testUtils'
+import { doNothing } from '../../utils/test/testUtils'
 import ModelExportAndSubmission from './ModelExportAndSubmission'
 
 vi.mock('../../data/uiConfig', () => ({

--- a/frontend/src/Wrapper.tsx
+++ b/frontend/src/Wrapper.tsx
@@ -321,7 +321,7 @@ export default function Wrapper({ title, page, children }: WrapperProps): ReactE
                 <ListItemIcon>
                   {!open ? (
                     <Tooltip title='Review' arrow placement='right'>
-                      <Badge badgeContent={isNumApprovalsLoading ? 0 : numApprovals} color='secondary'>
+                      <Badge badgeContent={isNumApprovalsLoading ? 0 : numApprovals} color='primary'>
                         <ListAltIcon />
                       </Badge>
                     </Tooltip>

--- a/frontend/src/common/ApprovalsChip.spec.tsx
+++ b/frontend/src/common/ApprovalsChip.spec.tsx
@@ -1,20 +1,48 @@
 import { ThemeProvider } from '@mui/material/styles'
 import { render, screen, waitFor } from '@testing-library/react'
-import { describe, expect, it } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 
-import { ApprovalStates, EntityKind } from '../../types/types'
+import { useGetVersionOrDeploymentApprovals } from '../../data/approvals'
+import { ApprovalCategory } from '../../types/types'
+import { testApproval1, testApproval2, testId, testUser } from '../../utils/testUtils'
 import { lightTheme } from '../theme'
 import ApprovalsChip from './ApprovalsChip'
 
+vi.mock('../../data/approvals', () => ({
+  useGetVersionOrDeploymentApprovals: vi.fn(),
+  useGetNumApprovals: vi.fn().mockReturnValue({
+    numApprovals: 2,
+    isNumApprovalsLoading: false,
+    isNumApprovalsError: undefined,
+    mutateNumApprovals: vi.fn(),
+  }),
+}))
+
+vi.mock('../../utils/fetcher', () => ({
+  getErrorMessage: vi.fn().mockResolvedValue('Test error message'),
+}))
+
+vi.mock('../../data/api', () => ({
+  postEndpoint: vi.fn(),
+}))
+
 describe('ApprovalsChip', () => {
-  it('renders an ApprovalsChip component with 0/2 approvals', async () => {
+  it.only('renders an ApprovalsChip component with 0/2 approvals', async () => {
+    const mockUseGetVersionOrDeploymentApprovals = {
+      approvals: [testApproval1, testApproval2],
+      isApprovalsLoading: false,
+      isApprovalsError: undefined,
+      mutateApprovals: vi.fn(),
+    }
+
+    vi.mocked(useGetVersionOrDeploymentApprovals).mockReturnValue(mockUseGetVersionOrDeploymentApprovals)
+
     render(
       <ThemeProvider theme={lightTheme}>
         <ApprovalsChip
-          approvals={[
-            { reviewers: [{ kind: EntityKind.USER, id: 'Alice' }], status: ApprovalStates.NoResponse },
-            { reviewers: [{ kind: EntityKind.USER, id: 'Bob' }], status: ApprovalStates.NoResponse },
-          ]}
+          versionOrDeploymentId={testId}
+          approvalCategory={ApprovalCategory.Upload}
+          currentUser={testUser}
         />
       </ThemeProvider>
     )
@@ -24,65 +52,65 @@ describe('ApprovalsChip', () => {
     })
   })
 
-  it('renders an ApprovalsChip component with 1/2 approvals', async () => {
-    render(
-      <ThemeProvider theme={lightTheme}>
-        <ApprovalsChip
-          approvals={[
-            { reviewers: [{ kind: EntityKind.USER, id: 'Alice' }], status: ApprovalStates.Accepted },
-            { reviewers: [{ kind: EntityKind.USER, id: 'Bob' }], status: ApprovalStates.NoResponse },
-          ]}
-        />
-      </ThemeProvider>
-    )
+  // it('renders an ApprovalsChip component with 1/2 approvals', async () => {
+  //   render(
+  //     <ThemeProvider theme={lightTheme}>
+  //       <ApprovalsChip
+  //         approvals={[
+  //           { reviewers: [{ kind: EntityKind.USER, id: 'Alice' }], status: ApprovalStates.Accepted },
+  //           { reviewers: [{ kind: EntityKind.USER, id: 'Bob' }], status: ApprovalStates.NoResponse },
+  //         ]}
+  //       />
+  //     </ThemeProvider>
+  //   )
 
-    await waitFor(async () => {
-      expect(await screen.findByText('Approvals 1/2')).not.toBeUndefined()
-    })
-  })
+  //   await waitFor(async () => {
+  //     expect(await screen.findByText('Approvals 1/2')).not.toBeUndefined()
+  //   })
+  // })
 
-  it('renders an ApprovalsChip component with 2/2 approvals', async () => {
-    render(
-      <ThemeProvider theme={lightTheme}>
-        <ApprovalsChip
-          approvals={[
-            { reviewers: [{ kind: EntityKind.USER, id: 'Alice' }], status: ApprovalStates.Accepted },
-            { reviewers: [{ kind: EntityKind.USER, id: 'Bob' }], status: ApprovalStates.Accepted },
-          ]}
-        />
-      </ThemeProvider>
-    )
+  // it('renders an ApprovalsChip component with 2/2 approvals', async () => {
+  //   render(
+  //     <ThemeProvider theme={lightTheme}>
+  //       <ApprovalsChip
+  //         approvals={[
+  //           { reviewers: [{ kind: EntityKind.USER, id: 'Alice' }], status: ApprovalStates.Accepted },
+  //           { reviewers: [{ kind: EntityKind.USER, id: 'Bob' }], status: ApprovalStates.Accepted },
+  //         ]}
+  //       />
+  //     </ThemeProvider>
+  //   )
 
-    await waitFor(async () => {
-      expect(await screen.findByText('Approvals 2/2')).not.toBeUndefined()
-    })
-  })
+  //   await waitFor(async () => {
+  //     expect(await screen.findByText('Approvals 2/2')).not.toBeUndefined()
+  //   })
+  // })
 
-  it('renders an ApprovalsChip component with 0/1 approvals', async () => {
-    render(
-      <ThemeProvider theme={lightTheme}>
-        <ApprovalsChip
-          approvals={[{ reviewers: [{ kind: EntityKind.USER, id: 'Alice' }], status: ApprovalStates.NoResponse }]}
-        />
-      </ThemeProvider>
-    )
+  // it('renders an ApprovalsChip component with 0/1 approvals', async () => {
+  //   render(
+  //     <ThemeProvider theme={lightTheme}>
+  //       <ApprovalsChip
+  //         approvals={[{ reviewers: [{ kind: EntityKind.USER, id: 'Alice' }], status: ApprovalStates.NoResponse }]}
+  //       />
+  //     </ThemeProvider>
+  //   )
 
-    await waitFor(async () => {
-      expect(await screen.findByText('Approvals 0/1')).not.toBeUndefined()
-    })
-  })
+  //   await waitFor(async () => {
+  //     expect(await screen.findByText('Approvals 0/1')).not.toBeUndefined()
+  //   })
+  // })
 
-  it('renders an ApprovalsChip component with 1/1 approvals', async () => {
-    render(
-      <ThemeProvider theme={lightTheme}>
-        <ApprovalsChip
-          approvals={[{ reviewers: [{ kind: EntityKind.USER, id: 'Alice' }], status: ApprovalStates.Accepted }]}
-        />
-      </ThemeProvider>
-    )
+  // it('renders an ApprovalsChip component with 1/1 approvals', async () => {
+  //   render(
+  //     <ThemeProvider theme={lightTheme}>
+  //       <ApprovalsChip
+  //         approvals={[{ reviewers: [{ kind: EntityKind.USER, id: 'Alice' }], status: ApprovalStates.Accepted }]}
+  //       />
+  //     </ThemeProvider>
+  //   )
 
-    await waitFor(async () => {
-      expect(await screen.findByText('Approvals 1/1')).not.toBeUndefined()
-    })
-  })
+  //   await waitFor(async () => {
+  //     expect(await screen.findByText('Approvals 1/1')).not.toBeUndefined()
+  //   })
+  // })
 })

--- a/frontend/src/common/ApprovalsChip.spec.tsx
+++ b/frontend/src/common/ApprovalsChip.spec.tsx
@@ -26,7 +26,7 @@ vi.mock('../../data/approvals', () => ({
 }))
 
 describe('ApprovalsChip', () => {
-  it.only('renders an ApprovalsChip component with 0/2 approvals', async () => {
+  it('renders an ApprovalsChip component with 0/2 approvals', async () => {
     const mockUseGetVersionOrDeploymentApprovals = {
       approvals: [testApproval1, testApproval2],
       isApprovalsLoading: false,

--- a/frontend/src/common/ApprovalsChip.spec.tsx
+++ b/frontend/src/common/ApprovalsChip.spec.tsx
@@ -4,7 +4,14 @@ import { describe, expect, it, vi } from 'vitest'
 
 import { useGetVersionOrDeploymentApprovals } from '../../data/approvals'
 import { ApprovalCategory } from '../../types/types'
-import { testApproval1, testApproval2, testApproval3, testApproval4, testId, testUser } from '../../utils/testUtils'
+import {
+  testApproval1,
+  testApproval2,
+  testApproval3,
+  testApproval4,
+  testId,
+  testUser,
+} from '../../utils/test/testModels'
 import { lightTheme } from '../theme'
 import ApprovalsChip from './ApprovalsChip'
 
@@ -16,14 +23,6 @@ vi.mock('../../data/approvals', () => ({
     isNumApprovalsError: undefined,
     mutateNumApprovals: vi.fn(),
   }),
-}))
-
-vi.mock('../../utils/fetcher', () => ({
-  getErrorMessage: vi.fn().mockResolvedValue('Test error message'),
-}))
-
-vi.mock('../../data/api', () => ({
-  postEndpoint: vi.fn(),
 }))
 
 describe('ApprovalsChip', () => {
@@ -59,7 +58,9 @@ describe('ApprovalsChip', () => {
       isApprovalsError: undefined,
       mutateApprovals: vi.fn(),
     }
+
     vi.mocked(useGetVersionOrDeploymentApprovals).mockReturnValue(mockUseGetVersionOrDeploymentApprovals)
+
     render(
       <ThemeProvider theme={lightTheme}>
         <ApprovalsChip
@@ -82,7 +83,9 @@ describe('ApprovalsChip', () => {
       isApprovalsError: undefined,
       mutateApprovals: vi.fn(),
     }
+
     vi.mocked(useGetVersionOrDeploymentApprovals).mockReturnValue(mockUseGetVersionOrDeploymentApprovals)
+
     render(
       <ThemeProvider theme={lightTheme}>
         <ApprovalsChip
@@ -105,7 +108,9 @@ describe('ApprovalsChip', () => {
       isApprovalsError: undefined,
       mutateApprovals: vi.fn(),
     }
+
     vi.mocked(useGetVersionOrDeploymentApprovals).mockReturnValue(mockUseGetVersionOrDeploymentApprovals)
+
     render(
       <ThemeProvider theme={lightTheme}>
         <ApprovalsChip
@@ -128,7 +133,9 @@ describe('ApprovalsChip', () => {
       isApprovalsError: undefined,
       mutateApprovals: vi.fn(),
     }
+
     vi.mocked(useGetVersionOrDeploymentApprovals).mockReturnValue(mockUseGetVersionOrDeploymentApprovals)
+
     render(
       <ThemeProvider theme={lightTheme}>
         <ApprovalsChip

--- a/frontend/src/common/ApprovalsChip.spec.tsx
+++ b/frontend/src/common/ApprovalsChip.spec.tsx
@@ -4,7 +4,7 @@ import { describe, expect, it, vi } from 'vitest'
 
 import { useGetVersionOrDeploymentApprovals } from '../../data/approvals'
 import { ApprovalCategory } from '../../types/types'
-import { testApproval1, testApproval2, testId, testUser } from '../../utils/testUtils'
+import { testApproval1, testApproval2, testApproval3, testApproval4, testId, testUser } from '../../utils/testUtils'
 import { lightTheme } from '../theme'
 import ApprovalsChip from './ApprovalsChip'
 
@@ -52,65 +52,95 @@ describe('ApprovalsChip', () => {
     })
   })
 
-  // it('renders an ApprovalsChip component with 1/2 approvals', async () => {
-  //   render(
-  //     <ThemeProvider theme={lightTheme}>
-  //       <ApprovalsChip
-  //         approvals={[
-  //           { reviewers: [{ kind: EntityKind.USER, id: 'Alice' }], status: ApprovalStates.Accepted },
-  //           { reviewers: [{ kind: EntityKind.USER, id: 'Bob' }], status: ApprovalStates.NoResponse },
-  //         ]}
-  //       />
-  //     </ThemeProvider>
-  //   )
+  it('renders an ApprovalsChip component with 1/2 approvals', async () => {
+    const mockUseGetVersionOrDeploymentApprovals = {
+      approvals: [testApproval1, testApproval3],
+      isApprovalsLoading: false,
+      isApprovalsError: undefined,
+      mutateApprovals: vi.fn(),
+    }
+    vi.mocked(useGetVersionOrDeploymentApprovals).mockReturnValue(mockUseGetVersionOrDeploymentApprovals)
+    render(
+      <ThemeProvider theme={lightTheme}>
+        <ApprovalsChip
+          versionOrDeploymentId={testId}
+          approvalCategory={ApprovalCategory.Upload}
+          currentUser={testUser}
+        />
+      </ThemeProvider>
+    )
 
-  //   await waitFor(async () => {
-  //     expect(await screen.findByText('Approvals 1/2')).not.toBeUndefined()
-  //   })
-  // })
+    await waitFor(async () => {
+      expect(await screen.findByText('Approvals 1/2')).not.toBeUndefined()
+    })
+  })
 
-  // it('renders an ApprovalsChip component with 2/2 approvals', async () => {
-  //   render(
-  //     <ThemeProvider theme={lightTheme}>
-  //       <ApprovalsChip
-  //         approvals={[
-  //           { reviewers: [{ kind: EntityKind.USER, id: 'Alice' }], status: ApprovalStates.Accepted },
-  //           { reviewers: [{ kind: EntityKind.USER, id: 'Bob' }], status: ApprovalStates.Accepted },
-  //         ]}
-  //       />
-  //     </ThemeProvider>
-  //   )
+  it('renders an ApprovalsChip component with 2/2 approvals', async () => {
+    const mockUseGetVersionOrDeploymentApprovals = {
+      approvals: [testApproval3, testApproval4],
+      isApprovalsLoading: false,
+      isApprovalsError: undefined,
+      mutateApprovals: vi.fn(),
+    }
+    vi.mocked(useGetVersionOrDeploymentApprovals).mockReturnValue(mockUseGetVersionOrDeploymentApprovals)
+    render(
+      <ThemeProvider theme={lightTheme}>
+        <ApprovalsChip
+          versionOrDeploymentId={testId}
+          approvalCategory={ApprovalCategory.Upload}
+          currentUser={testUser}
+        />
+      </ThemeProvider>
+    )
 
-  //   await waitFor(async () => {
-  //     expect(await screen.findByText('Approvals 2/2')).not.toBeUndefined()
-  //   })
-  // })
+    await waitFor(async () => {
+      expect(await screen.findByText('Approvals 2/2')).not.toBeUndefined()
+    })
+  })
 
-  // it('renders an ApprovalsChip component with 0/1 approvals', async () => {
-  //   render(
-  //     <ThemeProvider theme={lightTheme}>
-  //       <ApprovalsChip
-  //         approvals={[{ reviewers: [{ kind: EntityKind.USER, id: 'Alice' }], status: ApprovalStates.NoResponse }]}
-  //       />
-  //     </ThemeProvider>
-  //   )
+  it('renders an ApprovalsChip component with 0/1 approvals', async () => {
+    const mockUseGetVersionOrDeploymentApprovals = {
+      approvals: [testApproval1],
+      isApprovalsLoading: false,
+      isApprovalsError: undefined,
+      mutateApprovals: vi.fn(),
+    }
+    vi.mocked(useGetVersionOrDeploymentApprovals).mockReturnValue(mockUseGetVersionOrDeploymentApprovals)
+    render(
+      <ThemeProvider theme={lightTheme}>
+        <ApprovalsChip
+          versionOrDeploymentId={testId}
+          approvalCategory={ApprovalCategory.Upload}
+          currentUser={testUser}
+        />
+      </ThemeProvider>
+    )
 
-  //   await waitFor(async () => {
-  //     expect(await screen.findByText('Approvals 0/1')).not.toBeUndefined()
-  //   })
-  // })
+    await waitFor(async () => {
+      expect(await screen.findByText('Approvals 0/1')).not.toBeUndefined()
+    })
+  })
 
-  // it('renders an ApprovalsChip component with 1/1 approvals', async () => {
-  //   render(
-  //     <ThemeProvider theme={lightTheme}>
-  //       <ApprovalsChip
-  //         approvals={[{ reviewers: [{ kind: EntityKind.USER, id: 'Alice' }], status: ApprovalStates.Accepted }]}
-  //       />
-  //     </ThemeProvider>
-  //   )
+  it('renders an ApprovalsChip component with 1/1 approvals', async () => {
+    const mockUseGetVersionOrDeploymentApprovals = {
+      approvals: [testApproval3],
+      isApprovalsLoading: false,
+      isApprovalsError: undefined,
+      mutateApprovals: vi.fn(),
+    }
+    vi.mocked(useGetVersionOrDeploymentApprovals).mockReturnValue(mockUseGetVersionOrDeploymentApprovals)
+    render(
+      <ThemeProvider theme={lightTheme}>
+        <ApprovalsChip
+          versionOrDeploymentId={testId}
+          approvalCategory={ApprovalCategory.Upload}
+          currentUser={testUser}
+        />
+      </ThemeProvider>
+    )
 
-  //   await waitFor(async () => {
-  //     expect(await screen.findByText('Approvals 1/1')).not.toBeUndefined()
-  //   })
-  // })
+    await waitFor(async () => {
+      expect(await screen.findByText('Approvals 1/1')).not.toBeUndefined()
+    })
+  })
 })

--- a/frontend/src/common/ApprovalsChip.tsx
+++ b/frontend/src/common/ApprovalsChip.tsx
@@ -105,7 +105,7 @@ export default function ApprovalsChip({
 
         if (approvalResponse.status >= 200 && approvalResponse.status < 400) {
           mutateApprovals()
-          // Mutate approvals on review page to update Badge in navigation menu
+          // Update number of approvals for Badge in navigation menu
           mutateNumApprovals()
         } else {
           sendNotification({ variant: 'error', msg: await getErrorMessage(approvalResponse) })

--- a/frontend/src/common/ApprovalsChip.tsx
+++ b/frontend/src/common/ApprovalsChip.tsx
@@ -3,7 +3,9 @@ import Close from '@mui/icons-material/CloseTwoTone'
 import Done from '@mui/icons-material/DoneTwoTone'
 import DownArrow from '@mui/icons-material/KeyboardArrowDown'
 import UpArrow from '@mui/icons-material/KeyboardArrowUp'
+import { Badge, IconButton, Tooltip } from '@mui/material'
 import Chip from '@mui/material/Chip'
+import Divider from '@mui/material/Divider'
 import List from '@mui/material/List'
 import ListItem from '@mui/material/ListItem'
 import ListItemIcon from '@mui/material/ListItemIcon'
@@ -11,65 +13,139 @@ import ListItemText from '@mui/material/ListItemText'
 import Menu from '@mui/material/Menu'
 import Stack from '@mui/material/Stack'
 import { useTheme } from '@mui/material/styles'
+import { postEndpoint } from 'data/api'
+import { useListApprovals } from 'data/approvals'
 import React, { MouseEvent, ReactElement, useCallback, useMemo, useState } from 'react'
 
-import { ApprovalStates, Entity } from '../../types/types'
+import { Approval, ApprovalCategory, ApprovalStates, Deployment, User, Version } from '../../types/types'
 
-type Approval = {
-  reviewers: Array<Entity>
-  status: ApprovalStates
-}
+/*
+- If current user is in approval.reviewers array AND approval.status === ApprovalStates.NoResponse -> Show approve/decline buttons 
+  - Show badge with number for number of times the above is true
+  - Will require user to be passed in via props
+
+- When user clicks approve/decline call:
+  await postEndpoint(`/api/v1/approval/${approval?._id}/respond`, { choice }).then((res) => res.json())
+
+- Assumption: Once POST approval has succeeded, call onChange prop from ApprovalsChip
+  - In the model (frontend/pages/model/[uuid].tsx) and deployment (frontend/pages/deployment/[uuid].tsx) overviews, call mutate when this onChange prop is called
+*/
 
 type ApprovalsChipProps = {
-  approvals: Approval[]
+  versionOrDeploymentId: Version['_id'] | Deployment['_id']
+  approvalCategory: ApprovalCategory
+  currentUser: User
 }
 
-export default function ApprovalsChip({ approvals }: ApprovalsChipProps): ReactElement {
+export default function ApprovalsChip({
+  versionOrDeploymentId,
+  approvalCategory,
+  currentUser,
+}: ApprovalsChipProps): ReactElement {
   const theme = useTheme()
   const [anchorEl, setAnchorEl] = useState<HTMLDivElement | null>(null)
+  // TODO use loading, error and mutate
+  const {
+    approvals: foundApprovals,
+    isApprovalsLoading,
+    isApprovalsError,
+    mutateApprovals,
+  } = useListApprovals(approvalCategory, 'user', versionOrDeploymentId)
+  const approvals = useMemo(() => foundApprovals || [], [foundApprovals])
 
   const open = useMemo(() => !!anchorEl, [anchorEl])
-  const numApprovals = useMemo(() => approvals.filter((approval) => approval.status === 'Accepted').length, [approvals])
+  const numAcceptedApprovals = useMemo(
+    () => approvals.filter((approval) => approval.status === ApprovalStates.Accepted).length,
+    [approvals]
+  )
   const totalApprovals = useMemo(() => approvals.length, [approvals])
+  const noResponseApprovals = useMemo(
+    () => approvals.filter((approval) => approval.status === ApprovalStates.NoResponse),
+    [approvals]
+  )
+  const numCurrentUserApprovals = useMemo(
+    () =>
+      noResponseApprovals.filter((approval) => approval.approvers.some((reviewer) => reviewer.id === currentUser.id))
+        .length,
+    [noResponseApprovals, currentUser]
+  )
 
   const backgroundColor = useMemo(() => {
-    if (numApprovals === 0) {
+    if (numAcceptedApprovals === 0) {
       return theme.palette.error.main
     }
-    if (numApprovals < totalApprovals) {
+    if (numAcceptedApprovals < totalApprovals) {
       return '#dc851b'
     }
     return '#4c8a4c'
-  }, [numApprovals, totalApprovals, theme])
+  }, [numAcceptedApprovals, totalApprovals, theme])
 
-  const getApprovalResponses = useCallback((approval: Approval, index: number) => {
-    let Icon
-    let secondaryText = ''
-    const primaryText = approval.reviewers.map((reviewer) => reviewer.id).join(', ')
+  const getApprovalResponses = useCallback(
+    (approval: Pick<Approval, '_id' | 'approvers' | 'status'>, index: number) => {
+      let Icon = AccessTime
+      let secondaryText = ''
+      const primaryText = approval.approvers.map((reviewer) => reviewer.id).join(', ')
+      const isAwaitingCurrentUserResponse =
+        approval.status === ApprovalStates.NoResponse &&
+        approval.approvers.some((reviewer) => reviewer.id === currentUser.id)
 
-    if (approval.status === ApprovalStates.Accepted) {
-      Icon = Done
-      secondaryText = 'Approved'
-    } else if (approval.status === ApprovalStates.Declined) {
-      Icon = Close
-      secondaryText = 'Declined'
-    } else if (approval.status === ApprovalStates.NoResponse) {
-      Icon = AccessTime
-      secondaryText = 'Awaiting response'
-    }
+      if (approval.status === ApprovalStates.Accepted) {
+        Icon = Done
+        secondaryText = 'Approved'
+      } else if (approval.status === ApprovalStates.Declined) {
+        Icon = Close
+        secondaryText = 'Declined'
+      } else if (approval.status === ApprovalStates.NoResponse) {
+        Icon = AccessTime
+        secondaryText = 'Awaiting response'
+      }
 
-    return (
-      <ListItem key={index}>
-        <ListItemIcon>
-          <Icon aria-hidden />
-        </ListItemIcon>
-        <ListItemText primary={primaryText} secondary={secondaryText} />
-      </ListItem>
-    )
-  }, [])
+      const updateApprovalState = async (newState: Exclude<ApprovalStates, ApprovalStates.NoResponse>) => {
+        // TODO: Error handling
+        const approvalResponse = await postEndpoint(`/api/v1/approval/${approval._id}/respond`, { choice: newState })
+        mutateApprovals()
+      }
+
+      return (
+        <ListItem key={index}>
+          <Stack direction='row' alignItems='center' spacing={2}>
+            <>
+              <ListItemIcon sx={{ minWidth: 24 }}>
+                <Icon aria-hidden />
+              </ListItemIcon>
+              <ListItemText primary={primaryText} secondary={secondaryText} />
+            </>
+            <>
+              {isAwaitingCurrentUserResponse && (
+                <Stack direction='row' alignItems='center'>
+                  <Tooltip title='Approve'>
+                    <IconButton onClick={() => updateApprovalState(ApprovalStates.Accepted)}>
+                      <Done />
+                    </IconButton>
+                  </Tooltip>
+                  <Tooltip title='Reject'>
+                    <IconButton onClick={() => updateApprovalState(ApprovalStates.Declined)}>
+                      <Close />
+                    </IconButton>
+                  </Tooltip>
+                </Stack>
+              )}
+            </>
+          </Stack>
+        </ListItem>
+      )
+    },
+    [currentUser, mutateApprovals]
+  )
 
   const approvalResponseListItems = useMemo(
-    () => approvals.map((approval, index) => getApprovalResponses(approval, index)),
+    () =>
+      approvals.map((approval, index) => (
+        <>
+          {getApprovalResponses(approval, index)}
+          {index < approvals.length - 1 && <Divider variant='middle' />}
+        </>
+      )),
     [approvals, getApprovalResponses]
   )
 
@@ -83,22 +159,24 @@ export default function ApprovalsChip({ approvals }: ApprovalsChipProps): ReactE
 
   return (
     <Stack direction='row'>
-      <Chip
-        sx={{ borderRadius: 1, color: 'white', height: 'auto', backgroundColor }}
-        label={`Approvals ${numApprovals}/${totalApprovals}`}
-        onClick={handleApprovalsClicked}
-        icon={
-          open ? (
-            <UpArrow sx={{ color: 'white !important', pl: 1 }} />
-          ) : (
-            <DownArrow sx={{ color: 'white !important', pl: 1 }} />
-          )
-        }
-        aria-controls='model-approvals-menu'
-        aria-haspopup='true'
-        aria-expanded={open ? 'true' : undefined}
-        data-test='approvalsChip'
-      />
+      <Badge badgeContent={numCurrentUserApprovals} color='primary'>
+        <Chip
+          sx={{ borderRadius: 1, color: 'white', height: 'auto', backgroundColor }}
+          label={`Approvals ${numAcceptedApprovals}/${totalApprovals}`}
+          onClick={handleApprovalsClicked}
+          icon={
+            open ? (
+              <UpArrow sx={{ color: 'white !important', pl: 1 }} />
+            ) : (
+              <DownArrow sx={{ color: 'white !important', pl: 1 }} />
+            )
+          }
+          aria-controls='model-approvals-menu'
+          aria-haspopup='true'
+          aria-expanded={open ? 'true' : undefined}
+          data-test='approvalsChip'
+        />
+      </Badge>
       <Menu id='model-approvals-menu' anchorEl={anchorEl} open={open} onClose={handleClose}>
         <List dense>{approvalResponseListItems}</List>
       </Menu>

--- a/frontend/src/common/ApprovalsChip.tsx
+++ b/frontend/src/common/ApprovalsChip.tsx
@@ -19,8 +19,8 @@ import { useTheme } from '@mui/material/styles'
 import { lighten } from '@mui/material/styles'
 import Tooltip from '@mui/material/Tooltip'
 import { postEndpoint } from 'data/api'
-import { useGetVersionOrDeploymentApprovals } from 'data/approvals'
-import { MouseEvent, ReactElement, useCallback, useEffect, useMemo, useState } from 'react'
+import { useGetNumApprovals, useGetVersionOrDeploymentApprovals } from 'data/approvals'
+import { Fragment, MouseEvent, ReactElement, useCallback, useEffect, useMemo, useState } from 'react'
 import { getErrorMessage } from 'utils/fetcher'
 
 import { Approval, ApprovalCategory, ApprovalStates, Deployment, User, Version } from '../../types/types'
@@ -40,7 +40,7 @@ export default function ApprovalsChip({
   const theme = useTheme()
   const [anchorEl, setAnchorEl] = useState<HTMLDivElement | null>(null)
   const sendNotification = useNotification()
-
+  const { mutateNumApprovals } = useGetNumApprovals()
   const {
     approvals: foundApprovals,
     isApprovalsLoading,
@@ -105,7 +105,8 @@ export default function ApprovalsChip({
 
         if (approvalResponse.status >= 200 && approvalResponse.status < 400) {
           mutateApprovals()
-          mutate()
+          // Mutate approvals on review page to update Badge in navigation menu
+          mutateNumApprovals()
         } else {
           sendNotification({ variant: 'error', msg: await getErrorMessage(approvalResponse) })
         }
@@ -140,16 +141,16 @@ export default function ApprovalsChip({
         </ListItem>
       )
     },
-    [currentUser, mutateApprovals, sendNotification]
+    [currentUser.id, mutateApprovals, mutateNumApprovals, sendNotification]
   )
 
   const approvalResponseListItems = useMemo(
     () =>
       approvals.map((approval, index) => (
-        <>
+        <Fragment key={`approvalResponse-${approval._id}`}>
           {getApprovalResponses(approval, index)}
           {index < approvals.length - 1 && <Divider variant='middle' />}
-        </>
+        </Fragment>
       )),
     [approvals, getApprovalResponses]
   )

--- a/frontend/src/common/ConfirmationDialogue.spec.tsx
+++ b/frontend/src/common/ConfirmationDialogue.spec.tsx
@@ -1,7 +1,7 @@
 import { render, screen, waitFor } from '@testing-library/react'
 import { describe, expect, it } from 'vitest'
 
-import { doNothing } from '../../utils/testUtils'
+import { doNothing } from '../../utils/test/testUtils'
 import ConfirmationDialogue from './ConfirmationDialogue'
 
 describe('ConfirmationDialogue', () => {

--- a/frontend/src/common/FileInput.spec.tsx
+++ b/frontend/src/common/FileInput.spec.tsx
@@ -1,7 +1,7 @@
 import { render, screen, waitFor } from '@testing-library/react'
 import { describe, expect } from 'vitest'
 
-import { doNothing } from '../../utils/testUtils'
+import { doNothing } from '../../utils/test/testUtils'
 import FileInput from './FileInput'
 
 describe('FileInput', () => {

--- a/frontend/utils/test/testModels.ts
+++ b/frontend/utils/test/testModels.ts
@@ -1,17 +1,4 @@
-import { configure } from '@testing-library/react'
-import { beforeAll, vi } from 'vitest'
-
-import { ApprovalCategory, ApprovalStates, ApprovalTypes, EntityKind } from '../types/types'
-
-configure({ testIdAttribute: 'data-test' })
-
-beforeAll(() => {
-  vi.mock('next/router', () => require('next-router-mock'))
-})
-
-export function doNothing() {
-  /* Do nothing */
-}
+import { ApprovalCategory, ApprovalStates, ApprovalTypes, EntityKind } from '../../types/types'
 
 export const testId = 'testId'
 
@@ -96,37 +83,17 @@ export const testApproval1: any = {
 export const testApproval2: any = {
   ...testApproval1,
   _id: 'testApprovalId2',
-  approvers: [
-    {
-      kind: EntityKind.USER,
-      id: 'testUserId',
-    },
-  ],
+  approvalType: ApprovalTypes.Manager,
 }
 
 export const testApproval3: any = {
+  ...testApproval1,
   _id: 'testApprovalId3',
-  version: testVersion,
-  approvers: [
-    {
-      kind: EntityKind.USER,
-      id: 'testUserId',
-    },
-  ],
   status: ApprovalStates.Accepted,
-  approvalType: ApprovalTypes.Reviewer,
-  approvalCategory: ApprovalCategory.Upload,
-  createdAt: new Date(),
-  updatedAt: new Date(),
 }
 
 export const testApproval4: any = {
-  ...testApproval3,
+  ...testApproval2,
   _id: 'testApprovalId4',
-  approvers: [
-    {
-      kind: EntityKind.USER,
-      id: 'testUserId',
-    },
-  ],
+  status: ApprovalStates.Accepted,
 }

--- a/frontend/utils/test/testUtils.ts
+++ b/frontend/utils/test/testUtils.ts
@@ -1,0 +1,12 @@
+import { configure } from '@testing-library/react'
+import { beforeAll, vi } from 'vitest'
+
+configure({ testIdAttribute: 'data-test' })
+
+beforeAll(() => {
+  vi.mock('next/router', () => require('next-router-mock'))
+})
+
+export function doNothing() {
+  /* Do nothing */
+}

--- a/frontend/utils/testUtils.ts
+++ b/frontend/utils/testUtils.ts
@@ -1,6 +1,8 @@
 import { configure } from '@testing-library/react'
 import { beforeAll, vi } from 'vitest'
 
+import { ApprovalCategory, ApprovalStates, ApprovalTypes, EntityKind } from '../types/types'
+
 configure({ testIdAttribute: 'data-test' })
 
 beforeAll(() => {
@@ -9,4 +11,95 @@ beforeAll(() => {
 
 export function doNothing() {
   /* Do nothing */
+}
+
+export const testId = 'testId'
+
+export const testUser: any = {
+  _id: 'testUserId',
+  id: 'user',
+  email: 'test@example.com',
+  roles: ['user'],
+}
+
+export const testModel: any = {
+  _id: 'testModelId',
+  versions: [],
+  schemaRef: 'test-schema',
+  uuid: 'testModelUuid',
+  latestVersion: 'testVersionId',
+  createdAt: new Date(),
+  updatedAt: new Date(),
+}
+
+export const testVersion: any = {
+  _id: 'testVersionId',
+  model: testModel,
+  version: '1',
+  metadata: {
+    highLevelDetails: {
+      name: 'test',
+    },
+    contacts: {
+      uploader: [
+        {
+          kind: EntityKind.USER,
+          id: 'user',
+        },
+      ],
+      reviewer: [
+        {
+          kind: EntityKind.USER,
+          id: 'reviewer',
+        },
+      ],
+      manager: [
+        {
+          kind: EntityKind.USER,
+          id: 'manager',
+        },
+      ],
+    },
+    buildOptions: {
+      seldonVersion: 'seldonio/seldon-core-s2i-python37:1.10.0',
+    },
+  },
+  files: {
+    rawCodePath: '',
+    rawBinaryPath: '',
+  },
+  built: false,
+  managerApproved: ApprovalStates.NoResponse,
+  reviewerApproved: ApprovalStates.NoResponse,
+  state: {},
+  logs: [],
+  createdAt: new Date(),
+  updatedAt: new Date(),
+}
+
+export const testApproval1: any = {
+  _id: 'testApprovalId1',
+  version: testVersion,
+  approvers: [
+    {
+      kind: EntityKind.USER,
+      id: 'testUserId',
+    },
+  ],
+  status: ApprovalStates.NoResponse,
+  approvalType: ApprovalTypes.Reviewer,
+  approvalCategory: ApprovalCategory.Upload,
+  createdAt: new Date(),
+  updatedAt: new Date(),
+}
+
+export const testApproval2: any = {
+  ...testApproval1,
+  _id: 'testApprovalId2',
+  approvers: [
+    {
+      kind: EntityKind.USER,
+      id: 'testUserId',
+    },
+  ],
 }

--- a/frontend/utils/testUtils.ts
+++ b/frontend/utils/testUtils.ts
@@ -103,3 +103,30 @@ export const testApproval2: any = {
     },
   ],
 }
+
+export const testApproval3: any = {
+  _id: 'testApprovalId3',
+  version: testVersion,
+  approvers: [
+    {
+      kind: EntityKind.USER,
+      id: 'testUserId',
+    },
+  ],
+  status: ApprovalStates.Accepted,
+  approvalType: ApprovalTypes.Reviewer,
+  approvalCategory: ApprovalCategory.Upload,
+  createdAt: new Date(),
+  updatedAt: new Date(),
+}
+
+export const testApproval4: any = {
+  ...testApproval3,
+  _id: 'testApprovalId4',
+  approvers: [
+    {
+      kind: EntityKind.USER,
+      id: 'testUserId',
+    },
+  ],
+}

--- a/frontend/vitest.config.ts
+++ b/frontend/vitest.config.ts
@@ -1,9 +1,9 @@
-import { defineConfig } from 'vitest/config'
 import react from '@vitejs/plugin-react'
+import tsconfigPaths from 'vite-tsconfig-paths'
+import { defineConfig } from 'vitest/config'
 
-// https://vitejs.dev/config/
 export default defineConfig({
-  plugins: [react()],
+  plugins: [react(), tsconfigPaths()],
   test: {
     globals: true,
     environment: 'jsdom',

--- a/frontend/vitest.config.ts
+++ b/frontend/vitest.config.ts
@@ -7,6 +7,6 @@ export default defineConfig({
   test: {
     globals: true,
     environment: 'jsdom',
-    setupFiles: ['./utils/testUtils.ts'],
+    setupFiles: ['./utils/test/testUtils.ts'],
   },
 })


### PR DESCRIPTION
Have added complete functionality so that if the user has permissions to approve a model, they can do so directly from the model page, rather than having to navigate to Review. The button has been updated to reflect this and improve user experience.

One outstanding issue that has been noted is that the badges that display the 'count' of approvals (how many are remaining to be reviewed) are not synchronised on the approve button on the model page and on the Review option, as we are not using a state sharing solution like Redux. 

Scenario example: If there are 2 approvals to be made and you are the approver for both, and you are on the model page, you will see a badge displaying '2' on the button on that page and on the Review tab on the left side of the screen. If you select to approve from the model page, the count there will drop to '1' but on the side will still show as '2' until you refresh the page or navigate to any other page. It won't automatically do it in snychronised real time.

We were uncertain of a solution for this, or at least within the scope of this ticket, but it would be great to hear any suggestions