### PR TITLE
Bai 650 add warning message for max model upload size

### DIFF
--- a/backend/config/default.cjs
+++ b/backend/config/default.cjs
@@ -215,5 +215,6 @@ module.exports = {
         image: 'seldonio/seldon-core-s2i-python37:1.10.0',
       },
     ],
+    maxModelSizeGB: 50
   },
 }

--- a/backend/src/routes/v1/specification.ts
+++ b/backend/src/routes/v1/specification.ts
@@ -507,6 +507,12 @@ function parseValue(value: unknown) {
       example: value,
     }
   }
+  if (typeof value === 'number') {
+    return {
+      type: 'number',
+      example: value,
+    }
+  }
   if (typeof value === 'boolean') {
     return {
       type: 'boolean',

--- a/backend/src/types/types.ts
+++ b/backend/src/types/types.ts
@@ -133,6 +133,7 @@ export interface UiConfig {
   }
 
   seldonVersions: Array<SeldonVersion>
+  maxModelSizeGB: number
 }
 
 export type SeldonVersion = {

--- a/backend/src/utils/config.ts
+++ b/backend/src/utils/config.ts
@@ -147,6 +147,8 @@ export interface Config {
       name: string
       image: string
     }>
+    //max model size is calculated in gigabytes
+    maxModelSizeGB: number
   }
 }
 

--- a/frontend/pages/model/[uuid]/new-version.tsx
+++ b/frontend/pages/model/[uuid]/new-version.tsx
@@ -1,7 +1,9 @@
 import Paper from '@mui/material/Paper'
 import axios from 'axios'
+import { useGetUiConfig } from 'data/uiConfig'
 import { useRouter } from 'next/router'
 import React, { useEffect, useState } from 'react'
+import Loading from 'src/common/Loading'
 import MessageAlert from 'src/MessageAlert'
 
 import { useGetModel, useGetModelVersions } from '../../../data/model'
@@ -47,6 +49,7 @@ function Upload() {
   const { model, isModelLoading, isModelError, mutateModel } = useGetModel(modelUuid)
   const { schema, isSchemaLoading, isSchemaError } = useGetSchema(model?.schemaRef)
   const { versions } = useGetModelVersions(modelUuid)
+  const { uiConfig, isUiConfigError, isUiConfigLoading } = useGetUiConfig()
 
   const cModel = useCacheVariable(model)
   const cSchema = useCacheVariable(schema)
@@ -88,7 +91,7 @@ function Upload() {
 
         render: RenderFileTab,
         renderBasic: RenderBasicFileTab,
-        isComplete: fileTabComplete,
+        isComplete: (step) => fileTabComplete(step, uiConfig ? uiConfig.maxModelSizeGB : 0),
       })
     )
 
@@ -115,16 +118,17 @@ function Upload() {
     }
 
     setSplitSchema({ reference: cSchema.reference, steps })
-  }, [cModel, cSchema])
+  }, [cModel, cSchema, uiConfig])
 
   const errorWrapper = MultipleErrorWrapper(`Unable to load edit page`, {
     isModelError,
     isSchemaError,
+    isUiConfigError,
   })
   if (errorWrapper) return errorWrapper
 
-  if (isModelLoading || isSchemaLoading) {
-    return null
+  if (isModelLoading || isSchemaLoading || isUiConfigLoading) {
+    return <Loading />
   }
 
   if (!model || !schema) {

--- a/frontend/pages/upload.tsx
+++ b/frontend/pages/upload.tsx
@@ -2,8 +2,10 @@ import Box from '@mui/material/Box'
 import Grid from '@mui/material/Grid'
 import Paper from '@mui/material/Paper'
 import axios from 'axios'
+import { useGetUiConfig } from 'data/uiConfig'
 import { useRouter } from 'next/router'
 import React, { useEffect, useState } from 'react'
+import Loading from 'src/common/Loading'
 
 import { useGetDefaultSchema, useGetSchemas } from '../data/schema'
 import { useGetCurrentUser } from '../data/user'
@@ -47,6 +49,7 @@ function Upload() {
   const { defaultSchema, isDefaultSchemaError, isDefaultSchemaLoading } = useGetDefaultSchema('UPLOAD')
   const { schemas, isSchemasLoading, isSchemasError } = useGetSchemas('UPLOAD')
   const { currentUser, isCurrentUserLoading, isCurrentUserError } = useGetCurrentUser()
+  const { uiConfig, isUiConfigError, isUiConfigLoading } = useGetUiConfig()
 
   const router = useRouter()
 
@@ -104,7 +107,7 @@ function Upload() {
 
         render: RenderFileTab,
         renderBasic: RenderBasicFileTab,
-        isComplete: fileTabComplete,
+        isComplete: (step) => fileTabComplete(step, uiConfig ? uiConfig.maxModelSizeGB : 0),
       })
     )
 
@@ -131,7 +134,7 @@ function Upload() {
     }
 
     setSplitSchema({ reference, steps })
-  }, [currentSchema, user])
+  }, [currentSchema, uiConfig, user])
 
   const errorWrapper = MultipleErrorWrapper(
     `Unable to load upload page`,
@@ -139,19 +142,16 @@ function Upload() {
       isDefaultSchemaError,
       isSchemasError,
       isCurrentUserError,
+      isUiConfigError,
     },
     MinimalErrorWrapper
   )
   if (errorWrapper) return errorWrapper
 
-  if (isDefaultSchemaLoading || isSchemasLoading || isCurrentUserLoading) {
-    return null
-  }
-  const Loading = <Wrapper title='Loading...' page='deployment' />
-
-  if (isDefaultSchemaLoading || !defaultSchema) return Loading
-  if (isSchemasLoading || !schemas) return Loading
-  if (isCurrentUserLoading || !currentUser) return Loading
+  if (isDefaultSchemaLoading || !defaultSchema) return <Loading />
+  if (isSchemasLoading || !schemas) return <Loading />
+  if (isCurrentUserLoading || !currentUser) return <Loading />
+  if (isUiConfigLoading || !uiConfig) return <Loading />
 
   const onSubmit = async () => {
     setError(undefined)

--- a/frontend/src/Form/RenderFileTab.tsx
+++ b/frontend/src/Form/RenderFileTab.tsx
@@ -34,7 +34,7 @@ export default function RenderFileTab({ step, splitSchema, setSplitSchema }: Ren
     if (isUiConfigError) setError(isUiConfigError.message)
     else if (!uiConfig) setError('Failed to load ui config')
     else if (totalFileSize > convertGigabytesToBytes(uiConfig.maxModelSizeGB))
-      setError('Model size exceeds maximum upload size of')
+      setError('Model size exceeds maximum upload size of ' + uiConfig.maxModelSizeGB + 'GB')
     else setError('')
   }, [isUiConfigError, totalFileSize, uiConfig])
 

--- a/frontend/src/Form/RenderFileTab.tsx
+++ b/frontend/src/Form/RenderFileTab.tsx
@@ -32,7 +32,7 @@ export default function RenderFileTab({ step, splitSchema, setSplitSchema }: Ren
 
   useEffect(() => {
     if (isUiConfigError) setError(isUiConfigError.message)
-    else if (!uiConfig) setError('Failed to load ui config')
+    else if (!uiConfig) setError('Failed to load UI config')
     else if (totalFileSize > convertGigabytesToBytes(uiConfig.maxModelSizeGB))
       setError('Model size exceeds maximum upload size of ' + uiConfig.maxModelSizeGB + 'GB')
     else setError('')

--- a/frontend/src/common/Loading.tsx
+++ b/frontend/src/common/Loading.tsx
@@ -1,0 +1,10 @@
+import { Box, CircularProgress } from '@mui/material'
+import { ReactElement } from 'react'
+
+export default function Loading(): ReactElement {
+  return (
+    <Box sx={{ display: 'flex', justifyContent: 'center' }}>
+      <CircularProgress />
+    </Box>
+  )
+}

--- a/frontend/types/types.ts
+++ b/frontend/types/types.ts
@@ -137,6 +137,9 @@ export interface UiConfig {
   }
 
   seldonVersions: Array<SeldonVersion>
+
+  //max model size is calculated in gigabytes
+  maxModelSizeGB: number
 }
 
 export type SeldonVersion = {

--- a/frontend/utils/byteUtils.ts
+++ b/frontend/utils/byteUtils.ts
@@ -1,0 +1,3 @@
+export function convertGigabytesToBytes(gigabytes: number) {
+  return gigabytes * 1024 * 1024 * 1024
+}


### PR DESCRIPTION
Added functionality so that if the user tries to upload a combination of code, binary and docker files (or any one of these) that exceeds the maximum upload size we allow, they are presented with an error message which tells them the issue, what the upper limit is, and they cannot proceed to select upload.
The amount set is configurable and at the time of this PR is set within backend>config>default.cjs to 50 GB.
This PR also includes an improved Loading state which displays a loading spinner rather than a Wrapper, which was confusing to the user and not visually attractive.