### PR TITLE
Hide experimental warnings from node

### DIFF
--- a/backend/nodemon.json
+++ b/backend/nodemon.json
@@ -1,6 +1,6 @@
 {
   "watch": ["src", "config"],
   "ignore": [".git", "src/scripts"],
-  "exec": "node --loader ts-node/esm --inspect=0.0.0.0:9229 src/index.ts",
+  "exec": "node --no-warnings=ExperimentalWarning --loader ts-node/esm --inspect=0.0.0.0:9229 src/index.ts",
   "ext": "js ts cjs"
 }


### PR DESCRIPTION
These come up on every restart and don't particularly matter.  We already realise we're using multiple experimental features and these warnings just pollute the logs.