### PR TITLE
add start of ui work for access requests

### DIFF
--- a/backend/src/models/v2/Model.ts
+++ b/backend/src/models/v2/Model.ts
@@ -21,6 +21,10 @@ export interface ModelCardInterface {
   metadata: unknown
 }
 
+export interface AccessRequestSettings {
+  schemaId: string
+}
+
 // This interface stores information about the properties on the base object.
 // It should be used for plain object representations, e.g. for sending to the
 // client.
@@ -30,6 +34,7 @@ export interface ModelInterface {
   name: string
   description: string
   card?: ModelCardInterface
+  accessRequestSettings?: AccessRequestSettings
 
   collaborators: Array<CollaboratorEntry>
 
@@ -71,7 +76,7 @@ const ModelSchema = new Schema<ModelInterface>(
   {
     timestamps: true,
     collection: 'v2_models',
-  }
+  },
 )
 
 ModelSchema.plugin(MongooseDelete, { overrideMethods: 'all', deletedBy: true, deletedByType: Schema.Types.ObjectId })

--- a/backend/src/models/v2/Model.ts
+++ b/backend/src/models/v2/Model.ts
@@ -71,7 +71,7 @@ const ModelSchema = new Schema<ModelInterface>(
   {
     timestamps: true,
     collection: 'v2_models',
-  },
+  }
 )
 
 ModelSchema.plugin(MongooseDelete, { overrideMethods: 'all', deletedBy: true, deletedByType: Schema.Types.ObjectId })

--- a/backend/src/models/v2/Model.ts
+++ b/backend/src/models/v2/Model.ts
@@ -76,7 +76,7 @@ const ModelSchema = new Schema<ModelInterface>(
   {
     timestamps: true,
     collection: 'v2_models',
-  },
+  }
 )
 
 ModelSchema.plugin(MongooseDelete, { overrideMethods: 'all', deletedBy: true, deletedByType: Schema.Types.ObjectId })

--- a/backend/src/models/v2/Model.ts
+++ b/backend/src/models/v2/Model.ts
@@ -21,10 +21,6 @@ export interface ModelCardInterface {
   metadata: unknown
 }
 
-export interface AccessRequestSettings {
-  schemaId: string
-}
-
 // This interface stores information about the properties on the base object.
 // It should be used for plain object representations, e.g. for sending to the
 // client.
@@ -34,7 +30,6 @@ export interface ModelInterface {
   name: string
   description: string
   card?: ModelCardInterface
-  accessRequestSettings?: AccessRequestSettings
 
   collaborators: Array<CollaboratorEntry>
 
@@ -76,7 +71,7 @@ const ModelSchema = new Schema<ModelInterface>(
   {
     timestamps: true,
     collection: 'v2_models',
-  }
+  },
 )
 
 ModelSchema.plugin(MongooseDelete, { overrideMethods: 'all', deletedBy: true, deletedByType: Schema.Types.ObjectId })

--- a/backend/src/scripts/example_schemas/minimal_access_request_schema_beta.json
+++ b/backend/src/scripts/example_schemas/minimal_access_request_schema_beta.json
@@ -1,0 +1,69 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "definitions": {
+    "useType": {
+      "type": "string",
+      "enum": ["RESEARCH", "TESTING", "CAPABILITY DEVELOPMENT", "OPERATIONAL"],
+      "enumNames": [
+        "Model will be used in researching e.g.testing new use cases.",
+        "Model will be used in testing - how the model will be integrated into a wider system.",
+        "Model will be used as part of capability development.",
+        "Model will be part of an operational system."
+      ]
+    },
+    "entity": {
+      "type": "object",
+      "properties": {
+        "kind": {
+          "type": "string",
+          "description": "Type of entity (user, group)."
+        },
+        "id": {
+          "type": "string",
+          "description": "Unique identifier for entity."
+        }
+      }
+    }
+  },
+  "type": "object",
+  "properties": {
+    "id": {
+      "type": "string"
+    },
+    "timeStamp": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "schemaRef": {
+      "title": "Schema reference",
+      "type": "string"
+    },
+    "highLevelDetails": {
+      "title": "Details",
+      "type": "object",
+      "properties": {
+        "name": {
+          "title": "What is the name of the access request?",
+          "description": "This will be used to distinguish your access request from other access requests of this model",
+          "type": "string",
+          "maxLength": 100,
+          "widget": "customTextInput"
+        },
+        "hasEndDate": {
+          "title": "Is there a known end date for this access request?",
+          "description": "Choose YES if this access request will only be used for a short period choose an end date. Choose NO if the access request will be ongoing and/or using new versions of the model when released.",
+          "type": "boolean"
+        },
+        "endDate": {
+          "title": "If you have answered yes to the above then what is the end date for this access request?",
+          "type": "string",
+          "format": "date"
+        }
+      },
+      "required": ["name", "hasEndDate"],
+      "additionalProperties": false
+    }
+  },
+  "required": ["timeStamp", "user", "highLevelDetails"],
+  "additionalProperties": false
+}

--- a/backend/src/services/v2/schema.ts
+++ b/backend/src/services/v2/schema.ts
@@ -57,7 +57,7 @@ export async function addDefaultSchemas() {
       active: true,
       hidden: false,
     },
-    true,
+    true
   )
 
   await createSchema(
@@ -70,6 +70,6 @@ export async function addDefaultSchemas() {
       active: true,
       hidden: false,
     },
-    true,
+    true
   )
 }

--- a/backend/src/services/v2/schema.ts
+++ b/backend/src/services/v2/schema.ts
@@ -1,5 +1,6 @@
 import { testDeploymentSchema } from '../../../test/testUtils/testModels.js'
 import Schema, { SchemaInterface } from '../../models/v2/Schema.js'
+import accessRequestSchemaBeta from '../../scripts/example_schemas/minimal_access_request_schema_beta.json' assert { type: 'json' }
 import modelSchemaBeta from '../../scripts/example_schemas/minimal_upload_schema_beta.json' assert { type: 'json' }
 import { SchemaKind, SchemaKindKeys } from '../../types/v2/enums.js'
 import { BadReq, NotFound } from '../../utils/v2/error.js'
@@ -56,6 +57,19 @@ export async function addDefaultSchemas() {
       active: true,
       hidden: false,
     },
-    true
+    true,
+  )
+
+  await createSchema(
+    {
+      name: 'Minimal Access REquestSchema v10 Beta',
+      id: 'minimal-access-request-general-v10-beta',
+      description: 'This is a test beta schema',
+      jsonSchema: accessRequestSchemaBeta,
+      kind: SchemaKind.Deployment,
+      active: true,
+      hidden: false,
+    },
+    true,
   )
 }

--- a/frontend/pages/beta/index.tsx
+++ b/frontend/pages/beta/index.tsx
@@ -71,9 +71,6 @@ export default function ExploreModels() {
     <Wrapper title='Explore Models' page='marketplace'>
       <Stack direction='row' spacing={2}>
         <Stack spacing={2}>
-          <Typography component='h1' variant='h4' color='primary'>
-            Marketplace
-          </Typography>
           <Button component={Link} href='/beta/model/new' variant='contained'>
             Add new model
           </Button>

--- a/frontend/pages/beta/model/[modelId].tsx
+++ b/frontend/pages/beta/model/[modelId].tsx
@@ -14,7 +14,9 @@ export default function Model() {
   const { modelId }: { modelId?: string } = router.query
   const { model, isModelLoading, isModelError } = useGetModel(modelId)
 
-  // TODO implement function
+  function requestAccess() {
+    router.push(`/beta/model/${modelId}/access/new`)
+  }
 
   return (
     <Wrapper title='Model' page='marketplace' fullWidth>
@@ -28,6 +30,9 @@ export default function Model() {
             { title: 'Releases', view: <Releases model={model} /> },
             { title: 'Settings', view: <Settings model={model} /> },
           ]}
+          displayActionButton
+          actionButtonTitle='Request access'
+          actionButtonOnClick={requestAccess}
         />
       )}
     </Wrapper>

--- a/frontend/pages/beta/model/[modelId]/access/new.tsx
+++ b/frontend/pages/beta/model/[modelId]/access/new.tsx
@@ -1,0 +1,73 @@
+import ArrowBack from '@mui/icons-material/ArrowBack'
+import { Box, Button, Card, Stack } from '@mui/material'
+import { useRouter } from 'next/router'
+import { useEffect, useState } from 'react'
+
+import { useGetModel } from '../../../../../actions/model'
+import { useGetSchema } from '../../../../../actions/schema'
+import Loading from '../../../../../src/common/Loading'
+import ModelCardForm from '../../../../../src/Form/beta/ModelCardForm'
+import MessageAlert from '../../../../../src/MessageAlert'
+import Wrapper from '../../../../../src/Wrapper.beta'
+import { Styling } from '../../../../../types/enums'
+import { SplitSchemaNoRender } from '../../../../../types/interfaces'
+import { getStepsFromSchema } from '../../../../../utils/beta/formUtils'
+
+export default function NewAccessRequest() {
+  const router = useRouter()
+  const { modelId }: { modelId?: string } = router.query
+  const { model, isModelLoading, isModelError } = useGetModel(modelId)
+  // TODO - populate the accessRequestSettings property
+  const { schema, isSchemaLoading, isSchemaError } = useGetSchema(
+    model?.accessRequestSettings?.schemaId || 'minimal-access-request-general-v10-beta'
+  )
+
+  const [splitSchema, setSplitSchema] = useState<SplitSchemaNoRender>({ reference: '', steps: [] })
+
+  useEffect(() => {
+    if (!model || !schema) return
+    const metadata = model.card.metadata
+    const steps = getStepsFromSchema(schema, {}, ['properties.contacts'], metadata)
+
+    for (const step of steps) {
+      step.steps = steps
+    }
+
+    setSplitSchema({ reference: schema.id, steps })
+  }, [schema, model])
+
+  function onSubmit() {
+    console.log()
+  }
+
+  if (isSchemaError) {
+    return <MessageAlert message={isSchemaError.info.message} severity='error' />
+  }
+
+  if (isModelError) {
+    return <MessageAlert message={isModelError.info.message} severity='error' />
+  }
+
+  return (
+    <Wrapper title='Access Request' page='Model'>
+      {(isSchemaLoading || isModelLoading) && <Loading />}
+      <Card sx={{ maxWidth: Styling.NARROW_WIDTH, mx: 'auto', my: 4, p: 4 }}>
+        <Stack spacing={4}>
+          <Button
+            sx={{ width: 'fit-content' }}
+            startIcon={<ArrowBack />}
+            onClick={() => router.push(`/beta/model/${modelId}`)}
+          >
+            Back to model
+          </Button>
+          <ModelCardForm splitSchema={splitSchema} setSplitSchema={setSplitSchema} canEdit />
+          <Box sx={{ textAlign: 'right' }}>
+            <Button sx={{ width: 'fit-content' }} variant='contained' onClick={onSubmit}>
+              Submit
+            </Button>
+          </Box>
+        </Stack>
+      </Card>
+    </Wrapper>
+  )
+}

--- a/frontend/pages/beta/model/[modelId]/access/new.tsx
+++ b/frontend/pages/beta/model/[modelId]/access/new.tsx
@@ -52,28 +52,30 @@ export default function NewAccessRequest() {
   return (
     <Wrapper title='Access Request' page='Model'>
       {(isSchemaLoading || isModelLoading) && <Loading />}
-      <Card sx={{ mx: 'auto', my: 4, p: 4 }}>
-        {(!model || !model.card) && (
-          <Typography>Access requests can not be requested if a schema is not set for this model.</Typography>
-        )}
-        {model && model.card && (
-          <Stack spacing={4}>
-            <Button
-              sx={{ width: 'fit-content' }}
-              startIcon={<ArrowBack />}
-              onClick={() => router.push(`/beta/model/${modelId}`)}
-            >
-              Back to model
-            </Button>
-            <ModelCardForm splitSchema={splitSchema} setSplitSchema={setSplitSchema} canEdit displayLabelValidation />
-            <Box sx={{ textAlign: 'right' }}>
-              <Button sx={{ width: 'fit-content' }} variant='contained' onClick={onSubmit}>
-                Submit
+      {!isSchemaLoading && !isModelLoading && (
+        <Card sx={{ mx: 'auto', my: 4, p: 4 }}>
+          {(!model || !model.card) && (
+            <Typography>Access requests can not be requested if a schema is not set for this model.</Typography>
+          )}
+          {model && model.card && (
+            <Stack spacing={4}>
+              <Button
+                sx={{ width: 'fit-content' }}
+                startIcon={<ArrowBack />}
+                onClick={() => router.push(`/beta/model/${modelId}`)}
+              >
+                Back to model
               </Button>
-            </Box>
-          </Stack>
-        )}
-      </Card>
+              <ModelCardForm splitSchema={splitSchema} setSplitSchema={setSplitSchema} canEdit displayLabelValidation />
+              <Box sx={{ textAlign: 'right' }}>
+                <Button sx={{ width: 'fit-content' }} variant='contained' onClick={onSubmit}>
+                  Submit
+                </Button>
+              </Box>
+            </Stack>
+          )}
+        </Card>
+      )}
     </Wrapper>
   )
 }

--- a/frontend/pages/beta/model/[modelId]/access/schema.tsx
+++ b/frontend/pages/beta/model/[modelId]/access/schema.tsx
@@ -1,5 +1,5 @@
 import { Schema } from '@mui/icons-material'
-import { Button, Card, Container, Grid, Stack, Tooltip, Typography } from '@mui/material'
+import { Card, Container, Grid, Stack, Typography } from '@mui/material'
 import _ from 'lodash-es'
 import { useRouter } from 'next/router'
 import { useMemo } from 'react'
@@ -7,8 +7,10 @@ import { useMemo } from 'react'
 import { useGetSchemas } from '../../../../../actions/schema'
 import EmptyBlob from '../../../../../src/common/EmptyBlob'
 import Loading from '../../../../../src/common/Loading'
+import MessageAlert from '../../../../../src/MessageAlert'
+import SchemaButton from '../../../../../src/model/beta/common/SchemaButton'
 import Wrapper from '../../../../../src/Wrapper.beta'
-import { SchemaInterface, SchemaKind } from '../../../../../types/types'
+import { SchemaKind } from '../../../../../types/types'
 
 export default function NewSchemaSelection() {
   const router = useRouter()
@@ -18,10 +20,14 @@ export default function NewSchemaSelection() {
   const activeSchemas = useMemo(() => schemas.filter((schema) => schema.active), [schemas])
   const inactiveSchemas = useMemo(() => schemas.filter((schema) => !schema.active), [schemas])
 
+  if (isSchemasError) {
+    return <MessageAlert message={isSchemasError.info.message} severity='error' />
+  }
+
   return (
     <Wrapper title='Select a schema' page='upload'>
       {isSchemasLoading && <Loading />}
-      {schemas && !isSchemasLoading && !isSchemasError && (
+      {schemas && !isSchemasLoading && (
         <Container maxWidth='md'>
           <Card sx={{ mx: 'auto', my: 4, p: 4 }}>
             <Stack spacing={2} justifyContent='center' alignItems='center'>
@@ -60,38 +66,5 @@ export default function NewSchemaSelection() {
         </Container>
       )}
     </Wrapper>
-  )
-}
-
-interface SchemaButtonProps {
-  modelId: string
-  schema: any
-}
-
-function SchemaButton({ modelId, schema }: SchemaButtonProps) {
-  const router = useRouter()
-
-  async function createAccessRequestUsingSchema(newSchema: SchemaInterface) {
-    router.push(`/beta/model/${modelId}/access/new?schemaId=${newSchema.id}`)
-  }
-
-  return (
-    <Grid item md={4} sm={12}>
-      <Tooltip title={schema.description}>
-        <Button
-          sx={{ width: '200px', height: '60px' }}
-          variant='outlined'
-          size='large'
-          onClick={() => createAccessRequestUsingSchema(schema)}
-        >
-          <Stack sx={{ overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
-            <Typography variant='button'>{schema.name}</Typography>
-            <Typography sx={{ overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }} variant='caption'>
-              {schema.description}
-            </Typography>
-          </Stack>
-        </Button>
-      </Tooltip>
-    </Grid>
   )
 }

--- a/frontend/pages/beta/model/[modelId]/schema.tsx
+++ b/frontend/pages/beta/model/[modelId]/schema.tsx
@@ -12,6 +12,7 @@ import EmptyBlob from '../../../../src/common/EmptyBlob'
 import Loading from '../../../../src/common/Loading'
 import MessageAlert from '../../../../src/MessageAlert'
 import Wrapper from '../../../../src/Wrapper.beta'
+import { Styling } from '../../../../types/enums'
 import { SchemaInterface } from '../../../../types/types'
 
 export default function NewSchemaSelection() {
@@ -26,7 +27,7 @@ export default function NewSchemaSelection() {
     <Wrapper title='Select a schema' page='upload'>
       {isSchemasLoading && <Loading />}
       {schemas && !isSchemasLoading && !isSchemasError && (
-        <Card sx={{ maxWidth: '750px', mx: 'auto', my: 4, p: 4 }}>
+        <Card sx={{ maxWidth: Styling.NARROW_WIDTH, mx: 'auto', my: 4, p: 4 }}>
           <Stack spacing={2} justifyContent='center' alignItems='center'>
             <Typography variant='h6' color='primary'>
               Choose a schema

--- a/frontend/src/Form/beta/ModelCardForm.tsx
+++ b/frontend/src/Form/beta/ModelCardForm.tsx
@@ -1,26 +1,29 @@
-import { Divider, Stack, StepButton, StepLabel, Stepper } from '@mui/material'
+import ErrorIcon from '@mui/icons-material/ErrorOutline'
+import { Divider, Stack, StepButton, StepLabel, Stepper, Tooltip } from '@mui/material'
 import MaterialStep from '@mui/material/Step'
 import { useTheme } from '@mui/material/styles'
 import Form from '@rjsf/mui'
 import { RJSFSchema } from '@rjsf/utils'
 import validator from '@rjsf/validator-ajv8'
 import React, { Dispatch, SetStateAction, useState } from 'react'
-import CustomTextInput from 'src/MuiForms/CustomTextInput'
-import TagSelector from 'src/MuiForms/TagSelectorBeta'
-import { setStepState } from 'utils/beta/formUtils'
 
-import { SplitSchemaNoRender } from '../../../types/interfaces'
+import { SplitSchemaNoRender, StepNoRender } from '../../../types/interfaces'
+import { setStepState } from '../../../utils/beta/formUtils'
+import CustomTextInput from '../../MuiForms/CustomTextInput'
 import Nothing from '../../MuiForms/Nothing'
+import TagSelector from '../../MuiForms/TagSelectorBeta'
 
 // TODO - add validation BAI-866
 export default function ModelCardForm({
   splitSchema,
   setSplitSchema,
   canEdit = false,
+  displayLabelValidation = false,
 }: {
   splitSchema: SplitSchemaNoRender
   setSplitSchema: Dispatch<SetStateAction<SplitSchemaNoRender>>
   canEdit?: boolean
+  displayLabelValidation?: boolean
 }) {
   const [activeStep, setActiveStep] = useState(0)
 
@@ -61,25 +64,28 @@ export default function ModelCardForm({
         >
           {splitSchema.steps.map((step, index) => (
             <MaterialStep key={step.schema.title}>
-              <StepButton sx={{ p: 0, m: 0 }} onClick={() => setActiveStep(index)} icon={<Nothing />}>
-                <StepLabel
-                  sx={{
-                    padding: 0,
-                    '& .MuiStepLabel-label': {
-                      fontSize: '16px',
-                    },
-                    '& .MuiStepLabel-label.Mui-active': {
-                      color: `${theme.palette.primary.main}`,
-                    },
-                    '& .Mui-active': {
-                      borderBottomStyle: 'solid',
-                      borderColor: `${theme.palette.secondary.main}`,
-                    },
-                  }}
-                >
-                  {step.schema.title}
-                </StepLabel>
-              </StepButton>
+              <Stack direction='row' spacing={2} justifyContent='center' alignItems='center'>
+                <StepButton sx={{ p: 0, m: 0 }} onClick={() => setActiveStep(index)} icon={<Nothing />}>
+                  <StepLabel
+                    sx={{
+                      padding: 0,
+                      '& .MuiStepLabel-label': {
+                        fontSize: '16px',
+                      },
+                      '& .MuiStepLabel-label.Mui-active': {
+                        color: `${theme.palette.primary.main}`,
+                      },
+                      '& .Mui-active': {
+                        borderBottomStyle: 'solid',
+                        borderColor: `${theme.palette.secondary.main}`,
+                      },
+                    }}
+                  >
+                    {step.schema.title}
+                  </StepLabel>
+                </StepButton>
+                <ValidationErrorIcon displayLabelValidation={displayLabelValidation} step={step} />
+              </Stack>
             </MaterialStep>
           ))}
         </Stepper>
@@ -90,7 +96,6 @@ export default function ModelCardForm({
         formData={currentStep.state}
         onChange={onFormChange}
         validator={validator}
-        noValidate
         widgets={{
           nothing: Nothing,
           customTextInput: CustomTextInput,
@@ -114,5 +119,20 @@ export default function ModelCardForm({
         <></>
       </Form>
     </Stack>
+  )
+}
+
+interface ValidationErrorIconProps {
+  displayLabelValidation: boolean
+  step: StepNoRender
+}
+
+function ValidationErrorIcon({ displayLabelValidation, step }: ValidationErrorIconProps) {
+  return displayLabelValidation && !step.isComplete(step) ? (
+    <Tooltip title='This step is unfinished'>
+      <ErrorIcon sx={{ color: 'red' }} />
+    </Tooltip>
+  ) : (
+    <></>
   )
 }

--- a/frontend/src/Form/beta/ModelCardForm.tsx
+++ b/frontend/src/Form/beta/ModelCardForm.tsx
@@ -1,12 +1,12 @@
-import ErrorIcon from '@mui/icons-material/ErrorOutline'
-import { Divider, List, ListItem, ListItemButton, Stack, Stepper, Tooltip, Typography } from '@mui/material'
+import { Divider, List, ListItem, ListItemButton, Stack, Stepper, Typography } from '@mui/material'
 import Form from '@rjsf/mui'
 import { RJSFSchema } from '@rjsf/utils'
 import validator from '@rjsf/validator-ajv8'
 import React, { Dispatch, SetStateAction, useState } from 'react'
 
-import { SplitSchemaNoRender, StepNoRender } from '../../../types/interfaces'
+import { SplitSchemaNoRender } from '../../../types/interfaces'
 import { setStepState } from '../../../utils/beta/formUtils'
+import ValidationErrorIcon from '../../model/beta/common/ValidationErrorIcon'
 import CustomTextInput from '../../MuiForms/CustomTextInput'
 import Nothing from '../../MuiForms/Nothing'
 import TagSelector from '../../MuiForms/TagSelectorBeta'
@@ -64,7 +64,7 @@ export default function ModelCardForm({
                 <ListItemButton selected={activeStep === index} onClick={() => setActiveStep(index)}>
                   <Stack direction='row' spacing={2}>
                     <Typography>{step.schema.title}</Typography>
-                    <ValidationErrorIcon displayLabelValidation={displayLabelValidation} step={step} />
+                    {displayLabelValidation && <ValidationErrorIcon step={step} />}
                   </Stack>
                 </ListItemButton>
               </ListItem>
@@ -101,20 +101,5 @@ export default function ModelCardForm({
         <></>
       </Form>
     </Stack>
-  )
-}
-
-interface ValidationErrorIconProps {
-  displayLabelValidation: boolean
-  step: StepNoRender
-}
-
-function ValidationErrorIcon({ displayLabelValidation, step }: ValidationErrorIconProps) {
-  return displayLabelValidation && !step.isComplete(step) ? (
-    <Tooltip title='This step is unfinished'>
-      <ErrorIcon sx={{ color: 'red' }} />
-    </Tooltip>
-  ) : (
-    <></>
   )
 }

--- a/frontend/src/common/PageWithTabs.tsx
+++ b/frontend/src/common/PageWithTabs.tsx
@@ -1,4 +1,4 @@
-import { Box, Button, Stack, Tab, Tabs, Typography } from '@mui/material'
+import { Box, Button, Divider, Stack, Tab, Tabs, Typography } from '@mui/material'
 import { grey } from '@mui/material/colors/'
 import { useTheme } from '@mui/material/styles'
 import { ReactElement, useState } from 'react'
@@ -30,7 +30,13 @@ export default function PageWithTabs({
   return (
     <>
       <Box>
-        <Stack direction='row' justifyContent='space-between' alignItems='center' spacing={2} sx={{ p: 2 }}>
+        <Stack
+          direction='row'
+          divider={<Divider flexItem orientation='vertical' />}
+          alignItems='center'
+          spacing={2}
+          sx={{ p: 2 }}
+        >
           <Typography component='h1' color='primary' variant='h6'>
             {title}
           </Typography>

--- a/frontend/src/model/beta/Settings.tsx
+++ b/frontend/src/model/beta/Settings.tsx
@@ -2,9 +2,10 @@ import { Box, Button, Divider, List, ListItem, ListItemButton, Stack } from '@mu
 import { useState } from 'react'
 
 import { ModelInterface } from '../../../types/v2/types'
+import AccessRequestSettings from './settings/AccessRequestSettings'
 import ModelAccess from './settings/ModelAccess'
 
-type SettingsCategory = 'general' | 'danger'
+type SettingsCategory = 'general' | 'danger' | 'access'
 
 type SettingsProps = {
   model: ModelInterface
@@ -24,6 +25,11 @@ export default function Settings({ model }: SettingsProps) {
             General Settings
           </ListItemButton>
         </ListItem>
+        <ListItem>
+          <ListItemButton selected={selectedCategory === 'access'} onClick={() => handleListItemClick('access')}>
+            Access Requests
+          </ListItemButton>
+        </ListItem>
         <ListItem disablePadding>
           <ListItemButton selected={selectedCategory === 'danger'} onClick={() => handleListItemClick('danger')}>
             Danger Zone
@@ -32,6 +38,7 @@ export default function Settings({ model }: SettingsProps) {
       </List>
       <Box sx={{ width: '100%', maxWidth: '1000px' }}>
         {selectedCategory === 'general' && <ModelAccess model={model} />}
+        {selectedCategory === 'access' && <AccessRequestSettings model={model} />}
         {selectedCategory === 'danger' && (
           <Button variant='contained' disabled>
             Delete model

--- a/frontend/src/model/beta/common/SchemaButton.tsx
+++ b/frontend/src/model/beta/common/SchemaButton.tsx
@@ -1,0 +1,37 @@
+import { Button, Grid, Stack, Tooltip, Typography } from '@mui/material'
+import { useRouter } from 'next/router'
+
+import { SchemaInterface } from '../../../../types/types'
+
+interface SchemaButtonProps {
+  modelId: string
+  schema: any
+}
+
+export default function SchemaButton({ modelId, schema }: SchemaButtonProps) {
+  const router = useRouter()
+
+  async function createAccessRequestUsingSchema(newSchema: SchemaInterface) {
+    router.push(`/beta/model/${modelId}/access/new?schemaId=${newSchema.id}`)
+  }
+
+  return (
+    <Grid item md={4} sm={12}>
+      <Tooltip title={schema.description}>
+        <Button
+          sx={{ width: '200px', height: '60px' }}
+          variant='outlined'
+          size='large'
+          onClick={() => createAccessRequestUsingSchema(schema)}
+        >
+          <Stack sx={{ overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
+            <Typography variant='button'>{schema.name}</Typography>
+            <Typography sx={{ overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }} variant='caption'>
+              {schema.description}
+            </Typography>
+          </Stack>
+        </Button>
+      </Tooltip>
+    </Grid>
+  )
+}

--- a/frontend/src/model/beta/common/ValidationErrorIcon.tsx
+++ b/frontend/src/model/beta/common/ValidationErrorIcon.tsx
@@ -1,0 +1,17 @@
+import ErrorIcon from '@mui/icons-material/ErrorOutline'
+import { Tooltip } from '@mui/material'
+
+import { StepNoRender } from '../../../../types/interfaces'
+
+interface ValidationErrorIconProps {
+  step: StepNoRender
+}
+export default function ValidationErrorIcon({ step }: ValidationErrorIconProps) {
+  return !step.isComplete(step) ? (
+    <Tooltip title='This step is unfinished'>
+      <ErrorIcon sx={{ color: 'red' }} />
+    </Tooltip>
+  ) : (
+    <></>
+  )
+}

--- a/frontend/src/model/beta/settings/AccessRequestSettings.tsx
+++ b/frontend/src/model/beta/settings/AccessRequestSettings.tsx
@@ -1,0 +1,68 @@
+import { Autocomplete, Stack, TextField, Typography } from '@mui/material'
+import { useState } from 'react'
+
+import { useGetSchemas } from '../../../../actions/schema'
+import { SchemaInterface } from '../../../../types/types'
+import { ModelInterface } from '../../../../types/v2/types'
+import Loading from '../../../common/Loading'
+import MessageAlert from '../../../MessageAlert'
+
+interface AccessRequestSettingsProps {
+  model: ModelInterface
+}
+
+export default function AccessRequestSettings({ model }: AccessRequestSettingsProps) {
+  const { schemas, isSchemasLoading, isSchemasError } = useGetSchemas()
+
+  const [value, setValue] = useState<SchemaInterface>()
+  const [open, setOpen] = useState(false)
+
+  if (isSchemasError) {
+    return <MessageAlert message={isSchemasError.info.message} severity='error' />
+  }
+
+  return (
+    <>
+      {isSchemasLoading && <Loading />}
+      <Stack spacing={2}>
+        <Typography variant='h6' component='h2'>
+          Manage access requests
+        </Typography>
+        <Autocomplete
+          open={open}
+          value={value}
+          onOpen={() => {
+            setOpen(true)
+          }}
+          onClose={() => {
+            setOpen(false)
+          }}
+          // we might get a string or an object back
+          isOptionEqualToValue={(option: SchemaInterface, value: SchemaInterface) => option.id === value.id}
+          onChange={(_event: any, newValue: SchemaInterface | null) => {
+            if (newValue) {
+              setValue(newValue)
+            }
+          }}
+          getOptionLabel={(option) => option.name}
+          options={schemas}
+          renderInput={(params) => (
+            <TextField
+              {...params}
+              label='Select which schema model access requests should use'
+              InputProps={{
+                ...params.InputProps,
+                endAdornment: (
+                  <>
+                    {isSchemasLoading && <Loading size={20} />}
+                    {params.InputProps.endAdornment}
+                  </>
+                ),
+              }}
+            />
+          )}
+        />
+      </Stack>
+    </>
+  )
+}

--- a/frontend/src/model/beta/settings/AccessRequestSettings.tsx
+++ b/frontend/src/model/beta/settings/AccessRequestSettings.tsx
@@ -1,4 +1,4 @@
-import { Box, Button, Checkbox, Stack, Typography } from '@mui/material'
+import { Button, Checkbox, Stack, Typography } from '@mui/material'
 import { useState } from 'react'
 
 export default function AccessRequestSettings() {
@@ -13,9 +13,9 @@ export default function AccessRequestSettings() {
         <Checkbox onChange={(event) => setAllowUngoverned(event.target.checked)} value={allowUngoverned} size='small' />
         <Typography>Allow users to make ungoverned access requests</Typography>
       </Stack>
-      <Box>
+      <div>
         <Button>Save</Button>
-      </Box>
+      </div>
     </Stack>
   )
 }

--- a/frontend/src/model/beta/settings/ModelAccess.tsx
+++ b/frontend/src/model/beta/settings/ModelAccess.tsx
@@ -131,11 +131,11 @@ export default function ModelAccess({ model }: ModelAccessProps) {
               </TableBody>
             </Table>
           </Box>
-          <Box>
+          <div>
             <Button aria-label='Save access list' onClick={updateAccessList}>
               Save
             </Button>
-          </Box>
+          </div>
         </Stack>
       )}
     </>

--- a/frontend/types/enums.ts
+++ b/frontend/types/enums.ts
@@ -1,0 +1,3 @@
+export enum Styling {
+  NARROW_WIDTH = '750px',
+}

--- a/frontend/types/v2/types.ts
+++ b/frontend/types/v2/types.ts
@@ -8,11 +8,16 @@ export const ModelVisibility = {
 
 export type ModelVisibilityKeys = (typeof ModelVisibility)[keyof typeof ModelVisibility]
 
+export interface AccessRequestSettings {
+  schemaId: string
+}
+
 export interface ModelInterface {
   id: string
   name: string
   description: string
   card: ModelCardInterface
+  accessRequestSettings?: AccessRequestSettings
   visibility: ModelVisibilityKeys
   collaborators: CollaboratorEntry[]
 }

--- a/frontend/types/v2/types.ts
+++ b/frontend/types/v2/types.ts
@@ -8,16 +8,11 @@ export const ModelVisibility = {
 
 export type ModelVisibilityKeys = (typeof ModelVisibility)[keyof typeof ModelVisibility]
 
-export interface AccessRequestSettings {
-  schemaId: string
-}
-
 export interface ModelInterface {
   id: string
   name: string
   description: string
   card: ModelCardInterface
-  accessRequestSettings?: AccessRequestSettings
   visibility: ModelVisibilityKeys
   collaborators: CollaboratorEntry[]
 }

--- a/frontend/utils/uiSchemaUtils.ts
+++ b/frontend/utils/uiSchemaUtils.ts
@@ -24,5 +24,9 @@ export function createBaseSchema(schema: any) {
     }
   }
 
+  if (schema.type === 'boolean') {
+    uiSchema['ui:widget'] = 'radio'
+  }
+
   return uiSchema
 }


### PR DESCRIPTION
Changed living doc step labels to be consistent:

![image](https://github.com/gchq/Bailo/assets/89992537/9c0146e1-c673-43db-a81c-ab58e06a727a)

Added a "Request access" button:

![image](https://github.com/gchq/Bailo/assets/89992537/2878d6b5-a145-4c51-a0a7-541a52df0994)

This loads a select schema page (this could very easily change in the future!:

![image](https://github.com/gchq/Bailo/assets/89992537/4ee23545-3a11-4fa9-9aba-015348ba6ccb)

Added a form page for making an access request:

![image](https://github.com/gchq/Bailo/assets/89992537/fed18174-efc8-4e3b-985d-80597e25b69f)

This also has validation:

![image](https://github.com/gchq/Bailo/assets/89992537/8017da7f-8c54-4e0d-8954-0d44a395a946)
