### PR TITLE
Implemented URL validation on client initialisation & renamed methods to better align with HTTP requests

### DIFF
--- a/lib/python-beta/pyproject.toml
+++ b/lib/python-beta/pyproject.toml
@@ -19,6 +19,9 @@ classifiers = [
 ]
 requires-python = ">=3.8.1"
 dynamic = ["version"]
+dependencies = [
+    "validators==0.22.0"
+]
 
 [project.optional-dependencies]
 test = [

--- a/lib/python-beta/src/bailo/bailo.py
+++ b/lib/python-beta/src/bailo/bailo.py
@@ -1,6 +1,7 @@
 """Main entry point"""
 from __future__ import annotations
 import requests
+import validators
 from typing import List, Optional, Dict, Any
 from .enums import ModelVisibility, SchemaKind
 
@@ -20,6 +21,8 @@ class PkiAgent(Agent):
 
 class BailoClient():
     def __init__(self, url: str, agent: Agent = Agent()):
+        if not validators.url(url):
+            raise ValueError("URL not valid.")
         self.url = url.rstrip("/") + "/api"
         self.agent = agent
 

--- a/lib/python-beta/src/bailo/bailo.py
+++ b/lib/python-beta/src/bailo/bailo.py
@@ -26,7 +26,7 @@ class BailoClient():
         self.url = url.rstrip("/") + "/api"
         self.agent = agent
 
-    def create_model(
+    def post_model(
             self,
             name: str,
             description: str,
@@ -49,7 +49,7 @@ class BailoClient():
             },
         ).json()
 
-    def find_models(
+    def get_models(
         self,
         task: Optional[str] = None,
         libraries: List[str] = [],
@@ -89,7 +89,7 @@ class BailoClient():
             f"{self.url}/v2/model/{model_id}",
         ).json()
 
-    def update_model(
+    def patch_model(
         self,
         model_id: str,
         name: Optional[str] = None,
@@ -137,7 +137,7 @@ class BailoClient():
             f"{self.url}/v2/model/{model_id}/model-card/{version}",
         ).json()
 
-    def update_model_card(
+    def put_model_card(
         self,
         model_id: str,
         metadata: Any,
@@ -175,7 +175,7 @@ class BailoClient():
             },
         ).json()
     
-    def create_release(
+    def post_release(
         self,
         model_id: str,
         model_card_version: float,
@@ -345,7 +345,7 @@ class BailoClient():
         ).json()
 
 
-    def create_schema(
+    def post_schema(
         self,
         schema_id: str,
         name: str,
@@ -403,7 +403,7 @@ class BailoClient():
             f"{self.url}/v2/model/{model_id}/roles/mine",
         ).json()
     
-    def create_team(
+    def post_team(
         self,
         team_id: str,
         name: str,
@@ -464,7 +464,7 @@ class BailoClient():
             f"{self.url}/v2/team/{team_id}",
         ).json()
 
-    def update_team(
+    def patch_team(
         self,
         team_id: str,
         name: Optional[str] = None,

--- a/lib/python-beta/tests/test_client.py
+++ b/lib/python-beta/tests/test_client.py
@@ -12,11 +12,11 @@ from bailo.enums import ModelVisibility, SchemaKind
 mock_result = {"success": True}
 
 
-def test_create_model(requests_mock):
+def test_post_model(requests_mock):
     requests_mock.post("https://example.com/api/v2/models", json={"success": True})
 
     client = BailoClient("https://example.com")
-    result = client.create_model(
+    result = client.post_model(
         name="test",
         description="test",
         visibility=ModelVisibility.Public
@@ -25,11 +25,11 @@ def test_create_model(requests_mock):
     assert result == {"success": True}
 
 
-def test_find_models(requests_mock):
+def test_get_models(requests_mock):
     requests_mock.get("https://example.com/api/v2/models/search?task=image_classification", json={"success": True})
 
     client = BailoClient("https://example.com")
-    result = client.find_models(
+    result = client.get_models(
         task="image_classification"
     )
 
@@ -47,11 +47,11 @@ def test_get_model(requests_mock):
     assert result == {"success": True}
 
 
-def test_update_model(requests_mock):
+def test_patch_model(requests_mock):
     requests_mock.patch("https://example.com/api/v2/model/test_id", json={"success": True})
 
     client = BailoClient("https://example.com")
-    result = client.update_model(
+    result = client.patch_model(
         model_id="test_id",
         name="test",
     )
@@ -70,14 +70,14 @@ def test_get_model_card(requests_mock):
     assert result == {"success": True}
 
 
-def test_update_model_card(requests_mock):
+def test_put_model_card(requests_mock):
     requests_mock.put("https://example.com/api/v2/model/test_id/model-cards", json={"success": True})
 
     x = {"test" : "object"}
     y = json.dumps(x)
 
     client = BailoClient("https://example.com")
-    result = client.update_model_card(
+    result = client.put_model_card(
         model_id="test_id", metadata=y
     )
 
@@ -95,11 +95,11 @@ def test_model_card_from_schema(requests_mock):
     assert result == {"success": True}
 
 
-def test_create_release(requests_mock):
+def test_post_release(requests_mock):
     requests_mock.post("https://example.com/api/v2/model/test_id/releases", json={"success": True})
 
     client = BailoClient("https://example.com")
-    result = client.create_release(
+    result = client.post_release(
         model_id="test_id", 
         model_card_version=1, 
         release_version='v1',
@@ -206,11 +206,11 @@ def test_get_schema(requests_mock):
 
     assert result == {"success": True}
 
-def test_create_schema(requests_mock):
+def test_post_schema(requests_mock):
     requests_mock.post("https://example.com/api/v2/schemas", json={"success": True})
 
     client = BailoClient("https://example.com")
-    result = client.create_schema(
+    result = client.post_schema(
         schema_id="test_id",
         name="test",
         kind=SchemaKind.Model,
@@ -243,11 +243,11 @@ def test_get_model_user_roles(requests_mock):
 
     assert result == {"success": True}
 
-def test_create_team(requests_mock):
+def test_post_team(requests_mock):
     requests_mock.post("https://example.com/api/v2/teams", json={"success": True})
 
     client = BailoClient("https://example.com")
-    result = client.create_team(
+    result = client.post_team(
         team_id="test_id",
         name="test",
         description="test",
@@ -281,11 +281,11 @@ def test_get_team(requests_mock):
 
     assert result == {"success": True}
 
-def test_update_team(requests_mock):
+def test_patch_team(requests_mock):
     requests_mock.patch("https://example.com/api/v2/team/test_id", json={"success": True})
 
     client = BailoClient("https://example.com")
-    result = client.update_team(
+    result = client.patch_team(
         team_id="test_id",
         name="name",
     )


### PR DESCRIPTION
As discussed in ticket: [BAI-884](https://jira.tdx.gss.gov.uk/browse/BAI-884) and [BAI-902](https://jira.tdx.gss.gov.uk/browse/BAI-902)

- Using the validators library for URL validation.
- Renamed 'update' methods to 'patch' or 'put'. Renamed find_models to get_models.