### PR TITLE
added file uploads to post releases

### DIFF
--- a/frontend/actions/release.ts
+++ b/frontend/actions/release.ts
@@ -26,3 +26,11 @@ export async function postRelease(release: Partial<ReleaseInterface>, modelId: s
     body: JSON.stringify(release),
   })
 }
+
+export async function postArtefact(artefact: File, modelId: string, name: string, mime: string) {
+  return fetch(`/api/v2/model/${modelId}/files/upload/simple?name=${name}&mine=${mime}`, {
+    method: 'post',
+    headers: { 'Content-Type': 'application/json' },
+    body: artefact,
+  })
+}

--- a/frontend/actions/release.ts
+++ b/frontend/actions/release.ts
@@ -27,8 +27,8 @@ export async function postRelease(release: Partial<ReleaseInterface>, modelId: s
   })
 }
 
-export async function postArtefact(artefact: File, modelId: string, name: string, mime: string) {
-  return fetch(`/api/v2/model/${modelId}/files/upload/simple?name=${name}&mine=${mime}`, {
+export async function postFile(artefact: File, modelId: string, name: string, mime: string) {
+  return fetch(`/api/v2/model/${modelId}/files/uploadss/simple?name=${name}&mine=${mime}`, {
     method: 'post',
     headers: { 'Content-Type': 'application/json' },
     body: artefact,

--- a/frontend/src/model/beta/releases/DraftNewReleaseDialog.tsx
+++ b/frontend/src/model/beta/releases/DraftNewReleaseDialog.tsx
@@ -17,9 +17,9 @@ import {
 import { FormEvent, useState } from 'react'
 import semver from 'semver'
 
-import { postArtefact, postRelease } from '../../../../actions/release'
+import { postFile, postRelease } from '../../../../actions/release'
 import { ReleaseInterface } from '../../../../types/types'
-import { ModelInterface, PostSimpleUpload } from '../../../../types/v2/types'
+import { ModelInterface } from '../../../../types/v2/types'
 import { getErrorMessage } from '../../../../utils/fetcher'
 import HelpPopover from '../../../common/HelpPopover'
 import MultiFileInput from '../../../common/MultiFileInput'
@@ -57,11 +57,15 @@ export default function DraftNewReleaseDialog({
     if (isValidSemver(semanticVersion)) {
       const fileIds: string[] = []
       for (const artefact of artefacts) {
-        const postArtefactResponse = await postArtefact(artefact, model.id, artefact.name, artefact.type)
-        if (postArtefactResponse.status === 200) {
-          await postArtefactResponse.json().then((res: PostSimpleUpload) => {
-            fileIds.push(res.file._id)
-          })
+        const postArtefactResponse = await postFile(artefact, model.id, artefact.name, artefact.type)
+        if (postArtefactResponse.ok) {
+          const res = await postArtefactResponse.json()
+          fileIds.push(res.file._id)
+        } else {
+          setLoading(false)
+          return setErrorMessage(
+            `Status code ${postArtefactResponse.status}. There was a problem uploading your files, please try again.`,
+          )
         }
       }
 

--- a/frontend/src/model/beta/releases/DraftNewReleaseDialog.tsx
+++ b/frontend/src/model/beta/releases/DraftNewReleaseDialog.tsx
@@ -63,9 +63,7 @@ export default function DraftNewReleaseDialog({
           fileIds.push(res.file._id)
         } else {
           setLoading(false)
-          return setErrorMessage(
-            `Status code ${postArtefactResponse.status}. There was a problem uploading your files, please try again.`,
-          )
+          return setErrorMessage(await getErrorMessage(postArtefactResponse))
         }
       }
 

--- a/frontend/types/v2/types.ts
+++ b/frontend/types/v2/types.ts
@@ -49,3 +49,24 @@ export const SchemaKind = {
 } as const
 
 export type SchemaKindKeys = (typeof SchemaKind)[keyof typeof SchemaKind]
+
+export interface FileInterface {
+  _id: string
+  modelId: string
+
+  name: string
+  size: number
+  mime: string
+
+  bucket: string
+  path: string
+
+  complete: boolean
+
+  createdAt: Date
+  updatedAt: Date
+}
+
+export interface PostSimpleUpload {
+  file: FileInterface
+}


### PR DESCRIPTION
Files can now be uploaded as part of a release. The files are individually uploaded, and the `id` of each is added to the release model.

Currently we are just displaying those `id`s on the release display, but in the future we will expand on this.

![image](https://github.com/gchq/Bailo/assets/89992537/a44ac995-cbbf-4fe2-84e6-3d4da8f4b4de)
