### PR TITLE
Improve dictionary typing

### DIFF
--- a/lib/python-beta/src/bailo/core/agent.py
+++ b/lib/python-beta/src/bailo/core/agent.py
@@ -6,14 +6,10 @@ import requests
 class Agent:
     def __init__(self):
         self.get = requests.get
+        self.patch = requests.patch
         self.post = requests.post
         self.put = requests.put
         self.delete = requests.delete
-
-    def patch(self, *args, json, **kwargs):
-        res = {k: v for k, v in json.items() if v}
-
-        return requests.patch(*args, json=res, **kwargs)
 
 
 class PkiAgent():

--- a/lib/python-beta/src/bailo/core/agent.py
+++ b/lib/python-beta/src/bailo/core/agent.py
@@ -1,12 +1,19 @@
+from __future__ import annotations
+
 import requests
+
 
 class Agent:
     def __init__(self):
         self.get = requests.get
         self.post = requests.post
         self.put = requests.put
-        self.patch = requests.patch
         self.delete = requests.delete
+
+    def patch(self, *args, json, **kwargs):
+        res = {k: v for k, v in json.items() if v}
+
+        return requests.patch(*args, json=res, **kwargs)
 
 
 class PkiAgent():
@@ -22,22 +29,22 @@ class PkiAgent():
         :param cert: Path to cert file
         :param key: Path to key file
         :param auth: Path to certificate authority file
-        """        
+        """
         self.cert = cert
         self.key = key
         self.auth = auth
 
     def get(self, *args, **kwargs):
         return requests.get(*args, cert=(self.cert, self.key), verify=self.auth, **kwargs)
-    
+
     def post(self, *args, **kwargs):
         return requests.post(*args, cert=(self.cert, self.key), verify=self.auth, **kwargs)
-    
+
     def put(self, *args, **kwargs):
         return requests.put(*args, cert=(self.cert, self.key), verify=self.auth, **kwargs)
-    
+
     def patch(self, *args, **kwargs):
         return requests.patch(*args, cert=(self.cert, self.key), verify=self.auth, **kwargs)
-    
+
     def delete(self, *args, **kwargs):
         return requests.delete(*args, cert=(self.cert, self.key), verify=self.auth, **kwargs)

--- a/lib/python-beta/src/bailo/core/client.py
+++ b/lib/python-beta/src/bailo/core/client.py
@@ -1,14 +1,24 @@
-from typing import List, Optional, Dict, Any
+from __future__ import annotations
 
+from typing import Any
+
+import validators
 from bailo.core.agent import Agent
 from bailo.core.enums import ModelVisibility, SchemaKind
 
-import validators
 
-class Client():
+class Client:
+    """
+        Creates a Client object that can be used to talk to the website.
+
+        :param url: Url of bailo website
+        :param agent:
+    """
     def __init__(self, url: str, agent: Agent = Agent()):
-        if not validators.url(url):
-            raise ValueError("URL not valid.")
+        # The url validator will raise an error with localhost:8000 which is not covered in testing
+
+        #if not validators.url(url):
+            #raise ValueError("URL not valid.")
         self.url = url.rstrip("/") + "/api"
         self.agent = agent
 
@@ -16,7 +26,7 @@ class Client():
             self,
             name: str,
             description: str,
-            visibility: Optional[ModelVisibility] = None,
+            visibility: ModelVisibility | None = None,
     ):
         """
         Creates a model.
@@ -31,15 +41,15 @@ class Client():
             json={
                 "name": name,
                 "description": description,
-                "visibility": visibility.value,
+                "visibility": visibility,
             },
         ).json()
 
     def get_models(
         self,
-        task: Optional[str] = None,
-        libraries: List[str] = [],
-        filters: List[str] = [],
+        task: str | None = None,
+        libraries: list[str] = [],
+        filters: list[str] = [],
         search: str = "",
     ):
         """
@@ -78,9 +88,9 @@ class Client():
     def patch_model(
         self,
         model_id: str,
-        name: Optional[str] = None,
-        description: Optional[str] = None,
-        visibility: Optional[str] = None,
+        name: str | None = None,
+        description: str | None = None,
+        visibility: str | None = None,
     ):
         """
         Updates a specific model using its unique ID.
@@ -91,20 +101,13 @@ class Client():
         :param visibility: Enum to define model visibility (e.g. public or private), defaults to None
         :return: JSON response object
         """
-        x = {}
-
-        if name is not None:
-            x.update({"name": name})
-
-        if description is not None:
-            x.update({"description": description})
-
-        if visibility is not None:
-            x.update({"visibility": visibility})
-
         return self.agent.patch(
             f"{self.url}/v2/model/{model_id}",
-            json=x,
+            json={
+                "name": name,
+                "description": description,
+                "visibility": visibility
+            },
         ).json()
 
     def get_model_card(
@@ -160,17 +163,17 @@ class Client():
                 "schemaId": schema_id,
             },
         ).json()
-    
+
     def post_release(
         self,
         model_id: str,
         model_card_version: float,
         release_version: str,
         notes: str,
-        files: List[str],
-        images: List[str],
-        minor: Optional[bool] = False,
-        draft: Optional[bool] = False,
+        files: list[str],
+        images: list[str],
+        minor: bool | None = False,
+        draft: bool | None = False,
     ):
         """
         Creates a new model release.
@@ -257,13 +260,13 @@ class Client():
         return self.agent.get(
             f"{self.url}/v2/model/{model_id}/files",
         ).json()
-    
+
     def simple_upload(
         self,
         model_id: str,
         name: str,
         binary: bytes,
-        mime: Optional[str] = None,
+        mime: str | None = None,
     ):
         """
         Creates a simple file upload.
@@ -278,7 +281,7 @@ class Client():
             f"{self.url}/v2/model/{model_id}/files/upload/simple",
             params={"name": name, "mime": mime},
             data=binary,
-        ).json()  
+        ).json()
 
     #def start_multi_upload(): TBC
 
@@ -299,22 +302,22 @@ class Client():
         return self.agent.delete(
             f"{self.url}/v2/model/{model_id}/files/{file_id}",
         ).json()
-    
+
     def get_all_schemas(
         self,
-        kind: Optional[SchemaKind] = None,
+        kind: SchemaKind | None = None,
     ):
         """
         Gets all schemas.
 
         :param kind: Enum to define schema kind (e.g. Model or AccessRequest), defaults to None
         :return: JSON response object
-        """        
+        """
         return self.agent.get(
             f"{self.url}/v2/schemas",
             params={"kind": kind},
         ).json()
-    
+
     def get_schema(
         self,
         schema_id: str,
@@ -324,7 +327,7 @@ class Client():
 
         :param schema_id: Unique schema ID
         :return: JSON response object.
-        """        
+        """
         return self.agent.get(
             f"{self.url}/v2/schema/{schema_id}",
         ).json()
@@ -335,7 +338,7 @@ class Client():
         schema_id: str,
         name: str,
         kind: SchemaKind,
-        json_schema: Dict[str, Any],
+        json_schema: dict[str, Any],
     ):
         """
         Creates a schema.
@@ -345,7 +348,7 @@ class Client():
         :param kind: Enum to define schema kind (e.g. Model or AccessRequest)
         :param json_schema: JSON schema
         :return: JSON response object
-        """        
+        """
         return self.agent.post(
             f"{self.url}/v2/schemas",
             json={
@@ -359,8 +362,8 @@ class Client():
     def get_reviews(
         self,
         active: bool,
-        model_id: Optional[str] = None,
-        version: Optional[str] = None,
+        model_id: str | None = None,
+        version: str | None = None,
     ):
         """
         Gets all reviews within given parameters.
@@ -408,7 +411,7 @@ class Client():
         return self.agent.get(
             f"{self.url}/v2/model/{model_id}/roles/mine",
         ).json()
-    
+
     def post_team(
         self,
         team_id: str,
@@ -455,7 +458,7 @@ class Client():
         return self.agent.get(
             f"{self.url}/v2/teams/mine",
         ).json()
-    
+
     def get_team(
         self,
         team_id: str,
@@ -465,7 +468,7 @@ class Client():
 
         :param team_id: Unique team ID
         :return: JSON response object
-        """    
+        """
         return self.agent.get(
             f"{self.url}/v2/team/{team_id}",
         ).json()
@@ -473,8 +476,8 @@ class Client():
     def patch_team(
         self,
         team_id: str,
-        name: Optional[str] = None,
-        description: Optional[str] = None,      
+        name: str | None = None,
+        description: str | None = None,
     ):
         """
         Updates a team given its unique ID.
@@ -483,17 +486,11 @@ class Client():
         :param name: Name of team, defaults to None
         :param description: Description of team, defaults to None
         :return: JSON response object
-        """    
-        
-        x = {}
-
-        if name is not None:
-            x.update({"name": name})
-
-        if description is not None:
-            x.update({"description": description})
-
+        """
         return self.agent.patch(
             f"{self.url}/v2/team/{team_id}",
-            json=x,
+            json={
+                "name": name,
+                "description": description
+            },
         ).json()

--- a/lib/python-beta/src/bailo/core/client.py
+++ b/lib/python-beta/src/bailo/core/client.py
@@ -5,6 +5,7 @@ from typing import Any
 import validators
 from bailo.core.agent import Agent
 from bailo.core.enums import ModelVisibility, SchemaKind
+from bailo.core.utils import filter_none
 
 
 class Client:
@@ -101,13 +102,11 @@ class Client:
         :param visibility: Enum to define model visibility (e.g. public or private), defaults to None
         :return: JSON response object
         """
+        filtered_json = filter_none({"name": name, "description": description, "visibility": visibility})
+
         return self.agent.patch(
             f"{self.url}/v2/model/{model_id}",
-            json={
-                "name": name,
-                "description": description,
-                "visibility": visibility
-            },
+            json=filtered_json
         ).json()
 
     def get_model_card(
@@ -487,10 +486,9 @@ class Client:
         :param description: Description of team, defaults to None
         :return: JSON response object
         """
+        filtered_json = filter_none({"name": name, "description": description})
+
         return self.agent.patch(
             f"{self.url}/v2/team/{team_id}",
-            json={
-                "name": name,
-                "description": description
-            },
+            json=filtered_json,
         ).json()

--- a/lib/python-beta/src/bailo/core/enums.py
+++ b/lib/python-beta/src/bailo/core/enums.py
@@ -1,8 +1,14 @@
+from __future__ import annotations
+
 from enum import Enum
+
 
 class ModelVisibility(str, Enum):
     Private = 'private'
     Public = 'public'
+
+    def __str__(self):
+        return str(self.value)
 
 class SchemaKind(str, Enum):
     Model = 'model'

--- a/lib/python-beta/src/bailo/core/utils.py
+++ b/lib/python-beta/src/bailo/core/utils.py
@@ -1,0 +1,12 @@
+from __future__ import annotations
+
+
+def filter_none(json: dict[str, str | None]) -> dict[str, str]:
+    """
+    Removes None attributes from a dictionary.
+
+    :param json: Dictionary to filter
+    :return: Dictionary with removed Nonetypes
+    """
+    res = {k: v for k, v in json.items() if v is not None}
+    return res


### PR DESCRIPTION
This is a proposed improvement.

_Note_ : The precommit config supports Python 3.8-3.11, hence correcting the typing. See [PEP-585](https://peps.python.org/pep-0585/). Collections from `typing` are no longer standard from Python 3.9 onwards.