### PR TITLE
Setup Docker Compose to use replica sets

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,10 +94,10 @@ npm install
 npm run certs
 
 # This builds all the Bailo images, rerun it when you update dependencies.
-DOCKER_BUILDKIT=1 docker-compose build --parallel
+docker compose build --parallel
 
 # Then run the development instance of Bailo.
-docker-compose up -d
+docker compose up -d
 ```
 
 On first run, it may take a while (up to 30 seconds) to start up. It needs to build several hundred TypeScript modules.
@@ -169,7 +169,7 @@ invisibly by `p-mongo-queue` (`backend/utils/queues.ts`).
 
 _Issue: Sometimes Docker struggles when you add a new dependency._
 
-Fix: Run `docker-compose down --rmi all` followed by `docker-compose up --build`.
+Fix: Run `docker compose down --rmi all` followed by `docker compose up --build`.
 
 _Issue: Sometimes SWR fails to install its own binary and the project will refuse to start up (development only)_
 

--- a/docker-compose-prod.yml
+++ b/docker-compose-prod.yml
@@ -2,11 +2,17 @@ version: '3.9'
 services:
   mongo:
     image: mongo:6.0.4
-    ports:
-      - 27017:27017
+    command: [--replSet, repl-set, --bind_ip_all, --port, '27017', --quiet]
     volumes:
       - mongoVolume:/data/db
-    command: --quiet
+    ports:
+      - 27017:27017
+    healthcheck:
+      test:
+        test $$(mongosh --port 27017 --quiet --eval "try
+        {rs.initiate({_id:'repl-set',members:[{_id:0,host:\"mongo:27017\"}]})} catch(e) {rs.status().ok}") -eq 1
+      interval: 10s
+      start_period: 30s
 
   minio:
     image: minio/minio:RELEASE.2023-01-31T02-24-19Z

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,11 +2,17 @@ version: '3.9'
 services:
   mongo:
     image: mongo:6.0.4
-    ports:
-      - 27017:27017
+    command: [--replSet, repl-set, --bind_ip_all, --port, '27017', --quiet]
     volumes:
       - mongoVolume:/data/db
-    command: --quiet
+    ports:
+      - 27017:27017
+    healthcheck:
+      test:
+        test $$(mongosh --port 27017 --quiet --eval "try
+        {rs.initiate({_id:'repl-set',members:[{_id:0,host:\"mongo:27017\"}]})} catch(e) {rs.status().ok}") -eq 1
+      interval: 10s
+      start_period: 30s
 
   minio:
     image: minio/minio:RELEASE.2023-01-31T02-24-19Z


### PR DESCRIPTION
Also converts the usage of `docker-compose` to `docker compose`.  `docker-compose` was deprecated in July 2023.