### PR TITLE
Bugfix/bai 1067 add copy button to docker commands

### DIFF
--- a/frontend/src/model/beta/registry/CodeLine.tsx
+++ b/frontend/src/model/beta/registry/CodeLine.tsx
@@ -33,7 +33,7 @@ export default function CodeLine({ line, icon = <CodeIcon /> }: CodeLineProps) {
         </Stack>
       </Box>
       <Tooltip title='Copy to clipboard' arrow>
-        <IconButton onClick={() => handleButtonClick()}>
+        <IconButton onClick={() => handleButtonClick()} aria-label='Copy line to clipboard'>
           <ContentCopy />
         </IconButton>
       </Tooltip>

--- a/frontend/src/model/beta/registry/CodeLine.tsx
+++ b/frontend/src/model/beta/registry/CodeLine.tsx
@@ -33,7 +33,7 @@ export default function CodeLine({ line, icon = <CodeIcon /> }: CodeLineProps) {
         </Stack>
       </Box>
       <Tooltip title='Copy to clipboard' arrow>
-        <IconButton onClick={() => handleButtonClick()} aria-label='Copy line to clipboard'>
+        <IconButton onClick={() => handleButtonClick()} aria-label='Copy text to clipboard'>
           <ContentCopy />
         </IconButton>
       </Tooltip>

--- a/frontend/src/model/beta/registry/CodeLine.tsx
+++ b/frontend/src/model/beta/registry/CodeLine.tsx
@@ -1,5 +1,6 @@
+import { ContentCopy } from '@mui/icons-material'
 import CodeIcon from '@mui/icons-material/Code'
-import { Box, Stack, Tooltip, Typography } from '@mui/material'
+import { Box, IconButton, Stack, Tooltip, Typography } from '@mui/material'
 import { useTheme } from '@mui/material/styles'
 import { ReactElement } from 'react'
 import useNotification from 'src/common/Snackbar'
@@ -19,26 +20,23 @@ export default function CodeLine({ line, icon = <CodeIcon /> }: CodeLineProps) {
   }
 
   return (
-    <Tooltip title='Copy to clipboard' arrow>
+    <Stack direction='row'>
       <Box
-        sx={{ backgroundColor: theme.palette.container.main, p: 1, borderRadius: 2, cursor: 'pointer' }}
+        sx={{ backgroundColor: theme.palette.container.main, p: 1, borderRadius: 2, width: '100%' }}
         component='div'
         role='button'
         tabIndex={0}
-        onClick={() => {
-          handleButtonClick()
-        }}
-        onKeyDown={(e) => {
-          if (e.key === 'Enter' || e.key === 'Spacebar' || e.key === ' ') {
-            handleButtonClick()
-          }
-        }}
       >
         <Stack direction='row' spacing={2} alignItems='center'>
           {icon}
           <Typography>{line}</Typography>
         </Stack>
       </Box>
-    </Tooltip>
+      <Tooltip title='Copy to clipboard' arrow>
+        <IconButton onClick={() => handleButtonClick()}>
+          <ContentCopy />
+        </IconButton>
+      </Tooltip>
+    </Stack>
   )
 }

--- a/frontend/src/model/beta/registry/CodeLine.tsx
+++ b/frontend/src/model/beta/registry/CodeLine.tsx
@@ -20,7 +20,7 @@ export default function CodeLine({ line, icon = <CodeIcon /> }: CodeLineProps) {
   }
 
   return (
-    <Stack direction='row'>
+    <Stack direction='row' spacing={1}>
       <Box
         sx={{ backgroundColor: theme.palette.container.main, p: 1, borderRadius: 2, width: '100%' }}
         component='div'


### PR DESCRIPTION
![image](https://github.com/gchq/Bailo/assets/89992537/71fcb2a8-1230-4e67-9e4f-4cf420119ea8)

Previously, the whole code line was clickable and could be added to your clipboard, but this wasn't too helpful if you wanted to copy individually selected parts of the command. Now you are able to do both. 