### PR TITLE
added model filtering by model chip. updated prop/varialbe names in c…

### DIFF
--- a/frontend/pages/index.tsx
+++ b/frontend/pages/index.tsx
@@ -2,7 +2,6 @@ import SearchIcon from '@mui/icons-material/Search'
 import {
   Box,
   Button,
-  Chip,
   Container,
   FilledInput,
   FormControl,
@@ -129,6 +128,13 @@ function Marketplace() {
     e.preventDefault()
   }
 
+  const handleResetFilters = () => {
+    setSelectedTask('')
+    setSelectedLibraries([])
+    setFilter('')
+    router.replace('/', undefined, { shallow: true })
+  }
+
   return (
     <Container maxWidth='xl'>
       <Stack direction={{ xs: 'column', sm: 'row' }} spacing={2}>
@@ -165,8 +171,9 @@ function Marketplace() {
           <Box>
             <ChipSelector
               label='Tasks'
+              chipTooltipTitle={'Filter by task'}
               // TODO fetch all model tags
-              tags={[
+              options={[
                 'Translation',
                 'Image Classification',
                 'Summarization',
@@ -175,35 +182,39 @@ function Marketplace() {
                 'Tabular Regression',
               ]}
               expandThreshold={10}
-              selectedTags={selectedTask}
+              selectedChips={selectedTask}
               onChange={handleTaskOnChange}
               size='small'
+              ariaLabel='add task to search filter'
             />
           </Box>
           <Box>
             <ChipSelector
               label='Libraries'
+              chipTooltipTitle={'Filter by library'}
               // TODO fetch all model libraries
-              tags={['PyTorch', 'TensorFlow', 'JAX', 'Transformers', 'ONNX', 'Safetensors', 'spaCy']}
+              options={['PyTorch', 'TensorFlow', 'JAX', 'Transformers', 'ONNX', 'Safetensors', 'spaCy']}
               expandThreshold={10}
               multiple
-              selectedTags={selectedLibraries}
+              selectedChips={selectedLibraries}
               onChange={handleLibrariesOnChange}
               size='small'
+              ariaLabel='add library to search filter'
             />
           </Box>
           <Box>
             <ChipSelector
               label='Other'
               multiple
-              tags={[...searchFilterTypeLabels.map((type) => type.label)]}
+              options={[...searchFilterTypeLabels.map((type) => type.label)]}
               onChange={handleSelectedTypesOnChange}
-              selectedTags={searchFilterTypeLabels
+              selectedChips={searchFilterTypeLabels
                 .filter((label) => selectedTypes.includes(label.key))
                 .map((type) => type.label)}
               size='small'
             />
           </Box>
+          <Button onClick={handleResetFilters}>Reset filters</Button>
         </Stack>
         <Box sx={{ overflow: 'hidden', width: '100%' }}>
           <Paper sx={{ py: 2, px: 4 }}>
@@ -231,11 +242,16 @@ function Marketplace() {
                       <Typography variant='body1' sx={{ marginBottom: 2 }}>
                         {model.description}
                       </Typography>
-                      <Stack direction='row' spacing={1} sx={{ marginBottom: 2 }}>
-                        {model.tags.slice(0, 10).map((tag) => (
-                          <Chip color='secondary' key={`chip-${tag}`} label={tag} size='small' variant='outlined' />
-                        ))}
-                      </Stack>
+                      <ChipSelector
+                        chipTooltipTitle={'Filter by tag'}
+                        options={model.tags.slice(0, 10)}
+                        expandThreshold={10}
+                        multiple
+                        selectedChips={selectedLibraries}
+                        onChange={handleLibrariesOnChange}
+                        size='small'
+                        ariaLabel='add model tag to search filter'
+                      />
                       {index !== models.length - 1 && (
                         <Box sx={{ borderBottom: 1, borderColor: 'divider', marginBottom: 2 }} />
                       )}

--- a/frontend/src/common/ChipSelector.tsx
+++ b/frontend/src/common/ChipSelector.tsx
@@ -1,48 +1,53 @@
+import { Tooltip } from '@mui/material'
 import Button from '@mui/material/Button'
 import Chip from '@mui/material/Chip'
 import Typography from '@mui/material/Typography'
 import { ReactElement, useState } from 'react'
 
-type PartialTagSelectorProps =
+type PartialChipSelectorProps =
   | {
       multiple: true
-      tags: string[]
-      selectedTags: string[]
+      options: string[]
+      selectedChips: string[]
       onChange: (value: string[]) => void
     }
   | {
       multiple?: false
-      tags: string[]
-      selectedTags: string
+      options: string[]
+      selectedChips: string
       onChange: (value: string) => void
     }
 
-type TagSelectorProps = {
-  label: string
+type ChipSelectorProps = {
+  label?: string
   size?: 'small' | 'medium'
   expandThreshold?: number
-} & PartialTagSelectorProps
+  chipTooltipTitle?: string
+  ariaLabel?: string
+} & PartialChipSelectorProps
 
 export default function ChipSelector({
   label,
-  tags,
+  options,
   onChange,
-  selectedTags,
+  selectedChips,
   multiple,
   size = 'medium',
   expandThreshold = 5,
-}: TagSelectorProps): ReactElement {
+  chipTooltipTitle = '',
+  ariaLabel = '',
+}: ChipSelectorProps): ReactElement {
   const [expanded, setExpanded] = useState(false)
 
-  const handleChange = (selectedTag: string): void => {
+  const handleChange = (selectedChip: string): void => {
     if (multiple) {
-      if (selectedTags.includes(selectedTag)) {
-        onChange(selectedTags.filter((tag) => tag !== selectedTag))
+      if (selectedChips.includes(selectedChip)) {
+        onChange(selectedChips.filter((chipFilter) => chipFilter !== selectedChip))
       } else {
-        onChange([...selectedTags, selectedTag])
+        onChange([...selectedChips, selectedChip])
       }
     } else {
-      onChange(selectedTags !== selectedTag ? selectedTag : '')
+      onChange(selectedChips !== selectedChip ? selectedChip : '')
     }
   }
 
@@ -50,43 +55,52 @@ export default function ChipSelector({
     setExpanded(!expanded)
   }
 
-  const allTags = tags.map((tag) => (
-    <Tag key={tag} tag={tag} size={size} activeChip={selectedTags.includes(tag)} handleChange={handleChange} />
+  const allOptions = options.map((option) => (
+    <ChipItem
+      key={option}
+      chip={option}
+      size={size}
+      activeChip={selectedChips.includes(option)}
+      handleChange={handleChange}
+      chipTooltipTitle={chipTooltipTitle}
+      ariaLabel={ariaLabel}
+    />
   ))
-
-  function displaySelectedTagCount(): string {
-    return multiple && selectedTags.length > 0 ? `(${selectedTags.length} selected)` : ''
-  }
 
   return (
     <>
-      <Typography component='h2' variant='h6'>{`${label} ${displaySelectedTagCount()}`}</Typography>
-      {!expanded && allTags.slice(0, expandThreshold)}
-      {expanded && allTags}
-      {tags.length > expandThreshold && (
+      {label && <Typography component='h2' variant='h6'>{`${label}`}</Typography>}
+      {!expanded && allOptions.slice(0, expandThreshold)}
+      {expanded && allOptions}
+      {options.length > expandThreshold && (
         <Button onClick={toggleExpansion}>{expanded ? 'Show less' : 'Show more...'}</Button>
       )}
     </>
   )
 }
 
-type TagProps = {
-  tag: string
+type ChipItemProps = {
+  chip: string
   handleChange: (value: string) => void
-  size?: TagSelectorProps['size']
+  size?: ChipSelectorProps['size']
   activeChip: boolean
+  chipTooltipTitle?: string
+  ariaLabel?: string
 }
 
-function Tag({ tag, handleChange, size, activeChip }: TagProps) {
+function ChipItem({ chip, handleChange, size, activeChip, chipTooltipTitle = '', ariaLabel = '' }: ChipItemProps) {
   return (
-    <Chip
-      color={activeChip ? 'primary' : 'default'}
-      size={size}
-      key={tag}
-      sx={{ mr: 1, mb: 1 }}
-      label={tag}
-      data-test={`chipOption-${tag}`}
-      onClick={() => handleChange(tag)}
-    />
+    <Tooltip title={chipTooltipTitle}>
+      <Chip
+        color={activeChip ? 'secondary' : 'default'}
+        size={size}
+        key={chip}
+        sx={{ mr: 1, mb: 1 }}
+        label={chip}
+        data-test={`chipOption-${chip}`}
+        onClick={() => handleChange(chip)}
+        aria-label={ariaLabel}
+      />
+    </Tooltip>
   )
 }

--- a/frontend/test/common/ChipSelector.spec.tsx
+++ b/frontend/test/common/ChipSelector.spec.tsx
@@ -4,23 +4,20 @@ import { describe, expect, it } from 'vitest'
 import ChipSelector from '../../src/common/ChipSelector'
 
 describe('ChipSelector', () => {
-  it('when one chip is selected then the label should reflect this by displaying the same number of selected chips', async () => {
-    render(
-      <ChipSelector multiple tags={['cat', 'dog']} label='Pets' selectedTags={['cat']} onChange={() => undefined} />,
-    )
-    await waitFor(async () => {
-      expect(await screen.findByText('Pets (1 selected)')).toBeDefined()
-    })
-  })
-
   it('when dog is selected then it should have the appropriate css class to display that has been selected', async () => {
     render(
-      <ChipSelector multiple tags={['cat', 'dog']} label='Pets' selectedTags={['dog']} onChange={() => undefined} />,
+      <ChipSelector
+        multiple
+        options={['cat', 'dog']}
+        label='Pets'
+        selectedChips={['dog']}
+        onChange={() => undefined}
+      />,
     )
     const dogChipOption = await screen.findByTestId('chipOption-dog')
     const catChipOption = await screen.findByTestId('chipOption-cat')
     await waitFor(async () => {
-      expect(dogChipOption.className.includes('MuiChip-clickableColorPrimary')).toBe(true)
+      expect(dogChipOption.className.includes('MuiChip-clickableColorSecondary')).toBe(true)
       expect(catChipOption.className.includes('MuiChip-clickableColorDefault')).toBe(true)
     })
   })


### PR DESCRIPTION
You can now filter models by selecting the tags underneath them:

![image](https://github.com/gchq/Bailo/assets/89992537/64d25de3-a05f-4037-81c1-a2539490608c)

You can also reset all of your model filtering by pressing the following button at the bottom of the panel on the left-hand side:

![image](https://github.com/gchq/Bailo/assets/89992537/8d929e02-a689-4041-b2e2-898c8b0cc98c)
