### PR TITLE
Dependency updates for Docker & Helm

### DIFF
--- a/docker-compose-prod.yml
+++ b/docker-compose-prod.yml
@@ -41,7 +41,7 @@ services:
 
   registry:
     restart: always
-    image: registry:2.8.1
+    image: registry:2.8.3
     ports:
       - 5000:5000
     environment:

--- a/docker-compose-prod.yml
+++ b/docker-compose-prod.yml
@@ -1,10 +1,11 @@
 version: '3.9'
 services:
   mongo:
-    image: mongo:6.0.4
-    command: [--replSet, repl-set, --bind_ip_all, --port, '27017', --quiet]
+    image: bitnami/mongodb:7.0.8
+    environment:
+      - MONGODB_REPLICA_SET_NAME=repl-set
     volumes:
-      - mongoVolume:/data/db
+      - mongoVolume:/bitnami/mongodb
     ports:
       - 27017:27017
     healthcheck:

--- a/docker-compose-prod.yml
+++ b/docker-compose-prod.yml
@@ -1,4 +1,3 @@
-version: '3.9'
 services:
   mongo:
     image: bitnami/mongodb:7.0.8

--- a/docker-compose-prod.yml
+++ b/docker-compose-prod.yml
@@ -30,7 +30,7 @@ services:
       - 1025:1025
 
   nginx:
-    image: nginx:1.21.6-alpine
+    image: nginxinc/nginx-unprivileged:1.25.4-alpine3.18
     volumes:
       - ./infrastructure/nginx/nginx.conf:/etc/nginx/nginx.conf
     ports:

--- a/docker-compose-prod.yml
+++ b/docker-compose-prod.yml
@@ -24,7 +24,7 @@ services:
     command: server /data --console-address ":9001"
 
   mailcrab:
-    image: marlonb/mailcrab:v0.10.0
+    image: marlonb/mailcrab:v1.2.0
     ports:
       - 1080:1080
       - 1025:1025

--- a/docker-compose-prod.yml
+++ b/docker-compose-prod.yml
@@ -15,13 +15,15 @@ services:
       start_period: 30s
 
   minio:
-    image: minio/minio:RELEASE.2023-01-31T02-24-19Z
+    image: bitnami/minio:2024.4.6
+    environment:
+      MINIO_ROOT_USER: minioadmin
+      MINIO_ROOT_PASSWORD: minioadmin
     ports:
       - 9000:9000
       - 9001:9001
     volumes:
-      - minioVolume:/data
-    command: server /data --console-address ":9001"
+      - minioVolume:/bitnami/minio
 
   mailcrab:
     image: marlonb/mailcrab:v1.2.0

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,10 +1,11 @@
 version: '3.9'
 services:
   mongo:
-    image: mongo:6.0.4
-    command: [--replSet, repl-set, --bind_ip_all, --port, '27017', --quiet]
+    image: bitnami/mongodb:7.0.8
+    environment:
+      - MONGODB_REPLICA_SET_NAME=repl-set
     volumes:
-      - mongoVolume:/data/db
+      - mongoVolume:/bitnami/mongodb
     ports:
       - 27017:27017
     healthcheck:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,3 @@
-version: '3.9'
 services:
   mongo:
     image: bitnami/mongodb:7.0.8

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -45,7 +45,7 @@ services:
 
   registry:
     restart: always
-    image: registry:2.8.1
+    image: registry:2.8.3
     ports:
       - 5000:5000
     environment:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -33,7 +33,7 @@ services:
       - 1025:1025
 
   nginx:
-    image: nginx:1.21.6-alpine
+    image: nginxinc/nginx-unprivileged:1.25.4-alpine3.18
     volumes:
       - ./infrastructure/nginx/nginx.conf:/etc/nginx/nginx.conf
     ports:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,13 +15,15 @@ services:
       start_period: 30s
 
   minio:
-    image: minio/minio:RELEASE.2023-01-31T02-24-19Z
+    image: bitnami/minio:2024.4.6
+    environment:
+      MINIO_ROOT_USER: minioadmin
+      MINIO_ROOT_PASSWORD: minioadmin
     ports:
       - 9000:9000
       - 9001:9001
     volumes:
-      - minioVolume:/data
-    command: server /data --console-address ":9001"
+      - minioVolume:/bitnami/minio
 
   clamd:
     image: clamav/clamav:1.3

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -27,7 +27,7 @@ services:
     image: clamav/clamav:1.3
 
   mailcrab:
-    image: marlonb/mailcrab:v0.10.0
+    image: marlonb/mailcrab:v1.2.0
     ports:
       - 1080:1080
       - 1025:1025

--- a/infrastructure/helm/bailo/Chart.lock
+++ b/infrastructure/helm/bailo/Chart.lock
@@ -1,9 +1,9 @@
 dependencies:
 - name: minio
   repository: https://charts.bitnami.com/bitnami
-  version: 12.2.6
+  version: 14.2.0
 - name: mongodb
   repository: https://charts.bitnami.com/bitnami
   version: 13.9.4
-digest: sha256:9d27fe672ed3de1f04b9c8ee7a709ca6642355186193dd7bc21338553bd5d246
-generated: "2023-05-05T09:20:50.258884382Z"
+digest: sha256:664c706c2424e69ee49617880e8e77887860b3026b704d607a5b62430ae59613
+generated: "2024-04-19T15:10:24.36040904Z"

--- a/infrastructure/helm/bailo/Chart.lock
+++ b/infrastructure/helm/bailo/Chart.lock
@@ -4,6 +4,6 @@ dependencies:
   version: 14.2.0
 - name: mongodb
   repository: https://charts.bitnami.com/bitnami
-  version: 13.9.4
-digest: sha256:664c706c2424e69ee49617880e8e77887860b3026b704d607a5b62430ae59613
-generated: "2024-04-19T15:10:24.36040904Z"
+  version: 15.1.4
+digest: sha256:2e4238b5b4e1178aa1a0b7e73fe7ad3a4d2cc6b78066dbdc4ee19709d7286896
+generated: "2024-04-19T15:11:29.678367785Z"

--- a/infrastructure/helm/bailo/Chart.yaml
+++ b/infrastructure/helm/bailo/Chart.yaml
@@ -31,5 +31,5 @@ dependencies:
   condition: minio.enabled
 - name: mongodb
   repository: "https://charts.bitnami.com/bitnami"
-  version: "~13.9.4"
+  version: "~15.1.4"
   condition: mongodb.enabled

--- a/infrastructure/helm/bailo/Chart.yaml
+++ b/infrastructure/helm/bailo/Chart.yaml
@@ -27,7 +27,7 @@ appVersion: "0.1.0"
 dependencies:
 - name: minio
   repository: "https://charts.bitnami.com/bitnami"
-  version: "~12.2.5"
+  version: "~14.2.0"
   condition: minio.enabled
 - name: mongodb
   repository: "https://charts.bitnami.com/bitnami"

--- a/infrastructure/helm/bailo/values.yaml
+++ b/infrastructure/helm/bailo/values.yaml
@@ -142,7 +142,7 @@ mongodb:
   image:
     registry: docker.io
     repository: bitnami/mongodb
-    tag: 6.0.5-debian-11-r9
+    tag: 7.0.8-debian-12-r2
 
 # MinIO Dependencies
 minio:
@@ -174,7 +174,7 @@ minio:
   image:
     registry: docker.io
     repository: bitnami/minio
-    tag: 2022.2.12-debian-10-r0
+    tag: 2024.4.18-debian-12-r0
     debug: true
 
 # Registry Dependencies

--- a/infrastructure/nginx/nginx.conf
+++ b/infrastructure/nginx/nginx.conf
@@ -1,5 +1,6 @@
 # An example Nginx configuration
 
+pid /tmp/nginx.pid;
 worker_processes 1;
 events { worker_connections 1024; }
 


### PR DESCRIPTION
This PR bundles a number of changes together - happy to submit these separately if desired, and/or decouple the switch to Bitnami images.

- registry bumped from 2.8.1 to 2.8.3
- nginx switched to the 'unprivileged' variant, bumped from 1.21.6 to 1.25.4 (requires minor tweak to nginx.conf)
- mailcrab bumped from 0.10.0 to 1.2.0
- minio switched to the 'bitnami' variant, bumped from 2023.1.31 to 2024.4.6, retained default credentials
- mongodb switched to the 'bitnami' variant, bumped from 6.0.4 to 7.0.8
- bumped minio/mongodb helm dependencies to their current latest
- bumped minio/mongodb helm default image values
- removed 'version' from the docker compose files as this has been deprecated in the latest versions of compose.