### PR TITLE
Migrate to maintained extension

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -10,6 +10,6 @@
     "ms-python.flake8",
     "ms-python.black-formatter",
     "ryanluker.vscode-coverage-gutters",
-    "bungcip.better-toml"
+    "tamasfe.even-better-toml"
   ]
 }


### PR DESCRIPTION
VSCode prompts to migrate from the existing extension which appears to have been last updated in 2018. That said, the 'new' one is still in preview but actively maintained.