### PR TITLE
Enable local replica set + enable basic authentication

### DIFF
--- a/.github/workflows/build.js.yml
+++ b/.github/workflows/build.js.yml
@@ -313,6 +313,13 @@ jobs:
               secretKey: 'minioadmin',
             },
 
+            mongo: {
+              uri: 'mongodb://mongo:27017/bailo?replicaSet=rs0&authSource=admin',
+
+              user: 'mongoadmin',
+              pass: 'mongoadmin',
+            },
+
             smtp: {
               auth: {
                 user: 'mailuser',
@@ -428,6 +435,13 @@ jobs:
             minio: {
               accessKey: 'minioadmin',
               secretKey: 'minioadmin',
+            },
+
+            mongo: {
+              uri: 'mongodb://mongo:27017/bailo?replicaSet=rs0&authSource=admin',
+
+              user: 'mongoadmin',
+              pass: 'mongoadmin',
             },
 
             smtp: {

--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ npm run script -- addUploadSchema
 | ---------- | ----- | --------------------- |
 | Next UI    | 3000  | Stored in `frontend`  |
 | NodeJS App | 3001  | Stored in `backend`   |
-| Mongo      | 27017 | No credentials        |
+| Mongo      | 27017 | mongoadmin:mongoadmin |
 | Registry   | 5000  | HTTPS only, no UI     |
 | Minio UI   | 9001  | minioadmin:minioadmin |
 | Minio      | 9000  | minioadmin:minioadmin |

--- a/backend/config/docker_compose.cjs
+++ b/backend/config/docker_compose.cjs
@@ -5,7 +5,10 @@ module.exports = {
   },
 
   mongo: {
-    uri: 'mongodb://mongo:27017/bailo',
+    uri: 'mongodb://mongo:27017/bailo?replicaSet=rs0&authSource=admin',
+
+    user: 'mongoadmin',
+    pass: 'mongoadmin',
   },
 
   app: {

--- a/docker-compose-prod.yml
+++ b/docker-compose-prod.yml
@@ -2,15 +2,21 @@ services:
   mongo:
     image: bitnami/mongodb:7.0.8
     environment:
-      - MONGODB_REPLICA_SET_NAME=repl-set
+      - MONGODB_ADVERTISED_HOSTNAME=mongo
+      - MONGODB_ADVERTISED_PORT_NUMBER=27017
+      - MONGODB_REPLICA_SET_MODE=primary
+      - MONGODB_REPLICA_SET_KEY=developmentReplicaSetKey
+      - MONGODB_ROOT_USER=mongoadmin
+      - MONGODB_ROOT_PASSWORD=mongoadmin
+      - MONGODB_REPLICA_SET_NAME=rs0
     volumes:
       - mongoVolume:/bitnami/mongodb
     ports:
       - 27017:27017
     healthcheck:
       test:
-        test $$(mongosh --port 27017 --quiet --eval "try
-        {rs.initiate({_id:'repl-set',members:[{_id:0,host:\"mongo:27017\"}]})} catch(e) {rs.status().ok}") -eq 1
+        test $$(mongosh --authenticationDatabase admin --username ${MONGODB_ROOT_USER:-'mongoadmin'} --password
+        ${MONGODB_ROOT_PASSWORD:-'mongoadmin'} --quiet --eval "rs.status().ok") -eq 1
       interval: 10s
       start_period: 30s
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,15 +2,21 @@ services:
   mongo:
     image: bitnami/mongodb:7.0.8
     environment:
-      - MONGODB_REPLICA_SET_NAME=repl-set
+      - MONGODB_ADVERTISED_HOSTNAME=mongo
+      - MONGODB_ADVERTISED_PORT_NUMBER=27017
+      - MONGODB_REPLICA_SET_MODE=primary
+      - MONGODB_REPLICA_SET_KEY=developmentReplicaSetKey
+      - MONGODB_ROOT_USER=mongoadmin
+      - MONGODB_ROOT_PASSWORD=mongoadmin
+      - MONGODB_REPLICA_SET_NAME=rs0
     volumes:
       - mongoVolume:/bitnami/mongodb
     ports:
       - 27017:27017
     healthcheck:
       test:
-        test $$(mongosh --port 27017 --quiet --eval "try
-        {rs.initiate({_id:'repl-set',members:[{_id:0,host:\"mongo:27017\"}]})} catch(e) {rs.status().ok}") -eq 1
+        test $$(mongosh --authenticationDatabase admin --username ${MONGODB_ROOT_USER:-'mongoadmin'} --password
+        ${MONGODB_ROOT_PASSWORD:-'mongoadmin'} --quiet --eval "rs.status().ok") -eq 1
       interval: 10s
       start_period: 30s
 


### PR DESCRIPTION
Whilst working on transactions, I noticed the local instance wasn't quite in replica set mode, possibly after my switch to the Bitnami image.

Authentication seems to be required, I wasn't able to force it to be disabled during dev but happy to try again or take suggestions on that. If it remains enabled, I've followed the pattern for other services of `serviceadmin` for user/pass here but happy to use something else.

It may require dropping the mongo Docker volume if you struggle to bring it up when testing these changes, though the Bitnami image 'should' adapt automatically.