### PR TITLE
added isadmin property to getCurrentUser call so we can hide certain …

### DIFF
--- a/backend/src/routes/v2/entities/getCurrentUser.ts
+++ b/backend/src/routes/v2/entities/getCurrentUser.ts
@@ -2,6 +2,8 @@ import bodyParser from 'body-parser'
 import { Request, Response } from 'express'
 import { z } from 'zod'
 
+import { Roles } from '../../../connectors/authentication/Base.js'
+import authentication from '../../../connectors/authentication/index.js'
 import { UserInterface } from '../../../models/User.js'
 import { registerPath, userInterfaceSchema } from '../../../services/specification.js'
 import { parse } from '../../../utils/validate.js'
@@ -34,7 +36,6 @@ export const getCurrentUser = [
   bodyParser.json(),
   async (req: Request, res: Response<GetCurrentUserResponses>) => {
     const _ = parse(req, getCurrentUserSchema)
-
-    return res.json({ user: req.user })
+    return res.json({ user: { ...req.user, isAdmin: await authentication.hasRole(req.user, Roles.Admin) } })
   },
 ]

--- a/backend/src/routes/v2/entities/getCurrentUser.ts
+++ b/backend/src/routes/v2/entities/getCurrentUser.ts
@@ -36,6 +36,7 @@ export const getCurrentUser = [
   bodyParser.json(),
   async (req: Request, res: Response<GetCurrentUserResponses>) => {
     const _ = parse(req, getCurrentUserSchema)
-    return res.json({ user: { ...req.user, isAdmin: await authentication.hasRole(req.user, Roles.Admin) } })
+    const isAdmin = await authentication.hasRole(req.user, Roles.Admin)
+    return res.json({ user: { ...req.user, isAdmin } })
   },
 ]

--- a/backend/src/services/specification.ts
+++ b/backend/src/services/specification.ts
@@ -238,6 +238,7 @@ export const userTokenSchema = z.object({
 
 export const userInterfaceSchema = z.object({
   dn: z.string().openapi({ example: 'user' }),
+  isAdmin: z.boolean().openapi({ example: false }),
 
   createdAt: z.string().openapi({ example: new Date().toISOString() }),
   updatedAt: z.string().openapi({ example: new Date().toISOString() }),

--- a/frontend/pages/schemas/list.tsx
+++ b/frontend/pages/schemas/list.tsx
@@ -1,10 +1,29 @@
+import { useGetCurrentUser } from 'actions/user'
 import { useRouter } from 'next/router'
 import { useMemo } from 'react'
+import Forbidden from 'src/common/Forbidden'
+import Loading from 'src/common/Loading'
 import PageWithTabs from 'src/common/PageWithTabs'
 import Title from 'src/common/Title'
+import MultipleErrorWrapper from 'src/errors/MultipleErrorWrapper'
 import SchemaTab from 'src/schemas/SchemaTab'
 
 export default function SchemasPage() {
+  const { currentUser, isCurrentUserLoading, isCurrentUserError } = useGetCurrentUser()
+
+  if (isCurrentUserLoading) return <Loading />
+
+  if (!currentUser || !currentUser.isAdmin) {
+    return (
+      <Forbidden errorMessage='If you think this is in error please contact the model owners.' noMargin hideNavButton />
+    )
+  }
+
+  const error = MultipleErrorWrapper(`Unable to load model page`, {
+    isCurrentUserError,
+  })
+  if (error) return error
+
   return (
     <>
       <Title text='Schemas' />

--- a/frontend/pages/schemas/list.tsx
+++ b/frontend/pages/schemas/list.tsx
@@ -15,11 +15,15 @@ export default function SchemasPage() {
 
   if (!currentUser || !currentUser.isAdmin) {
     return (
-      <Forbidden errorMessage='If you think this is in error please contact the model owners.' noMargin hideNavButton />
+      <Forbidden
+        errorMessage='If you think this is in error please contact the Bailo admininistrators.'
+        noMargin
+        hideNavButton
+      />
     )
   }
 
-  const error = MultipleErrorWrapper(`Unable to load model page`, {
+  const error = MultipleErrorWrapper(`Unable to load schema page`, {
     isCurrentUserError,
   })
   if (error) return error

--- a/frontend/src/wrapper/SideNavigation.tsx
+++ b/frontend/src/wrapper/SideNavigation.tsx
@@ -152,7 +152,7 @@ export default function SideNavigation({
             />
             <Divider />
             {/* TODO Once currentUser api has been updated to use roles we should check if they're admin */}
-            {currentUser && (
+            {currentUser.isAdmin && (
               <>
                 <NavMenuItem
                   href='/schemas/list'

--- a/frontend/src/wrapper/SideNavigation.tsx
+++ b/frontend/src/wrapper/SideNavigation.tsx
@@ -151,7 +151,6 @@ export default function SideNavigation({
               icon={<ContactSupportIcon />}
             />
             <Divider />
-            {/* TODO Once currentUser api has been updated to use roles we should check if they're admin */}
             {currentUser.isAdmin && (
               <>
                 <NavMenuItem

--- a/frontend/types/types.ts
+++ b/frontend/types/types.ts
@@ -161,7 +161,7 @@ export interface PostSimpleUpload {
 
 export interface User {
   dn: string
-  isAdmin?: boolean
+  isAdmin: boolean
 }
 
 export interface EntityObject {

--- a/frontend/types/types.ts
+++ b/frontend/types/types.ts
@@ -161,6 +161,7 @@ export interface PostSimpleUpload {
 
 export interface User {
   dn: string
+  isAdmin?: boolean
 }
 
 export interface EntityObject {


### PR DESCRIPTION
…pages from nonadmins

Note this is used for client-side validation ONLY. This should not be used for checking for anything important - it's main purpose is to hide pages/sections that normal users are currently not able to use anyway.