### PR TITLE
Fixed ability to retrieve models without cards

### DIFF
--- a/lib/python/src/bailo/__init__.py
+++ b/lib/python/src/bailo/__init__.py
@@ -7,8 +7,8 @@ Bailo is a ecosystem for managing the lifecycle of managing machine learning mod
 from __future__ import annotations
 import logging
 
-# Package Version 2.3.2
-__version__ = "2.3.2"
+# Package Version 2.3.3
+__version__ = "2.3.3"
 
 
 from bailo.core.agent import Agent, PkiAgent, TokenAgent

--- a/lib/python/src/bailo/helper/entry.py
+++ b/lib/python/src/bailo/helper/entry.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Any
 import logging
+import warnings
 
 from bailo.core.client import Client
 from bailo.core.enums import EntryKind, ModelVisibility
@@ -69,7 +70,9 @@ class Entry:
             self.__unpack_card(res["model"]["card"])
             logger.info(f"Latest card for ID %s successfully retrieved.", self.id)
         else:
-            raise BailoException(f"A model card doesn't exist for model {self.id}")
+            warnings.warn(
+                f"ID {self.id} does not have any associated cards. If needed, create a card with the .card_from_schema() method."
+            )
 
     def get_card_revision(self, version: str) -> None:
         """Get a specific entry card revision from Bailo.


### PR DESCRIPTION
Code now provides a warning instead of an error if a card isn't found using the `get_card_latest()` method. This will also apply to data cards.