### PR TITLE
Disable next telemetry

### DIFF
--- a/frontend/cache/config.json
+++ b/frontend/cache/config.json
@@ -1,0 +1,6 @@
+{
+  "telemetry": {
+    "notifiedAt": "1719606276720",
+    "enabled": false
+  }
+}


### PR DESCRIPTION
If desired, this disables telemetry about commands etc being sent back to the NextJS folks.

More info: https://nextjs.org/telemetry