### PR TITLE
Use accordions for schema selection, hiding inactive schemas by default

### DIFF
--- a/frontend/pages/model/[modelId]/access-request/schema.tsx
+++ b/frontend/pages/model/[modelId]/access-request/schema.tsx
@@ -1,6 +1,18 @@
 import { Schema } from '@mui/icons-material'
 import ArrowBack from '@mui/icons-material/ArrowBack'
-import { Box, Button, Card, Container, Grid, Stack, Typography } from '@mui/material'
+import ExpandMoreIcon from '@mui/icons-material/ExpandMore'
+import {
+  Accordion,
+  AccordionDetails,
+  AccordionSummary,
+  Box,
+  Button,
+  Card,
+  Container,
+  Grid,
+  Stack,
+  Typography,
+} from '@mui/material'
 import { useGetSchemas } from 'actions/schema'
 import _ from 'lodash-es'
 import { useRouter } from 'next/router'
@@ -30,6 +42,13 @@ export default function AccessRequestSchema() {
     },
     [modelId, router],
   )
+
+  const accordionStyling = {
+    '&:before': {
+      display: 'none',
+    },
+    width: '100%',
+  } as const
 
   const activeSchemaButtons = useMemo(
     () =>
@@ -93,20 +112,32 @@ export default function AccessRequestSchema() {
               </Typography>
             </Stack>
             <Stack sx={{ mt: 2 }} spacing={2} alignItems='center'>
-              <Typography color='primary' component='h2' variant='h6'>
-                Active Schemas
-              </Typography>
-              <Box sx={{ m: 2 }}>
-                <Grid container spacing={2} justifyContent='center'>
-                  {modelId && activeSchemaButtons}
-                </Grid>
-              </Box>
-              <Typography color='primary' component='h2' variant='h6'>
-                Inactive Schemas
-              </Typography>
-              <Grid container spacing={2} justifyContent='center'>
-                {modelId && inactiveSchemaButtons}
-              </Grid>
+              <Accordion defaultExpanded sx={accordionStyling}>
+                <AccordionSummary expandIcon={<ExpandMoreIcon />}>
+                  <Typography sx={{ width: '100%' }} align='center' color='primary' variant='h6' component='h2'>
+                    Active Schemas
+                  </Typography>
+                </AccordionSummary>
+                <AccordionDetails>
+                  <Box sx={{ m: 2 }}>
+                    <Grid container spacing={2} justifyContent='center'>
+                      {modelId && activeSchemaButtons}
+                    </Grid>
+                  </Box>
+                </AccordionDetails>
+              </Accordion>
+              <Accordion sx={accordionStyling}>
+                <AccordionSummary expandIcon={<ExpandMoreIcon />}>
+                  <Typography sx={{ width: '100%' }} align='center' color='primary' variant='h6' component='h2'>
+                    Inactive Schemas
+                  </Typography>
+                </AccordionSummary>
+                <AccordionDetails>
+                  <Grid container spacing={2} justifyContent='center'>
+                    {modelId && inactiveSchemaButtons}
+                  </Grid>
+                </AccordionDetails>
+              </Accordion>
             </Stack>
           </Card>
         </Container>

--- a/frontend/src/schemas/SchemaSelect.tsx
+++ b/frontend/src/schemas/SchemaSelect.tsx
@@ -1,6 +1,17 @@
 import { Schema } from '@mui/icons-material'
 import ArrowBack from '@mui/icons-material/ArrowBack'
-import { Button, Card, Container, Grid, Stack, Typography } from '@mui/material'
+import ExpandMoreIcon from '@mui/icons-material/ExpandMore'
+import {
+  Accordion,
+  AccordionDetails,
+  AccordionSummary,
+  Button,
+  Card,
+  Container,
+  Grid,
+  Stack,
+  Typography,
+} from '@mui/material'
 import { useGetModel } from 'actions/model'
 import { postFromSchema } from 'actions/modelCard'
 import { useGetSchemas } from 'actions/schema'
@@ -55,6 +66,13 @@ export default function SchemaSelect({ entry }: SchemaSelectProps) {
     },
     [currentUser, entry, mutateEntry, router],
   )
+
+  const accordionStyling = {
+    '&:before': {
+      display: 'none',
+    },
+    width: '100%',
+  } as const
 
   const activeSchemaButtons = useMemo(
     () =>
@@ -120,18 +138,30 @@ export default function SchemaSelect({ entry }: SchemaSelectProps) {
               </Typography>
             </Stack>
             <Stack sx={{ mt: 2 }} spacing={2} alignItems='center'>
-              <Typography color='primary' variant='h6' component='h2'>
-                Active Schemas
-              </Typography>
-              <Grid container spacing={2} justifyContent='center'>
-                {activeSchemaButtons}
-              </Grid>
-              <Typography color='primary' variant='h6' component='h2'>
-                Inactive Schemas
-              </Typography>
-              <Grid container spacing={2} justifyContent='center'>
-                {inactiveSchemaButtons}
-              </Grid>
+              <Accordion defaultExpanded sx={accordionStyling}>
+                <AccordionSummary expandIcon={<ExpandMoreIcon />}>
+                  <Typography sx={{ width: '100%' }} align='center' color='primary' variant='h6' component='h2'>
+                    Active Schemas
+                  </Typography>
+                </AccordionSummary>
+                <AccordionDetails>
+                  <Grid container spacing={2} justifyContent='center'>
+                    {activeSchemaButtons}
+                  </Grid>
+                </AccordionDetails>
+              </Accordion>
+              <Accordion sx={accordionStyling}>
+                <AccordionSummary expandIcon={<ExpandMoreIcon />}>
+                  <Typography sx={{ width: '100%' }} align='center' color='primary' variant='h6' component='h2'>
+                    Inactive Schemas
+                  </Typography>
+                </AccordionSummary>
+                <AccordionDetails>
+                  <Grid container spacing={2} justifyContent='center'>
+                    {inactiveSchemaButtons}
+                  </Grid>
+                </AccordionDetails>
+              </Accordion>
               <MessageAlert message={errorMessage} severity='error' />
             </Stack>
           </Card>


### PR DESCRIPTION
Showing inactive schemas during selection could confuse some users, especially if an organisation is trying to encourage the use of active schemas only. This change makes both active and inactive schemas appear within accordions, with active schemas shown expanded by default. Users can still expand and select an inactive schema if desired, but it's a conscious choice.

The accordion styling props is configured to remove the divider that's shown only when collapsed, and also ensure that the expand icon is justified-right all the time. If the active/inactive schema accordion is empty (no schemas) it would be misaligned with the other accordion.

![image](https://github.com/gchq/Bailo/assets/73173408/465a97c8-cc19-4704-9e1d-614f0faeff3a)
