### PR TITLE
Wait for backend to be ready before starting cypress

### DIFF
--- a/.github/workflows/build.js.yml
+++ b/.github/workflows/build.js.yml
@@ -348,6 +348,7 @@ jobs:
 
       - uses: cypress-io/github-action@v5
         with:
+          wait-on: 'http://localhost:8080/api/v2/config/ui'
           working-directory: ./frontend
           install: false
           spec: cypress/e2e/bailo/**/*


### PR DESCRIPTION
Noticed this pop up a few times during PR builds. Seems like waitForIt is happy the port is open but the app isn't ready