### PR TITLE
1. Replace ts-node with tsx

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ npm run script -- addUploadSchema
 ```
 
 > NOTE: Scripts are also written in Typescript. In production, run them using `node`, in development, run them using
-> `ts-node` or `npm run script`.
+> `tsx` or `npm run script`.
 
 <br />
 

--- a/backend/nodemon.json
+++ b/backend/nodemon.json
@@ -1,6 +1,6 @@
 {
   "watch": ["src", "config"],
   "ignore": [".git"],
-  "exec": "node --no-warnings=ExperimentalWarning --loader ts-node/esm --inspect=0.0.0.0:9229 src/index.ts",
+  "exec": "tsx --no-warnings=ExperimentalWarning --inspect=0.0.0.0:9229 src/index.ts",
   "ext": "js ts cjs"
 }

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -85,7 +85,6 @@
         "nodemon": "^3.1.2",
         "prettier": "^3.2.5",
         "supertest": "^6.3.4",
-        "ts-node": "^10.9.2",
         "typescript": "^5.1.3",
         "vite-tsconfig-paths": "^4.2.1",
         "vitest": "^1.3.1"
@@ -6500,26 +6499,6 @@
       "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
       "dev": true
     },
-    "node_modules/@cspotcode/source-map-support": {
-      "version": "0.8.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@jridgewell/trace-mapping": "0.3.9"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@cspotcode/source-map-support/node_modules/@jridgewell/trace-mapping": {
-      "version": "0.3.9",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@jridgewell/resolve-uri": "^3.0.3",
-        "@jridgewell/sourcemap-codec": "^1.4.10"
-      }
-    },
     "node_modules/@esbuild/aix-ppc64": {
       "version": "0.21.5",
       "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.21.5.tgz",
@@ -10990,26 +10969,6 @@
       "integrity": "sha512-myfUej5naTBWnqOCc/MdVOLVjXUXtIA+NpDrDBKJtLLg2shUjBu3cZmB/85RyitKc55+lUUyl7oRfLOvkr2hsw==",
       "dev": true
     },
-    "node_modules/@tsconfig/node10": {
-      "version": "1.0.9",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@tsconfig/node12": {
-      "version": "1.0.11",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@tsconfig/node14": {
-      "version": "1.0.3",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@tsconfig/node16": {
-      "version": "1.0.3",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/@types/accepts": {
       "version": "1.3.7",
       "resolved": "https://registry.npmjs.org/@types/accepts/-/accepts-1.3.7.tgz",
@@ -12226,11 +12185,6 @@
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       }
     },
-    "node_modules/arg": {
-      "version": "4.1.3",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/argparse": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
@@ -13041,11 +12995,6 @@
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       }
     },
-    "node_modules/create-require": {
-      "version": "1.1.1",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/cross-spawn": {
       "version": "7.0.3",
       "license": "MIT",
@@ -13182,14 +13131,6 @@
       "dependencies": {
         "asap": "^2.0.0",
         "wrappy": "1"
-      }
-    },
-    "node_modules/diff": {
-      "version": "4.0.2",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "engines": {
-        "node": ">=0.3.1"
       }
     },
     "node_modules/diff-sequences": {
@@ -15796,11 +15737,6 @@
         "source-map-js": "^1.0.2"
       }
     },
-    "node_modules/make-error": {
-      "version": "1.3.6",
-      "dev": true,
-      "license": "ISC"
-    },
     "node_modules/media-typer": {
       "version": "0.3.0",
       "license": "MIT",
@@ -18350,49 +18286,6 @@
         "node": ">=12"
       }
     },
-    "node_modules/ts-node": {
-      "version": "10.9.2",
-      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.2.tgz",
-      "integrity": "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==",
-      "dev": true,
-      "dependencies": {
-        "@cspotcode/source-map-support": "^0.8.0",
-        "@tsconfig/node10": "^1.0.7",
-        "@tsconfig/node12": "^1.0.7",
-        "@tsconfig/node14": "^1.0.0",
-        "@tsconfig/node16": "^1.0.2",
-        "acorn": "^8.4.1",
-        "acorn-walk": "^8.1.1",
-        "arg": "^4.1.0",
-        "create-require": "^1.1.0",
-        "diff": "^4.0.1",
-        "make-error": "^1.1.1",
-        "v8-compile-cache-lib": "^3.0.1",
-        "yn": "3.1.1"
-      },
-      "bin": {
-        "ts-node": "dist/bin.js",
-        "ts-node-cwd": "dist/bin-cwd.js",
-        "ts-node-esm": "dist/bin-esm.js",
-        "ts-node-script": "dist/bin-script.js",
-        "ts-node-transpile-only": "dist/bin-transpile.js",
-        "ts-script": "dist/bin-script-deprecated.js"
-      },
-      "peerDependencies": {
-        "@swc/core": ">=1.2.50",
-        "@swc/wasm": ">=1.2.50",
-        "@types/node": "*",
-        "typescript": ">=2.7"
-      },
-      "peerDependenciesMeta": {
-        "@swc/core": {
-          "optional": true
-        },
-        "@swc/wasm": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/tsconfck": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/tsconfck/-/tsconfck-2.1.1.tgz",
@@ -18653,11 +18546,6 @@
       "bin": {
         "uuid": "dist/bin/uuid"
       }
-    },
-    "node_modules/v8-compile-cache-lib": {
-      "version": "3.0.1",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/v8-to-istanbul": {
       "version": "9.2.0",
@@ -19185,14 +19073,6 @@
       "license": "ISC",
       "engines": {
         "node": ">=12"
-      }
-    },
-    "node_modules/yn": {
-      "version": "3.1.1",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
       }
     },
     "node_modules/yocto-queue": {

--- a/backend/package.json
+++ b/backend/package.json
@@ -3,16 +3,16 @@
   "description": "",
   "type": "module",
   "scripts": {
-    "start": "ts-node src/index.ts",
+    "start": "tsx src/index.ts",
     "dev": "nodemon",
     "build": "tsc",
     "test": "vitest",
     "lint": "eslint . --ext .ts --max-warnings=0",
     "style": "prettier --write .",
     "check-style": "prettier --check .",
-    "script": "ts-node src/scripts/runScript.ts",
-    "certs": "mkdir -p certs && openssl genrsa -out certs/key.pem 2048 && openssl req -new -x509 -key certs/key.pem -out certs/cert.pem -config certs/san.cnf -extensions 'v3_req' -days 360 && npx tsx src/scripts/generateJWKS.ts",
-    "seed": "ts-node src/seeds/index.ts"
+    "script": "tsx src/scripts/runScript.ts",
+    "certs": "mkdir -p certs && openssl genrsa -out certs/key.pem 2048 && openssl req -new -x509 -key certs/key.pem -out certs/cert.pem -config certs/san.cnf -extensions 'v3_req' -days 360 && tsx src/scripts/generateJWKS.ts",
+    "seed": "tsx src/seeds/index.ts"
   },
   "keywords": [],
   "author": "",
@@ -96,7 +96,6 @@
     "nodemon": "^3.1.2",
     "prettier": "^3.2.5",
     "supertest": "^6.3.4",
-    "ts-node": "^10.9.2",
     "typescript": "^5.1.3",
     "vite-tsconfig-paths": "^4.2.1",
     "vitest": "^1.3.1"

--- a/backend/src/scripts/runScript.ts
+++ b/backend/src/scripts/runScript.ts
@@ -7,12 +7,12 @@ const { exec } = shelljs
 // This file allows you to run scripts as:
 //   npm run script -- uploadExampleModel
 // instead of the more verbose
-//   npx ts-node src/scripts/uploadExampleModel.ts
+//   npx tsx src/scripts/uploadExampleModel.ts
 export default async function runScript() {
   const argv = await yargs(hideBin(process.argv)).usage('Usage: $0 [script]').argv
   const script = argv._
 
-  exec(`npx ts-node src/scripts/${script}.ts`)
+  exec(`npx tsx src/scripts/${script}.ts`)
 }
 
 runScript()

--- a/backend/tsconfig.json
+++ b/backend/tsconfig.json
@@ -12,9 +12,5 @@
     "noImplicitAny": false,
     "composite": true
   },
-  "include": ["global.d.ts", "src/**/*", "src/**/*.json", "package.json", "package-lock.json", "test/**/*"],
-  "ts-node": {
-    "esm": true,
-    "swc": true
-  }
+  "include": ["global.d.ts", "src/**/*", "src/**/*.json", "package.json", "package-lock.json", "test/**/*"]
 }


### PR DESCRIPTION
An initial PR for upgrading to Node 22, replaces `ts-node` with `tsx` to fix some errors with the `.ts` extension not being recognised.