### PR TITLE
Added support for new v2/token endpoints

### DIFF
--- a/lib/python/src/bailo/__init__.py
+++ b/lib/python/src/bailo/__init__.py
@@ -8,8 +8,8 @@ from __future__ import annotations
 
 import logging
 
-# Package Version 2.5.0
-__version__ = "2.5.0"
+# Package Version 2.5.1
+__version__ = "2.5.1"
 
 
 from bailo.core.agent import Agent, PkiAgent, TokenAgent

--- a/lib/python/src/bailo/core/agent.py
+++ b/lib/python/src/bailo/core/agent.py
@@ -135,16 +135,21 @@ class TokenAgent(Agent):
         self.basic = HTTPBasicAuth(access_key, secret_key)
 
     def get(self, *args, **kwargs):
+        args[0] = args[0].replace("v2", "v2/token")
         return super().get(*args, auth=self.basic, **kwargs)
 
     def post(self, *args, **kwargs):
+        args[0] = args[0].replace("v2", "v2/token")
         return super().post(*args, auth=self.basic, **kwargs)
 
     def put(self, *args, **kwargs):
+        args[0] = args[0].replace("v2", "v2/token")
         return super().put(*args, auth=self.basic, **kwargs)
 
     def patch(self, *args, **kwargs):
+        args[0] = args[0].replace("v2", "v2/token")
         return super().patch(*args, auth=self.basic, **kwargs)
 
     def delete(self, *args, **kwargs):
+        args[0] = args[0].replace("v2", "v2/token")
         return super().delete(*args, auth=self.basic, **kwargs)


### PR DESCRIPTION
**DO NOT PUBLISH UNTIL ENDPOINTS ARE IMPLEMENTED**

- Added support for dedicated token endpoints (e.g. `/v2/token/models/search`, when using the `TokenAgent()`