### PR TITLE
fix: enable arg & kwarg passing to superclass for sub agents

### DIFF
--- a/lib/python/src/bailo/core/agent.py
+++ b/lib/python/src/bailo/core/agent.py
@@ -69,6 +69,8 @@ class PkiAgent(Agent):
         cert: str,
         key: str,
         auth: str,
+        *args,
+        **kwargs
     ):
         """Initiate an agent for PKI authentication.
 
@@ -76,7 +78,7 @@ class PkiAgent(Agent):
         :param key: Path to key file
         :param auth: Path to certificate authority file
         """
-        super().__init__(verify=auth)
+        super().__init__(verify=auth, *args, **kwargs)
 
         self.cert = cert
         self.key = key
@@ -102,13 +104,16 @@ class TokenAgent(Agent):
         self,
         access_key: str | None = None,
         secret_key: str | None = None,
+        *args,
+        **kwargs,
     ):
         """Initiate an agent for API token authentication.
 
         :param access_key: Access key
         :param secret_key: Secret key
+        :param verify: Path to certificate authority file, or bool for SSL verification.
         """
-        super().__init__()
+        super().__init__(*args, **kwargs)
 
         if access_key is None:
             logger.info("Access key not provided. Trying other sources...")

--- a/lib/python/src/bailo/core/agent.py
+++ b/lib/python/src/bailo/core/agent.py
@@ -64,21 +64,14 @@ class Agent:
 
 
 class PkiAgent(Agent):
-    def __init__(
-        self,
-        cert: str,
-        key: str,
-        auth: str,
-        *args,
-        **kwargs
-    ):
+    def __init__(self, cert: str, key: str, auth: str, **kwargs):
         """Initiate an agent for PKI authentication.
 
         :param cert: Path to cert file
         :param key: Path to key file
         :param auth: Path to certificate authority file
         """
-        super().__init__(verify=auth, *args, **kwargs)
+        super().__init__(verify=auth, **kwargs)
 
         self.cert = cert
         self.key = key
@@ -104,16 +97,14 @@ class TokenAgent(Agent):
         self,
         access_key: str | None = None,
         secret_key: str | None = None,
-        *args,
         **kwargs,
     ):
         """Initiate an agent for API token authentication.
 
         :param access_key: Access key
         :param secret_key: Secret key
-        :param verify: Path to certificate authority file, or bool for SSL verification.
         """
-        super().__init__(*args, **kwargs)
+        super().__init__(**kwargs)
 
         if access_key is None:
             logger.info("Access key not provided. Trying other sources...")


### PR DESCRIPTION
# Affected core subsystem(s):
python library

# Description of change:
Updated tokenagent and pkiagent to accept args and kwargs for super.__init__(), which will allow using these classes with verify=False