### PR TITLE
Bump deploy-pages and upload-pages-artifact GitHub action versions

### DIFF
--- a/.github/workflows/web.yml
+++ b/.github/workflows/web.yml
@@ -124,7 +124,7 @@ jobs:
       url: ${{ steps.deployment.outputs.page_url }}
     runs-on: ubuntu-latest
     needs: build
-    # if: github.ref == 'refs/heads/main'
+    if: github.ref == 'refs/heads/main'
     steps:
       - name: Deploy to GitHub Pages
         id: deployment

--- a/.github/workflows/web.yml
+++ b/.github/workflows/web.yml
@@ -108,7 +108,7 @@ jobs:
         env:
           BASE_PATH: "/Bailo"
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v1
+        uses: actions/upload-pages-artifact@v3
         with:
           path: ./lib/landing/out
 
@@ -128,4 +128,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v1
+        uses: actions/deploy-pages@v4

--- a/.github/workflows/web.yml
+++ b/.github/workflows/web.yml
@@ -124,7 +124,7 @@ jobs:
       url: ${{ steps.deployment.outputs.page_url }}
     runs-on: ubuntu-latest
     needs: build
-    if: github.ref == 'refs/heads/main'
+    # if: github.ref == 'refs/heads/main'
     steps:
       - name: Deploy to GitHub Pages
         id: deployment


### PR DESCRIPTION
To pre-emptively fix an upcoming deprecation of "Deprecation notice: v1, v2, and v3 of the artifact actions" e.g. https://github.com/gchq/Bailo/actions/runs/12254206960
> The following artifacts were uploaded using a version of actions/upload-artifact that is scheduled for deprecation: "github-pages".
Please update your workflow to use v4 of the artifact actions.
Learn more: https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/