### PR TITLE
BAI-1495 improve READMEs

### DIFF
--- a/.github/ISSUE_TEMPLATE/1-bug-report.md
+++ b/.github/ISSUE_TEMPLATE/1-bug-report.md
@@ -6,7 +6,7 @@ about: Create a report to help us improve Bailo
 <!--
 Thank you for reporting a possible bug in Bailo.  Below is a template of useful information you can provide to help us out.
 
-Sometimes the issue is obvious, feel free to remove any categories that don't apply.
+Sometimes the issue is obvious, feel free to remove any categories that do not apply.
 -->
 
 ### Subject of the issue

--- a/.github/ISSUE_TEMPLATE/2-feature-request.md
+++ b/.github/ISSUE_TEMPLATE/2-feature-request.md
@@ -6,17 +6,17 @@ about: Suggest an idea for this project
 <!--
 Thank you for suggesting an idea to make Bailo better.
 
-Please fill in as much of the template below as you're able.
+Please fill in as much of the template below as you are able.
 -->
 
 ## Is your feature request related to a problem? Please describe.
 
 Please describe the problem you are trying to solve
 
-## Describe the solution you'd like
+## Describe the solution you would like
 
 Please describe the desired behaviour
 
-## Describe alternatives you've considered
+## Describe alternatives you have considered
 
 Please describe alternative solutions or features you have considered

--- a/README.md
+++ b/README.md
@@ -2,8 +2,12 @@
 [![Stargazers][stars-shield]][stars-url] [![Issues][issues-shield]][issues-url]
 [![License][license-shield]][license-url]
 
-> **NOTE: `main` branch now tracks `v2` by default. To access the original Bailo, see the `v1` branch. `v1` is in the
-> process of being removed from this project, see [migration]() for more information.**
+<!-- prettier-ignore-start -->
+> [!NOTE]
+> `main` branch now tracks `v2` by default. To access the legacy Bailo, see the `v1` branch. `v1` has been removed
+> from this project - see [migrations](https://gchq.github.io/Bailo/docs/administration/migrations/bailo-2.0) for more
+> information.
+<!-- prettier-ignore-end -->
 
 <!-- PROJECT LOGO -->
 <br />
@@ -40,13 +44,16 @@
     <li>
       <a href="#getting-started">Getting Started</a>
       <ul>
-        <li><a href="#prerequisites">Prerequisites</a></li>
+        <li><a href="#requirements">Requirements</a></li>
         <li><a href="#installation">Installation</a></li>
+        <li><a href="#service-ports">Service Ports</a></li>
+        <li><a href="#logical-project-flow-overview">Logical Project Flow (Overview)</a></li>
+        <li><a href="#known-issues">Known Issues</a></li>
       </ul>
     </li>
     <li><a href="#usage">Usage</a></li>
     <li><a href="#contributing">Contributing</a></li>
-    <li><a href="#breaking">Breaking Changes</a></li>
+    <li><a href="#breaking-changes">Breaking Changes</a></li>
     <li><a href="#license">License</a></li>
     <li><a href="#acknowledgments">Acknowledgments</a></li>
   </ol>
@@ -76,14 +83,14 @@ sharing.
 
 ## Getting Started
 
-### Requirements:
+### Requirements
 
 - Node v22
 - Docker / Docker Compose
 
 <br />
 
-### Installation:
+### Installation
 
 To run in standalone mode, not development mode (http://localhost:8080). Not for production use:
 
@@ -116,7 +123,7 @@ JWKS file for the public key referenced in the backend application configuration
 
 <br />
 
-### Service Ports:
+### Service Ports
 
 | Service    | Host  | Notes                 |
 | ---------- | ----- | --------------------- |
@@ -149,29 +156,26 @@ You can test out your new deployment using the example models which can be found
 
 1. A user accesses a URL. We use [NextJS routing](https://nextjs.org/docs/routing/introduction) to point it to a file in
    `frontend/pages`. `[xxx].tsx` files accept any route, `xxx.tsx` files allow only that specific route.
-2. Data is loaded using [SWR](https://swr.vercel.app/). Data loaders are stored in `./frontend/data`. Each one exposes
+2. Data is loaded using [SWR](https://swr.vercel.app/). Data loaders are stored in `frontend/actions`. Each one exposes
    variables to specify if it is loading, errored, data, etc.
-3. Requests to the backend get routed through [express](https://expressjs.com/) within `backend/routes.ts`. Each route
-   is an array with all items being middleware except the last, which is the handler (`[...middleware, handler]`).
-4. Routes interact with the database via `mongoose`, which stores models in `./backend/models`.
+3. Requests to the backend get routed through [express](https://expressjs.com/) within `backend/src/routes.ts`. Each
+   route is an array with all items being middleware except the last, which is the handler (`[...middleware, handler]`).
+4. Routes interact with the database via `mongoose`, which stores models in `backend/src/models`.
 
 <br />
 
 ### Known Issues
 
-_Issue: Sometimes Docker struggles when you add a new dependency._
+- _Issue: Sometimes Docker struggles when you add a new dependency._ <br /> Fix: Run `docker compose down --rmi all`
+  followed by `docker compose up --build`.
 
-Fix: Run `docker compose down --rmi all` followed by `docker compose up --build`.
+- _Issue: Sometimes SWR fails to install its own binary and the project will refuse to start up (development only)_
+  <br /> Fix: Run `npm uninstall next && npm install next`. Some users report still having issues. If so, run:
+  `rm -rf node_modules && rm -rf package-lock.json && npm cache clean -f && npm i`.
 
-_Issue: Sometimes SWR fails to install its own binary and the project will refuse to start up (development only)_
-
-Fix: Run `npm uninstall next && npm install next`. Some users report still having issues. If so, run:
-`rm -rf node_modules && rm -rf package-lock.json && npm cache clean -f && npm i`.
-
-_Issue: Unable to authenticate to the Docker registry / compile binaries._
-
-Fix: Make sure that your authentication proxy is setup to allow the 'Authorisation' header. Make sure that your
-application is able to access the Docker registry internally as it will not provide user authentication.
+- _Issue: Unable to authenticate to the Docker registry / compile binaries._ <br /> Fix: Make sure that your
+  authentication proxy is setup to allow the 'Authorisation' header. Make sure that your application is able to access
+  the Docker registry internally as it will not provide user authentication.
 
 <br />
 
@@ -185,7 +189,20 @@ See [our user documentation](https://gchq.github.io/Bailo/docs)
 
 ## Contributing
 
-See [our contribution guide](https://gchq.github.io/Bailo/docs/developers/contributing)
+If you're looking for an existing issue to help with, check out the
+[help wanted tickets](https://github.com/gchq/bailo/issues?q=is%3Aopen+is%3Aissue+label%3A%22help+wanted%22) on GitHub.
+If you see any that you’re interested in working on, comment on it to let everyone know you’re working on it. If there’s
+no ticket for what you want to contribute, start a [new issue](https://github.com/gchq/bailo/issues) to discuss whether
+it follows the aims of this project. We ask this even for bugs, as there may be multiple solutions to be considered.
+
+Prior to us accepting any work, you must sign the [GCHQ CLA Agreement](https://cla-assistant.io/gchq/Bailo). We follow a
+branching strategy for handling contributions:
+
+1. Fork the Project
+2. Create your Feature Branch (`git checkout -b feature/new_thing`)
+3. Commit your Changes (`git commit -m 'Add a new thing'`)
+4. Push to the Branch (`git push origin feature/new_thing`)
+5. Open a Pull Request
 
 <br />
 
@@ -228,7 +245,3 @@ information.
 [license-shield]: https://img.shields.io/github/license/gchq/bailo.svg?style=for-the-badge
 [license-url]: https://github.com/gchq/bailo/blob/main/public/LICENSE.txt
 [product-screenshot]: frontend/public/images/bailo-marketplace.png
-
-```
-
-```

--- a/README.md
+++ b/README.md
@@ -189,11 +189,12 @@ See [our user documentation](https://gchq.github.io/Bailo/docs)
 
 ## Contributing
 
-If you're looking for an existing issue to help with, check out the
+If you are looking for an existing issue to help with, check out the
 [help wanted tickets](https://github.com/gchq/bailo/issues?q=is%3Aopen+is%3Aissue+label%3A%22help+wanted%22) on GitHub.
-If you see any that you’re interested in working on, comment on it to let everyone know you’re working on it. If there’s
-no ticket for what you want to contribute, start a [new issue](https://github.com/gchq/bailo/issues) to discuss whether
-it follows the aims of this project. We ask this even for bugs, as there may be multiple solutions to be considered.
+If you see any that you’re interested in working on, comment on it to let everyone know you’re working on it. If there
+is no ticket for what you want to contribute, start a [new issue](https://github.com/gchq/bailo/issues) to discuss
+whether it follows the aims of this project. We ask this even for bugs, as there may be multiple solutions to be
+considered.
 
 Prior to us accepting any work, you must sign the [GCHQ CLA Agreement](https://cla-assistant.io/gchq/Bailo). We follow a
 branching strategy for handling contributions:

--- a/README.md
+++ b/README.md
@@ -191,7 +191,7 @@ See [our user documentation](https://gchq.github.io/Bailo/docs)
 
 If you are looking for an existing issue to help with, check out the
 [help wanted tickets](https://github.com/gchq/bailo/issues?q=is%3Aopen+is%3Aissue+label%3A%22help+wanted%22) on GitHub.
-If you see any that you’re interested in working on, comment on it to let everyone know you’re working on it. If there
+If you see any that you are interested in working on, comment on it to let everyone know you are working on it. If there
 is no ticket for what you want to contribute, start a [new issue](https://github.com/gchq/bailo/issues) to discuss
 whether it follows the aims of this project. We ask this even for bugs, as there may be multiple solutions to be
 considered.

--- a/backend/docs/make.bat
+++ b/backend/docs/make.bat
@@ -19,7 +19,7 @@ if errorlevel 9009 (
 	echo.to the full path of the 'sphinx-build' executable. Alternatively you
 	echo.may add the Sphinx directory to PATH.
 	echo.
-	echo.If you don't have Sphinx installed, grab it from
+	echo.If you do not have Sphinx installed, grab it from
 	echo.https://www.sphinx-doc.org/
 	exit /b 1
 )

--- a/backend/docs/notebooks/experiment_tracking_demo.ipynb
+++ b/backend/docs/notebooks/experiment_tracking_demo.ipynb
@@ -38,7 +38,7 @@
     "\n",
     "### Connecting with Bailo\n",
     "\n",
-    "In order to create an `Experiment()` object, you'll first need to have a Bailo `Model()` object, and thus a defined `Client()` too. We learned how to do this in a previous notebook, but this time we will create a new model with a custom schema which supports model metrics. *More on that later...*"
+    "In order to create an `Experiment()` object, you will first need to have a Bailo `Model()` object, and thus a defined `Client()` too. We learned how to do this in a previous notebook, but this time we will create a new model with a custom schema which supports model metrics. *More on that later...*"
    ]
   },
   {

--- a/backend/docs/pylint.md
+++ b/backend/docs/pylint.md
@@ -430,7 +430,7 @@ contextmanager-decorators=contextlib.contextmanager
 
 # List of members which are set dynamically and missed by pylint inference
 
-# system, and so shouldn't trigger E1101 when accessed. Python regular
+# system, and so should not trigger E1101 when accessed. Python regular
 
 # expressions are accepted.
 

--- a/lib/modelscan_api/README.md
+++ b/lib/modelscan_api/README.md
@@ -11,7 +11,10 @@ This directory provides all of the necessary functionality to interact with
 
 ## Setup
 
-Note that **Python 3.9 to 3.12** is required.
+<!-- prettier-ignore-start -->
+> [!IMPORTANT]
+> Python 3.9 to 3.12 is required
+<!-- prettier-ignore-end -->
 
 Create and activate a virtual environment
 


### PR DESCRIPTION
Fix some broken links, out if date resources and generally tidy up readmes.

Relates to #1574 but does not fully fix this problem as the legacy file is still referenced in `frontend/pages/docs/directory.tsx` and `frontend/pages/docs/administration/helm/configuration.mdx`.