### PR TITLE
feat: add keycloak authentication closes #1634

### DIFF
--- a/backend/src/clients/cognito.ts
+++ b/backend/src/clients/cognito.ts
@@ -12,6 +12,9 @@ export async function listUsers(query: string, exactMatch = false) {
   let dnName: string
   let userPoolId: string
   try {
+    if (!config?.oauth?.cognito) {
+      throw ConfigurationError('OAuth Cognito configuration is missing')
+    }
     dnName = config.oauth.cognito.userIdAttribute
     userPoolId = config.oauth.cognito.userPoolId
   } catch (e) {

--- a/backend/src/clients/keycloak.ts
+++ b/backend/src/clients/keycloak.ts
@@ -1,0 +1,82 @@
+import { UserInformation } from '../connectors/authentication/Base.js'
+import config from '../utils/config.js'
+import { ConfigurationError, InternalError } from '../utils/error.js'
+
+export async function listUsers(query: string, exactMatch = false) {
+  let dnName: string
+  let realm: string
+  try {
+    if (!config?.oauth?.keycloak) {
+      throw ConfigurationError('OAuth Keycloak configuration is missing')
+    }
+    realm = config.oauth.keycloak.realm
+  } catch (e) {
+    throw ConfigurationError('Cannot find userIdAttribute in oauth configuration', { oauthConfiguration: config?.oauth })
+  }
+
+  const token = await getKeycloakToken()
+
+  const filter = exactMatch ? `${query}` : `${query}*`
+  const url = `${config.oauth.keycloak.authServerUrl}/admin/realms/${realm}/users?search=${filter}`
+
+  let results
+  try {
+    results = await fetch(url, {
+      method: 'GET',
+      headers: {
+        Authorization: `Bearer ${token}`
+      }
+    })
+  } catch (err) {
+    throw InternalError('Error when querying Keycloak for users.', { err })
+  }
+  const resultsData = await results.json() as { data: any[] }
+  if (!resultsData.data) {
+    return []
+  }
+
+  const initialValue: Array<UserInformation & { dn: string }> = []
+  const users = resultsData.data.reduce((acc, keycloakUser) => {
+    const dn = keycloakUser[dnName]
+    if (!dn) {
+      return acc
+    }
+    const email = keycloakUser.email
+    const name = keycloakUser.firstName
+    const info: UserInformation = {
+      ...(email && { email }),
+      ...(name && { name }),
+    }
+    acc.push({ ...info, dn })
+    return acc
+  }, initialValue)
+  return users
+}
+
+async function getKeycloakToken() {
+  if (!config?.oauth?.keycloak) {
+    throw ConfigurationError('OAuth Keycloak configuration is missing')
+  }
+  const url = `${config.oauth.keycloak.authServerUrl}/realms/${config.oauth.keycloak.realm}/protocol/openid-connect/token`
+  const params = new URLSearchParams()
+  params.append('client_id', config.oauth.keycloak.clientId)
+  params.append('client_secret', config.oauth.keycloak.clientSecret)
+  params.append('grant_type', 'client_credentials')
+
+  try {
+    const response = await fetch(url, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/x-www-form-urlencoded'
+      },
+      body: params
+    })
+    const data = await response.json() as { access_token: string }
+    if (!data.access_token) {
+      throw InternalError('Access token is missing in the response', { response: data })
+    }
+    return data.access_token
+  } catch (err) {
+    throw InternalError('Error when obtaining Keycloak token.', { err })
+  }
+}

--- a/backend/src/connectors/authentication/oauth.ts
+++ b/backend/src/connectors/authentication/oauth.ts
@@ -3,13 +3,25 @@ import { NextFunction, Request, Response, Router } from 'express'
 import session from 'express-session'
 import grant from 'grant'
 
-import { listUsers } from '../../clients/cognito.js'
+import { listUsers as listUsersCognito } from '../../clients/cognito.js'
+import { listUsers as listUsersKeycloak } from '../../clients/keycloak.js'
+
 import { UserInterface } from '../../models/User.js'
 import config from '../../utils/config.js'
 import { getConnectionURI } from '../../utils/database.js'
 import { fromEntity, toEntity } from '../../utils/entity.js'
 import { InternalError, NotFound } from '../../utils/error.js'
 import { BaseAuthenticationConnector, RoleKeys, UserInformation } from './Base.js'
+
+function listUsers(query: string, exactMatch = false) {
+  if (config.oauth.cognito) {
+    return listUsersCognito(query, exactMatch)
+  } else if (config.oauth.keycloak) {
+    return listUsersKeycloak(query, exactMatch)
+  } else {
+    throw InternalError('No oauth configuration found', { oauthConfiguration: config.oauth })
+  }
+}
 
 const OauthEntityKind = {
   User: 'user',

--- a/backend/src/utils/config.ts
+++ b/backend/src/utils/config.ts
@@ -123,7 +123,7 @@ export interface Config {
       realm: string
       clientId: string
       clientSecret: string
-      authServerUrl: string
+      serverUrl: string
     }
   }
 

--- a/backend/src/utils/config.ts
+++ b/backend/src/utils/config.ts
@@ -114,10 +114,16 @@ export interface Config {
   oauth: {
     provider: string
     grant: grant.GrantConfig | grant.GrantOptions
-    cognito: {
+    cognito?: {
       identityProviderClient: { region: string; credentials: { accessKeyId: string; secretAccessKey: string } }
       userPoolId: string
       userIdAttribute: string
+    }
+    keycloak?: {
+      realm: string
+      clientId: string
+      clientSecret: string
+      authServerUrl: string
     }
   }
 
@@ -172,4 +178,12 @@ export interface Config {
 }
 
 const config: Config = _config.util.toObject()
+
+if (config.oauth &&
+  !config.oauth.keycloak &&
+  !config.oauth.cognito
+) {
+  throw new Error('If OAuth is configured, either Keycloak or Cognito configuration must be provided.')
+}
+
 export default deepFreeze(config) as Config


### PR DESCRIPTION
### Affected core subsystem(s)

Alterations of the backend to support keycloak as an OAuth mechanism for user lookup functionality. 

### Description of change

I've got grant working with keycloak using the below config:
```js
oauth: {
    provider: 'keycloak',

    grant: {
      defaults: {
        origin: 'http://localhost:8080',
        prefix: '/api/connect',
        transport: 'session',
      },

      keycloak: {
        key: 'bailo_app',
        secret: 'client_secret',
        dynamic: ['scope'],
        access_url: 'http://keycloak:8080/realms/bailo/protocol/openid-connect/token', // internal/backend container accessible route
        response: ['tokens', 'raw', 'jwt'],
        callback: '/',
        authorize_url: 'http://localhost:8888/realms/bailo/protocol/openid-connect/auth', // public url
        scope: ['openid'],
      },
    },
}
```

To support this authentication mechanism the backend needs updating to support another client from cognito so the code changes made are in aim of supporting multiple providers naively. This required the following changes:
- additional config is required to communicate with keycloak for user list interactivity
- creating the code to mimic the cognito client for keycloak to actually 'get' users
- enabling a toggle system based on the config for the application to load the correct provider
- updating the existing cognito client to recognise optional config

The aim is you can do this with the config:
```js
    // cognito: {
    //   identityProviderClient: {
    //     region: 'eu-west-1',
    //     credentials: {
    //       accessKeyId: '',
    //       secretAccessKey: '',
    //     },
    //     userPoolId: '',
    //   },
    // },

    keycloak: {
      realm: 'baio',
      clientId: 'client_id',
      clientSecret: 'client_secret',
      serverUrl: 'http://keycloak:8080', // internal route 
    }
```
---
**so you could use either keycloak or cognito and dont need to specifiy one or the other if they are not required, but i'll take your guidance on how we do this multiple provider interactivity!**

---
Appreciate this is naïve implementation so feedback is appreciated!
