### PR TITLE
BAI-1591 drop python 3.8 support and standardise versioning

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.8', '3.11']
+        python-version: ['3.9', '3.12']
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.9', '3.12']
+        python-version: ['3.9', '3.11']
 
     steps:
       - uses: actions/checkout@v4

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1
-FROM python:3.13.1-bullseye AS sphinx-docs
+FROM python:3.12.8-bullseye AS sphinx-docs
 
 RUN apt update && apt install -y pandoc
 

--- a/backend/Dockerfile.dev
+++ b/backend/Dockerfile.dev
@@ -1,4 +1,4 @@
-FROM python:3.13.1-bullseye AS sphinx-docs
+FROM python:3.12.8-bullseye AS sphinx-docs
 
 RUN apt update && apt install -y pandoc
 

--- a/backend/docs/README.md
+++ b/backend/docs/README.md
@@ -33,7 +33,7 @@ Documentation is rendered with Sphinx and served [here](https://gchq.github.io/B
 
 <!-- prettier-ignore-start -->
 > [!IMPORTANT]
-> Python 3.8.1 or higher is required
+> Python 3.9 or higher is required
 <!-- prettier-ignore-end -->
 
 #### Prerequisites

--- a/backend/docs/notebooks/access_requests_demo.ipynb
+++ b/backend/docs/notebooks/access_requests_demo.ipynb
@@ -22,7 +22,7 @@
     "\n",
     "Prerequisites:\n",
     "\n",
-    "* Python 3.8.1 or higher (including a notebook environment for this demo).\n",
+    "* Python 3.9 or higher (including a notebook environment for this demo).\n",
     "* A local or remote Bailo service (see https://github.com/gchq/Bailo)."
    ]
   },

--- a/backend/docs/notebooks/datacards_demo.ipynb
+++ b/backend/docs/notebooks/datacards_demo.ipynb
@@ -20,7 +20,7 @@
     "\n",
     "Prerequisites:\n",
     "\n",
-    "* Python 3.8.1 or higher (including a notebook environment for this demo).\n",
+    "* Python 3.9 or higher (including a notebook environment for this demo).\n",
     "* A local or remote Bailo service (see https://github.com/gchq/Bailo)."
    ]
   },

--- a/backend/docs/notebooks/experiment_tracking_demo.ipynb
+++ b/backend/docs/notebooks/experiment_tracking_demo.ipynb
@@ -23,7 +23,7 @@
     "Prerequisites:\n",
     "\n",
     "* Completion of the basic notebooks, in particular **models_and_releases_demo_pytorch.ipynb**.\n",
-    "* Python 3.8.1 or higher (including a notebook environment for this demo).\n",
+    "* Python 3.9 or higher (including a notebook environment for this demo).\n",
     "* A local or remote Bailo service (see https://github.com/gchq/Bailo).\n",
     "* Dependencies for MLFlow.\n",
     "* A local or remote MLFlow Tracking server, if following the MLFlow steps.\n"

--- a/backend/docs/notebooks/models_and_releases_demo_pytorch.ipynb
+++ b/backend/docs/notebooks/models_and_releases_demo_pytorch.ipynb
@@ -23,7 +23,7 @@
     "\n",
     "Prerequisites:\n",
     "\n",
-    "* Python 3.8.1 or higher (including a notebook environment for this demo).\n",
+    "* Python 3.9 or higher (including a notebook environment for this demo).\n",
     "* A local or remote Bailo service (see https://github.com/gchq/Bailo).\n"
    ]
   },

--- a/backend/docs/notebooks/schemas_demo.ipynb
+++ b/backend/docs/notebooks/schemas_demo.ipynb
@@ -20,7 +20,7 @@
         "\n",
         "Prerequisites:\n",
         "\n",
-        "* Python 3.8.1 or higher (including a notebook environment for this demo).\n",
+        "* Python 3.9 or higher (including a notebook environment for this demo).\n",
         "* A local or remote Bailo service (see https://github.com/gchq/Bailo)."
       ]
     },
@@ -134,7 +134,7 @@
         "    json_schema=json_schema\n",
         ")\n",
         "\n",
-        "schema_id = schema.schema_id "
+        "schema_id = schema.schema_id"
       ]
     },
     {

--- a/lib/python/README.md
+++ b/lib/python/README.md
@@ -44,7 +44,7 @@ A simple Python API Wrapper for Bailo
 
 <!-- prettier-ignore-start -->
 > [!IMPORTANT]
-> Python 3.8.1 or higher is required
+> Python 3.9 or higher is required
 <!-- prettier-ignore-end -->
 
 ```bash

--- a/lib/python/pyproject.toml
+++ b/lib/python/pyproject.toml
@@ -13,7 +13,7 @@ classifiers = [
     "License :: OSI Approved :: MIT License",
     "Programming Language :: Python :: 3 :: Only",
     "Programming Language :: Python :: 3.9",
-    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.11",
 ]
 requires-python = ">=3.9"
 dynamic = ["version"]

--- a/lib/python/pyproject.toml
+++ b/lib/python/pyproject.toml
@@ -12,10 +12,10 @@ classifiers = [
     "Intended Audience :: Developers",
     "License :: OSI Approved :: MIT License",
     "Programming Language :: Python :: 3 :: Only",
-    "Programming Language :: Python :: 3.8",
-    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.9",
+    "Programming Language :: Python :: 3.12",
 ]
-requires-python = ">=3.8.1"
+requires-python = ">=3.9"
 dynamic = ["version"]
 dependencies = [
     "semantic-version==2.10.0",


### PR DESCRIPTION
As per https://devguide.python.org/versions/, python 3.8 reached end of life on 2024-10-07 so no longer requires support. For the python Bailo client, we must replace all references to 3.8 with 3.9.

The Modelscan REST API already has a minimum version of python 3.9 so this does not need changing.

I also found some mismatching versions for the maximum supported python version (currently 3.11, but this needs bumping to 3.13 soon).