### PR TITLE
Potential fix for code scanning alert no. 47: Clear text transmission of sensitive cookie

### DIFF
--- a/backend/src/connectors/authentication/oauth.ts
+++ b/backend/src/connectors/authentication/oauth.ts
@@ -28,7 +28,7 @@ export class OauthAuthenticationConnector extends BaseAuthenticationConnector {
             secret: config.session.secret,
             resave: true,
             saveUninitialized: true,
-            cookie: { maxAge: 30 * 24 * 60 * 60000 }, // store for 30 days
+            cookie: { maxAge: 30 * 24 * 60 * 60000, secure: true, httpOnly: true }, // store for 30 days
             store: MongoStore.create({
               mongoUrl: getConnectionURI(),
             }),


### PR DESCRIPTION
Potential fix for [https://github.com/gchq/Bailo/security/code-scanning/47](https://github.com/gchq/Bailo/security/code-scanning/47)

To fix the problem, we need to ensure that the session cookie is only transmitted over HTTPS by setting the `secure` attribute to `true`. This can be done by modifying the `session` middleware configuration to include the `secure` attribute in the `cookie` object. Additionally, we should set the `httpOnly` attribute to `true` to prevent client-side scripts from accessing the cookie, further enhancing security.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
