### PR TITLE
Dependabot config for python and docker compose

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -173,12 +173,39 @@ updates:
     # Look for a `requirements*` or `pyproject.toml` in these directories
     directories:
       - '/lib/python'
+    schedule:
+      interval: 'weekly'
+    versioning-strategy: increase
+    open-pull-requests-limit: 10
+    labels:
+      - 'python dependencies'
+      - '/lib/python'
+
+  # Enable version updates for python
+  - package-ecosystem: 'pip'
+    # Look for a `requirements*` or `pyproject.toml` in these directories
+    directories:
       - '/lib/modelscan_api'
+    schedule:
+      interval: 'weekly'
+    versioning-strategy: increase
+    open-pull-requests-limit: 10
+    labels:
+      - 'python dependencies'
+      - '/lib/modelscan_api'
+
+  # Enable version updates for python
+  - package-ecosystem: 'pip'
+    # Look for a `requirements*` or `pyproject.toml` in these directories
+    directories:
       - '/backend/docs'
     schedule:
       interval: 'weekly'
     versioning-strategy: increase
     open-pull-requests-limit: 10
+    labels:
+      - 'python dependencies'
+      - '/backend/docs'
 
   # Set update schedule for GitHub Actions
   - package-ecosystem: 'github-actions'

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -43,6 +43,9 @@ updates:
         patterns:
           - "@mdx-js/*"
           - "@next/mdx"
+    labels:
+      - 'npm dependencies'
+      - '/'
 
   - package-ecosystem: 'npm'
     # Look for `package.json` and `lock` files in the `/frontend` directory
@@ -80,6 +83,9 @@ updates:
         patterns:
           - "@mdx-js/*"
           - "@next/mdx"
+    labels:
+      - 'npm dependencies'
+      - '/frontend'
 
   - package-ecosystem: 'npm'
     # Look for `package.json` and `lock` files in the `/lib/landing` directory
@@ -117,6 +123,9 @@ updates:
         patterns:
           - "@mdx-js/*"
           - "@next/mdx"
+    labels:
+      - 'npm dependencies'
+      - '/lib/landing'
 
   - package-ecosystem: 'npm'
     # Look for `package.json` and `lock` files in the `/backend` directory
@@ -154,6 +163,9 @@ updates:
         patterns:
           - "@mdx-js/*"
           - "@next/mdx"
+    labels:
+      - 'npm dependencies'
+      - '/backend'
 
   # Enable version updates for Docker
   - package-ecosystem: 'docker'
@@ -163,6 +175,16 @@ updates:
       - '/backend'
       - '/frontend'
       - '/lib/modelscan_api'
+    # Check for updates once a week
+    schedule:
+      interval: 'weekly'
+    open-pull-requests-limit: 10
+
+  # Enable version updates for Docker Compose
+  - package-ecosystem: 'docker-compose'
+    # Look for docker-compose in these directories
+    directories:
+      - '/'
     # Check for updates once a week
     schedule:
       interval: 'weekly'


### PR DESCRIPTION
- Add docker-compose to dependabot config
- Split python config into each directory so that upgrade checks are isolated. Previously, dependabot was failing to resolve some updates as it treated all of the directories as a single environment