### PR TITLE
Update Scan errors

### DIFF
--- a/backend/src/connectors/audit/stdout.ts
+++ b/backend/src/connectors/audit/stdout.ts
@@ -79,7 +79,7 @@ export class StdoutAuditConnector extends BaseAuditConnector {
 
   onCreateFile(req: Request, file: FileInterfaceDoc) {
     this.checkEventType(AuditInfo.CreateFile, req)
-    const event = this.generateEvent(req, { id: file._id, modelId: file.modelId })
+    const event = this.generateEvent(req, { id: file._id.toString(), modelId: file.modelId })
     req.log.info(event, req.audit.description)
   }
 
@@ -91,7 +91,7 @@ export class StdoutAuditConnector extends BaseAuditConnector {
 
   onViewFiles(req: Request, modelId: string, files: FileInterface[]) {
     this.checkEventType(AuditInfo.ViewFiles, req)
-    const event = this.generateEvent(req, { modelId, results: files.map((file) => file._id) })
+    const event = this.generateEvent(req, { modelId, results: files.map((file) => file._id.toString()) })
     req.log.info(event, req.audit.description)
   }
 

--- a/backend/src/connectors/fileScanning/Base.ts
+++ b/backend/src/connectors/fileScanning/Base.ts
@@ -14,25 +14,31 @@ export const ScanState = {
 } as const
 export type ScanStateKeys = (typeof ScanState)[keyof typeof ScanState]
 
-export abstract class BaseFileScanningConnector {
-  abstract readonly toolName: string
+export type FileScanningConnectorInfo = Pick<FileScanResult, 'toolName' | 'scannerVersion'>
 
-  abstract info(): string[]
+export abstract class BaseFileScanningConnector {
+  abstract info(): Promise<FileScanningConnectorInfo>
   abstract scan(file: FileInterface): Promise<FileScanResult[]>
 
-  getScannerVersion(): Promise<string | void> {
-    // default to promise undefined, but allow child classes to override this
-    return Promise.resolve(undefined)
-  }
-
-  async scanError(error: unknown, file: FileInterface): Promise<FileScanResult[]> {
-    const scannerVersion = await this.getScannerVersion()
-    log.error({ error, modelId: file.modelId, fileId: file._id.toString(), name: file.name }, 'Scan errored.')
+  async scanError(
+    error: unknown | undefined = undefined,
+    file: FileInterface | undefined = undefined,
+    errorMessage: string = 'Scan errored.',
+    extraErrorObj: object = {},
+  ): Promise<FileScanResult[]> {
+    const scannerInfo = await this.info()
+    log.error(
+      {
+        // conditional spreading operator so that objects are only used if they exist
+        ...(error !== undefined ? { error } : {}),
+        ...(file !== undefined ? { modelId: file.modelId, fileId: file._id.toString(), name: file.name } : {}),
+        ...extraErrorObj,
+      },
+      errorMessage,
+    )
     return [
       {
-        toolName: this.toolName,
-        // include scannerVersion if it is defined
-        ...(scannerVersion !== undefined ? { scannerVersion } : {}),
+        ...scannerInfo,
         state: ScanState.Error,
         lastRunAt: new Date(),
       },

--- a/backend/src/connectors/fileScanning/Base.ts
+++ b/backend/src/connectors/fileScanning/Base.ts
@@ -1,5 +1,6 @@
 import { FileInterface } from '../../models/File.js'
 import { ScanInterface } from '../../models/Scan.js'
+import log from '../../services/log.js'
 export type FileScanResult = Pick<
   ScanInterface,
   'toolName' | 'scannerVersion' | 'state' | 'isInfected' | 'viruses' | 'lastRunAt'
@@ -14,6 +15,27 @@ export const ScanState = {
 export type ScanStateKeys = (typeof ScanState)[keyof typeof ScanState]
 
 export abstract class BaseFileScanningConnector {
+  abstract readonly toolName: string
+
   abstract info(): string[]
   abstract scan(file: FileInterface): Promise<FileScanResult[]>
+
+  getScannerVersion(): Promise<string | void> {
+    // default to promise undefined, but allow child classes to override this
+    return Promise.resolve(undefined)
+  }
+
+  async scanError(error: unknown, file: FileInterface): Promise<FileScanResult[]> {
+    const scannerVersion = await this.getScannerVersion()
+    log.error({ error, modelId: file.modelId, fileId: file._id.toString(), name: file.name }, 'Scan errored.')
+    return [
+      {
+        toolName: this.toolName,
+        // include scannerVersion if it is defined
+        ...(scannerVersion !== undefined ? { scannerVersion } : {}),
+        state: ScanState.Error,
+        lastRunAt: new Date(),
+      },
+    ]
+  }
 }

--- a/backend/src/connectors/fileScanning/clamAv.ts
+++ b/backend/src/connectors/fileScanning/clamAv.ts
@@ -50,14 +50,11 @@ export class ClamAvFileScanningConnector extends BaseFileScanningConnector {
 
   async scan(file: FileInterfaceDoc): Promise<FileScanResult[]> {
     if (!av) {
-      return [
-        {
-          ...(await this.info()),
-          state: ScanState.Error,
-          scannerVersion: 'Unknown',
-          lastRunAt: new Date(),
-        },
-      ]
+      return await this.scanError(
+        undefined,
+        undefined,
+        `Could not use ${(await this.info()).toolName} as it is not running`,
+      )
     }
     const s3Stream = (await getObjectStream(file.bucket, file.path)).Body as Readable
     try {

--- a/backend/src/connectors/fileScanning/clamAv.ts
+++ b/backend/src/connectors/fileScanning/clamAv.ts
@@ -66,7 +66,7 @@ export class ClamAvFileScanningConnector extends BaseFileScanningConnector {
       const { isInfected, viruses } = await av.scanStream(s3Stream)
       const scannerVersion = await this.getScannerVersion()
       log.info(
-        { modelId: file.modelId, fileId: file._id, name: file.name, result: { isInfected, viruses } },
+        { modelId: file.modelId, fileId: file._id.toString(), name: file.name, result: { isInfected, viruses } },
         'Scan complete.',
       )
       return [

--- a/backend/src/connectors/fileScanning/index.ts
+++ b/backend/src/connectors/fileScanning/index.ts
@@ -12,7 +12,7 @@ export const FileScanKind = {
 export type FileScanKindKeys = (typeof FileScanKind)[keyof typeof FileScanKind]
 
 const fileScanConnectors: BaseFileScanningConnector[] = []
-let scannerWrapper: undefined | BaseFileScanningConnector = undefined
+let scannerWrapper: undefined | FileScanningWrapper = undefined
 export function runFileScanners(cache = true) {
   if (scannerWrapper && cache) {
     return scannerWrapper

--- a/backend/src/connectors/fileScanning/wrapper.ts
+++ b/backend/src/connectors/fileScanning/wrapper.ts
@@ -1,6 +1,6 @@
 import { FileInterface } from '../../models/File.js'
 import log from '../../services/log.js'
-import { BaseFileScanningConnector, FileScanResult } from './Base.js'
+import { BaseFileScanningConnector, FileScanningConnectorInfo, FileScanResult } from './Base.js'
 
 export class FileScanningWrapper extends BaseFileScanningConnector {
   toolName = this.constructor.name
@@ -11,12 +11,14 @@ export class FileScanningWrapper extends BaseFileScanningConnector {
     this.scanners = scanners
   }
 
-  info() {
-    const scannerNames: string[] = []
-    for (const scanner of this.scanners) {
-      scannerNames.push(...scanner.info())
-    }
-    return scannerNames
+  async info(): Promise<FileScanningConnectorInfo & { scannerNames: string[] }> {
+    const scannersInfo = await Promise.all(
+      this.scanners.map(async (scanner) => {
+        return await scanner.info()
+      }),
+    )
+    const scannerNames = scannersInfo.map((scannerInfo) => scannerInfo.toolName)
+    return { toolName: this.constructor.name, scannerNames: scannerNames }
   }
 
   async scan(file: FileInterface) {

--- a/backend/src/connectors/fileScanning/wrapper.ts
+++ b/backend/src/connectors/fileScanning/wrapper.ts
@@ -3,6 +3,7 @@ import log from '../../services/log.js'
 import { BaseFileScanningConnector, FileScanResult } from './Base.js'
 
 export class FileScanningWrapper extends BaseFileScanningConnector {
+  toolName = this.constructor.name
   scanners: BaseFileScanningConnector[] = []
 
   constructor(scanners: BaseFileScanningConnector[]) {
@@ -22,7 +23,7 @@ export class FileScanningWrapper extends BaseFileScanningConnector {
     const results: FileScanResult[] = []
     for (const scanner of this.scanners) {
       log.info(
-        { modelId: file.modelId, fileId: file._id, name: file.name, toolName: scanner.info().pop() },
+        { modelId: file.modelId, fileId: file._id.toString(), name: file.name, toolName: this.toolName },
         'Scan started.',
       )
       const scannerResults = await scanner.scan(file)

--- a/backend/src/migrations/015_migrate_avscan_to_own_model.ts
+++ b/backend/src/migrations/015_migrate_avscan_to_own_model.ts
@@ -14,7 +14,7 @@ export async function up() {
         // create new Scan Document
         const newScan = new ScanModel({
           artefactKind: ArtefactKind.File,
-          fileId: file._id,
+          fileId: file._id.toString(),
           ...avResult,
           createdAt: file.createdAt,
           updatedAt: file.updatedAt,

--- a/backend/src/routes/v2/filescanning/getFilescanningInfo.ts
+++ b/backend/src/routes/v2/filescanning/getFilescanningInfo.ts
@@ -10,6 +10,6 @@ interface GetFileScanningInfoResponse {
 export const getFilescanningInfo = [
   bodyParser.json(),
   async (req: Request, res: Response<GetFileScanningInfoResponse>) => {
-    return res.json({ scanners: scanners.info() })
+    return res.json({ scanners: (await scanners.info()).scannerNames })
   },
 ]

--- a/backend/src/routes/v2/model/file/getDownloadFile.ts
+++ b/backend/src/routes/v2/model/file/getDownloadFile.ts
@@ -101,7 +101,7 @@ export const getDownloadFile = [
 
     if (req.headers.range) {
       // TODO: support ranges
-      throw BadReq('Ranges are not supported', { fileId: file._id })
+      throw BadReq('Ranges are not supported', { fileId: file._id.toString() })
     }
 
     res.set('Content-Length', String(file.size))
@@ -110,7 +110,7 @@ export const getDownloadFile = [
     const stream = await downloadFile(req.user, file.id)
 
     if (!stream.Body) {
-      throw InternalError('We were not able to retrieve the body of this file', { fileId: file._id })
+      throw InternalError('We were not able to retrieve the body of this file', { fileId: file._id.toString() })
     }
 
     await audit.onViewFile(req, file)

--- a/backend/src/services/file.ts
+++ b/backend/src/services/file.ts
@@ -70,8 +70,9 @@ export async function uploadFile(user: UserInterface, modelId: string, name: str
 
   await file.save()
 
-  if (scanners.info() && fileSize > 0) {
-    const resultsInprogress: FileScanResult[] = scanners.info().map((scannerName) => ({
+  const scannersInfo = await scanners.info()
+  if (scannersInfo && scannersInfo.scannerNames && fileSize > 0) {
+    const resultsInprogress: FileScanResult[] = scannersInfo.scannerNames.map((scannerName) => ({
       toolName: scannerName,
       state: ScanState.InProgress,
       lastRunAt: new Date(),
@@ -285,8 +286,9 @@ export async function rerunFileScan(user: UserInterface, modelId, fileId: string
   if (!auth.success) {
     throw Forbidden(auth.info, { userDn: user.dn })
   }
-  if (scanners.info()) {
-    const resultsInprogress = scanners.info().map((scannerName) => ({
+  const scannersInfo = await scanners.info()
+  if (scannersInfo && scannersInfo.scannerNames) {
+    const resultsInprogress = scannersInfo.scannerNames.map((scannerName) => ({
       toolName: scannerName,
       state: ScanState.InProgress,
       lastRunAt: new Date(),

--- a/backend/src/services/file.ts
+++ b/backend/src/services/file.ts
@@ -59,7 +59,7 @@ export async function uploadFile(user: UserInterface, modelId: string, name: str
 
   const auth = await authorisation.file(user, model, file, FileAction.Upload)
   if (!auth.success) {
-    throw Forbidden(auth.info, { userDn: user.dn, fileId: file._id })
+    throw Forbidden(auth.info, { userDn: user.dn, fileId: file._id.toString() })
   }
 
   const { fileSize } = await putObjectStream(bucket, path, stream)
@@ -80,7 +80,7 @@ export async function uploadFile(user: UserInterface, modelId: string, name: str
     scanners.scan(file).then((resultsArray) => updateFileWithResults(file._id, resultsArray))
   }
 
-  const avScan = await ScanModel.find({ fileId: file._id })
+  const avScan = await ScanModel.find({ fileId: file._id.toString() })
   const ret: FileWithScanResultsInterface = {
     ...file.toObject(),
     avScan,
@@ -93,7 +93,7 @@ export async function uploadFile(user: UserInterface, modelId: string, name: str
 async function updateFileWithResults(_id: Schema.Types.ObjectId, results: FileScanResult[]) {
   for (const result of results) {
     const updateExistingResult = await ScanModel.updateOne(
-      { fileId: _id, toolName: result.toolName },
+      { fileId: _id.toString(), toolName: result.toolName },
       {
         $set: { ...result },
       },
@@ -101,7 +101,7 @@ async function updateFileWithResults(_id: Schema.Types.ObjectId, results: FileSc
     if (updateExistingResult.modifiedCount === 0) {
       await ScanModel.create({
         artefactKind: ArtefactKind.File,
-        fileId: _id,
+        fileId: _id.toString(),
         ...result,
       })
     }
@@ -249,7 +249,7 @@ async function fileScanDelay(file: FileInterface): Promise<number> {
     return 0
   }
   let minutesBeforeRetrying = 0
-  const fileAvScans = await ScanModel.find({ fileId: file._id })
+  const fileAvScans = await ScanModel.find({ fileId: file._id.toString() })
   for (const scanResult of fileAvScans) {
     const delayInMilliseconds = delay * 60000
     const scanTimeAtLimit = scanResult.lastRunAt.getTime() + delayInMilliseconds

--- a/backend/src/services/mirroredModel.ts
+++ b/backend/src/services/mirroredModel.ts
@@ -551,7 +551,7 @@ async function addReleaseToZip(
   try {
     zip.append(JSON.stringify(release.toJSON()), { name: `releases/${release.semver}.json` })
     for (const file of files) {
-      zip.append(JSON.stringify(file), { name: `files/${file._id}.json` })
+      zip.append(JSON.stringify(file), { name: `files/${file._id.toString()}.json` })
       await uploadToS3(
         file.id,
         (await downloadFile(user, file.id)).Body as stream.Readable,

--- a/backend/src/services/mirroredModel.ts
+++ b/backend/src/services/mirroredModel.ts
@@ -595,7 +595,7 @@ async function checkReleaseFiles(user: UserInterface, modelId: string, semvers: 
     }
   }
 
-  if (scanners.info()) {
+  if (await scanners.info()) {
     const files = await getFilesByIds(user, modelId, fileIds)
     const scanErrors: {
       missingScan: Array<{ name: string; id: string }>

--- a/backend/test/services/__snapshots__/file.spec.ts.snap
+++ b/backend/test/services/__snapshots__/file.spec.ts.snap
@@ -88,7 +88,30 @@ exports[`services > file > uploadFile > success 1`] = `
       "calls": [
         [
           {
-            "fileId": [MockFunction spy],
+            "fileId": "function(...s) {
+    let r = T(t);
+    r.called = !0, r.callCount++, r.calls.push(s);
+    let S = r.next.shift();
+    if (S) {
+      r.results.push(S);
+      let [o, g] = S;
+      if (o === "ok")
+        return g;
+      throw g;
+    }
+    let p, c = "ok", a = r.results.length;
+    if (r.impl)
+      try {
+        new.target ? p = Reflect.construct(r.impl, s, new.target) : p = r.impl.apply(this, s), c = "ok";
+      } catch (o) {
+        throw p = o, c = "error", r.results.push([c, o]), o;
+      }
+    let R = [c, p];
+    return w(p) && p.then(
+      (o) => r.resolves[a] = ["ok", o],
+      (o) => r.resolves[a] = ["error", o]
+    ), r.results.push(R), p;
+  }",
           },
         ],
       ],
@@ -229,7 +252,30 @@ exports[`services > file > uploadFile > virus scan initialised 1`] = `
       "calls": [
         [
           {
-            "fileId": [MockFunction spy],
+            "fileId": "function(...s) {
+    let r = T(t);
+    r.called = !0, r.callCount++, r.calls.push(s);
+    let S = r.next.shift();
+    if (S) {
+      r.results.push(S);
+      let [o, g] = S;
+      if (o === "ok")
+        return g;
+      throw g;
+    }
+    let p, c = "ok", a = r.results.length;
+    if (r.impl)
+      try {
+        new.target ? p = Reflect.construct(r.impl, s, new.target) : p = r.impl.apply(this, s), c = "ok";
+      } catch (o) {
+        throw p = o, c = "error", r.results.push([c, o]), o;
+      }
+    let R = [c, p];
+    return w(p) && p.then(
+      (o) => r.resolves[a] = ["ok", o],
+      (o) => r.resolves[a] = ["error", o]
+    ), r.results.push(R), p;
+  }",
           },
         ],
       ],


### PR DESCRIPTION
E.g. https://github.com/gchq/Bailo/blob/main/backend/src/connectors/fileScanning/clamAv.ts#L76

Create a function in the base scanner to unify error log and creation of the error object for all scanners. The function should take in all information needed to create a scan result and log that information.

Update uses of `file._id` to `file.id` so that the object ID is output in string form.
