### PR TITLE
Feature/bai 1640 cleanup python client api endpoints

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -20,7 +20,7 @@ repos:
       - id: trailing-whitespace
 
   - repo: https://github.com/PyCQA/isort
-    rev: 6.0.0
+    rev: 6.0.1
     hooks:
       - id: isort
         args: ['-a', 'from __future__ import annotations', '-l', '120']

--- a/lib/python/README.md
+++ b/lib/python/README.md
@@ -42,6 +42,16 @@ A simple Python API Wrapper for Bailo
 ## Key Features
 
 - Uploading and downloading model binaries
+- Managing Models and Releases
+- Managing Datacards
+- Managing Schemas
+- Managing Access Requests
+
+The Bailo Python client aims to programmatically cover Bailo's core functionality by interacting with the endpoints in
+the backend. The functionality covered is that which a Data Scientist, Software Engineer or other similarly technical
+role might be expected to utilise, meaning that it does _not_ have complete coverage of all endpoints, such as those
+relating to the discussion & approval of reviews & access requests. For these interactions, the web frontend is expected
+to be used.
 
 ## Installing
 
@@ -71,7 +81,7 @@ yolo.card_from_schema("minimal-general-v10")
 
 # Create a new release
 my_release = yolo.create_release(version="0.1.0",
-                              notes="Beta")
+                                 notes="Beta")
 
 # Upload a file to the release
 with open("yolo.onnx") as f:

--- a/lib/python/src/bailo/core/client.py
+++ b/lib/python/src/bailo/core/client.py
@@ -405,7 +405,7 @@ class Client:
         :return: JSON response object
         """
         return self.agent.delete(
-            f"{self.url}/v2/model/{model_id}/files/{file_id}",
+            f"{self.url}/v2/model/{model_id}/file/{file_id}",
         ).json()
 
     def get_all_images(

--- a/lib/python/tests/test_files.py
+++ b/lib/python/tests/test_files.py
@@ -2,16 +2,18 @@ from __future__ import annotations
 
 import os
 from io import BytesIO
+from pathlib import Path
 
 import pytest
 
 # isort: split
 
 from bailo.core.exceptions import BailoException
+from bailo.helper.model import Model
 
 
 @pytest.mark.integration
-def test_file_upload(example_model):
+def test_file_upload(example_model: Model):
     byte_obj = b"Test Binary"
     file = BytesIO(byte_obj)
 
@@ -27,7 +29,7 @@ def test_file_upload(example_model):
 
 
 @pytest.mark.integration
-def test_file_upload_from_disk_large(example_model, test_path_large):
+def test_file_upload_from_disk_large(example_model: Model, test_path_large: str):
     example_release = example_model.create_release("0.1.0", "test")
 
     example_release.upload(test_path_large)
@@ -37,7 +39,9 @@ def test_file_upload_from_disk_large(example_model, test_path_large):
 
 
 @pytest.mark.integration
-def test_file_download_all(example_model, tmpdir):
+def test_file_download_all(example_model: Model, tmp_path: Path):
+    print(type(tmp_path))
+
     byte_obj = b"Test Binary"
     file = BytesIO(byte_obj)
 
@@ -48,14 +52,15 @@ def test_file_download_all(example_model, tmpdir):
         example_release.upload(filename, file)
         file.seek(0)
 
-    downloads_path = tmpdir.mkdir("downloads")
-    example_release.download_all(path=downloads_path)
+    downloads_path = tmp_path / "downloads"
+    downloads_path.mkdir()
+    example_release.download_all(path=str(downloads_path.absolute()))
 
     assert set(os.listdir(downloads_path)).issubset(filenames)
 
 
 @pytest.mark.integration
-def test_file_download_filter(example_model, tmpdir):
+def test_file_download_filter(example_model: Model, tmp_path: Path):
     byte_obj = b"Test Binary"
     file = BytesIO(byte_obj)
 
@@ -66,14 +71,15 @@ def test_file_download_filter(example_model, tmpdir):
         example_release.upload(filename, file)
         file.seek(0)
 
-    downloads_path = tmpdir.mkdir("downloads")
-    example_release.download_all(path=downloads_path, include=["*.txt"], exclude=["to_exclude.txt"])
+    downloads_path = tmp_path / "downloads"
+    downloads_path.mkdir()
+    example_release.download_all(path=str(downloads_path.absolute()), include=["*.txt"], exclude=["to_exclude.txt"])
 
     assert os.listdir(downloads_path) == ["test2.txt"]
 
 
 @pytest.mark.integration
-def test_file_download_all_no_files(example_model):
+def test_file_download_all_no_files(example_model: Model):
     example_release = example_model.create_release("0.1.0", "test")
 
     with pytest.raises(BailoException):
@@ -81,7 +87,32 @@ def test_file_download_all_no_files(example_model):
 
 
 @pytest.mark.integration
-def test_source_target_doesnt_exist(example_model):
+def test_source_target_does_not_exist(example_model: Model):
     example_release = example_model.create_release("0.1.0", "test")
     with pytest.raises(BailoException):
         example_release.download("non_existant_model")
+
+
+@pytest.mark.integration
+def test_file_delete(example_model: Model):
+    byte_obj = b"Test Binary"
+    file = BytesIO(byte_obj)
+
+    example_release = example_model.create_release("0.1.0", "test")
+
+    with file as file:
+        example_release.upload("test", file)
+
+    original_files = example_model.client.get_files(example_model.model_id).copy()
+    original_file_id = original_files["files"][0]["id"]
+
+    delete_file_response = example_model.client.delete_file(example_model.model_id, original_file_id)
+
+    # assert deletion was successful
+    assert delete_file_response == {"message": "Successfully removed file."}
+
+    new_files = example_model.client.get_files(example_model.model_id).copy()
+    diff_files = [x for x in original_files["files"] if x not in new_files["files"]]
+
+    # assert the specific file is no longer accessible
+    assert len(diff_files) == 1 and diff_files[0]["id"] == original_file_id


### PR DESCRIPTION
- Fix the `delete:/api/v2/model/{modelId}/files/{fileId}` endpoint by updating it to `delete:/api/v2/model/{modelId}/file/{fileId}` (note `file` is singular, not plural);
- Add integration test to cover this endpoint as it's currently not covered;
- Update the documentation stating which backend endpoints should be covered.