### PR TITLE
Fix bugs and refactor file scanners

### DIFF
--- a/backend/src/connectors/fileScanning/clamAv.ts
+++ b/backend/src/connectors/fileScanning/clamAv.ts
@@ -48,7 +48,10 @@ export class ClamAvFileScanningConnector extends BaseFileScanningConnector {
         },
       ]
     } catch (error) {
-      return this.scanError(`Unable to scan file. ${this.toolName} errored.`, { error, file })
+      return this.scanError(`This file could not be scanned due to an error caused by ${this.toolName}`, {
+        error,
+        file,
+      })
     }
   }
 }

--- a/backend/src/connectors/fileScanning/clamAv.ts
+++ b/backend/src/connectors/fileScanning/clamAv.ts
@@ -5,60 +5,35 @@ import { getObjectStream } from '../../clients/s3.js'
 import { FileInterfaceDoc } from '../../models/File.js'
 import log from '../../services/log.js'
 import config from '../../utils/config.js'
-import { ConfigurationError } from '../../utils/error.js'
 import { BaseFileScanningConnector, FileScanResult, ScanState } from './Base.js'
 
-let av: NodeClam
-
 export class ClamAvFileScanningConnector extends BaseFileScanningConnector {
+  toolName = 'Clam AV'
+  version: string | undefined = undefined
+  av: NodeClam | undefined = undefined
+
   constructor() {
     super()
   }
 
-  async info() {
-    return { toolName: 'Clam AV', scannerVersion: await this.getScannerVersion() }
+  async init() {
+    this.av = await new NodeClam().init({ clamdscan: config.avScanning.clamdscan })
+    const scannerVersion = await this.av.getVersion()
+    this.version = scannerVersion.substring(scannerVersion.indexOf(' ') + 1, scannerVersion.indexOf('/'))
+    return this
   }
 
-  async init(retryCount: number = 1) {
-    log.info('Initialising Clam AV...')
-    if (retryCount <= config.connectors.fileScanners.maxInitRetries) {
-      setTimeout(async () => {
-        try {
-          av = await new NodeClam().init({ clamdscan: config.avScanning.clamdscan })
-          log.info('Clam AV initialised.')
-        } catch (_error) {
-          log.warn(`Could not initialise Clam AV, retrying (attempt ${retryCount})...`)
-          this.init(++retryCount)
-        }
-      }, config.connectors.fileScanners.initRetryDelay)
-    } else {
-      throw ConfigurationError(
-        `Could not initialise Clam AV after ${retryCount} attempts, make sure that it is setup and configured correctly.`,
-        {
-          modelScanConfig: config.avScanning.modelscan,
-        },
-      )
-    }
-  }
-
-  async getScannerVersion() {
-    if (!av) return
-    const scannerVersion = await av.getVersion()
-    const modifiedVersion = scannerVersion.substring(scannerVersion.indexOf(' ') + 1, scannerVersion.indexOf('/'))
-    return modifiedVersion
+  getScannerVersion() {
+    return this.version
   }
 
   async scan(file: FileInterfaceDoc): Promise<FileScanResult[]> {
-    if (!av) {
-      return await this.scanError(
-        undefined,
-        undefined,
-        `Could not use ${(await this.info()).toolName} as it is not running`,
-      )
+    if (!this.av) {
+      return await this.scanError(`Could not use ${this.toolName} as it is not been correctly initialised.`)
     }
     const s3Stream = (await getObjectStream(file.bucket, file.path)).Body as Readable
     try {
-      const { isInfected, viruses } = await av.scanStream(s3Stream)
+      const { isInfected, viruses } = await this.av.scanStream(s3Stream)
       log.info(
         { modelId: file.modelId, fileId: file._id.toString(), name: file.name, result: { isInfected, viruses } },
         'Scan complete.',
@@ -73,7 +48,7 @@ export class ClamAvFileScanningConnector extends BaseFileScanningConnector {
         },
       ]
     } catch (error) {
-      return this.scanError(error, file)
+      return this.scanError(`Unable to scan file. ${this.toolName} errored.`, { error, file })
     }
   }
 }

--- a/backend/src/connectors/fileScanning/index.ts
+++ b/backend/src/connectors/fileScanning/index.ts
@@ -13,28 +13,26 @@ export type FileScanKindKeys = (typeof FileScanKind)[keyof typeof FileScanKind]
 
 const fileScanConnectors: BaseFileScanningConnector[] = []
 let scannerWrapper: undefined | FileScanningWrapper = undefined
-export function runFileScanners(cache = true) {
+export async function runFileScanners(cache = true) {
   if (scannerWrapper && cache) {
     return scannerWrapper
   }
-  config.connectors.fileScanners.kinds.forEach(async (fileScanner) => {
+  for (const fileScanner of config.connectors.fileScanners.kinds) {
     switch (fileScanner) {
       case FileScanKind.ClamAv:
         try {
           const scanner = new ClamAvFileScanningConnector()
-          await scanner.init()
           fileScanConnectors.push(scanner)
-        } catch (_error) {
-          throw ConfigurationError('Could not configure or initialise Clam AV')
+        } catch (error) {
+          throw ConfigurationError('Could not configure or initialise Clam AV', { error })
         }
         break
       case FileScanKind.ModelScan:
         try {
           const scanner = new ModelScanFileScanningConnector()
-          await scanner.init()
           fileScanConnectors.push(scanner)
-        } catch (_error) {
-          throw ConfigurationError('Could not configure or initialise ModelScan')
+        } catch (error) {
+          throw ConfigurationError('Could not configure or initialise ModelScan', { error })
         }
         break
       default:
@@ -42,9 +40,11 @@ export function runFileScanners(cache = true) {
           validKinds: Object.values(FileScanKind),
         })
     }
-  })
+  }
+
   scannerWrapper = new FileScanningWrapper(fileScanConnectors)
+  await scannerWrapper.init()
   return scannerWrapper
 }
 
-export default runFileScanners()
+export default await runFileScanners()

--- a/backend/src/connectors/fileScanning/modelScan.ts
+++ b/backend/src/connectors/fileScanning/modelScan.ts
@@ -4,51 +4,27 @@ import { getModelScanInfo, scanStream } from '../../clients/modelScan.js'
 import { getObjectStream } from '../../clients/s3.js'
 import { FileInterfaceDoc } from '../../models/File.js'
 import log from '../../services/log.js'
-import config from '../../utils/config.js'
-import { ConfigurationError } from '../../utils/error.js'
 import { BaseFileScanningConnector, FileScanResult, ScanState } from './Base.js'
 
 export class ModelScanFileScanningConnector extends BaseFileScanningConnector {
+  toolName: string = 'ModelScan'
+  version: string | undefined = undefined
+
   constructor() {
     super()
   }
 
-  async info() {
-    return { toolName: 'ModelScan', scannerVersion: await this.getScannerVersion() }
-  }
-
-  async getScannerVersion() {
+  async init() {
     const modelScanInfo = await getModelScanInfo()
-    return modelScanInfo.modelscanVersion
-  }
-
-  async init(retryCount: number = 1) {
-    log.info('Initialising ModelScan...')
-    if (retryCount <= config.connectors.fileScanners.maxInitRetries) {
-      setTimeout(async () => {
-        try {
-          await getModelScanInfo()
-          log.info('ModelScan initialised.')
-        } catch (_error) {
-          log.warn(`Could not initialise ModelScan, retrying (attempt ${retryCount})...`)
-          this.init(++retryCount)
-        }
-      }, config.connectors.fileScanners.initRetryDelay)
-    } else {
-      throw ConfigurationError(
-        `Could not initialise Model Scan after ${retryCount} attempts, make sure that it is setup and configured correctly.`,
-        {
-          modelScanConfig: config.avScanning.modelscan,
-        },
-      )
-    }
+    this.version = modelScanInfo.modelscanVersion
+    return this
   }
 
   async scan(file: FileInterfaceDoc): Promise<FileScanResult[]> {
     this.init()
     const scannerInfo = await this.info()
     if (scannerInfo.scannerVersion === undefined) {
-      return await this.scanError(undefined, undefined, 'Could not use ModelScan as it is not running')
+      return await this.scanError('Could not use ModelScan as it is not running.')
     }
 
     const s3Stream = (await getObjectStream(file.bucket, file.path)).Body as Readable
@@ -56,7 +32,7 @@ export class ModelScanFileScanningConnector extends BaseFileScanningConnector {
       const scanResults = await scanStream(s3Stream, file.name, file.size)
 
       if (scanResults.errors.length !== 0) {
-        return this.scanError(scanResults.errors, file)
+        return this.scanError(`Unable to scan file. ${this.toolName} errored.`, { errors: scanResults.errors, file })
       }
 
       const issues = scanResults.summary.total_issues
@@ -81,7 +57,7 @@ export class ModelScanFileScanningConnector extends BaseFileScanningConnector {
         },
       ]
     } catch (error) {
-      return this.scanError(error, file)
+      return this.scanError(`Unable to scan file. ${this.toolName} errored.`, { error, file })
     }
   }
 }

--- a/backend/src/connectors/fileScanning/modelScan.ts
+++ b/backend/src/connectors/fileScanning/modelScan.ts
@@ -32,7 +32,10 @@ export class ModelScanFileScanningConnector extends BaseFileScanningConnector {
       const scanResults = await scanStream(s3Stream, file.name, file.size)
 
       if (scanResults.errors.length !== 0) {
-        return this.scanError(`Unable to scan file. ${this.toolName} errored.`, { errors: scanResults.errors, file })
+        return this.scanError(`This file could not be scanned due to an error caused by ${this.toolName}`, {
+          errors: scanResults.errors,
+          file,
+        })
       }
 
       const issues = scanResults.summary.total_issues
@@ -57,7 +60,10 @@ export class ModelScanFileScanningConnector extends BaseFileScanningConnector {
         },
       ]
     } catch (error) {
-      return this.scanError(`Unable to scan file. ${this.toolName} errored.`, { error, file })
+      return this.scanError(`This file could not be scanned due to an error caused by ${this.toolName}`, {
+        error,
+        file,
+      })
     }
   }
 }

--- a/backend/src/connectors/fileScanning/wrapper.ts
+++ b/backend/src/connectors/fileScanning/wrapper.ts
@@ -1,9 +1,12 @@
 import { FileInterface } from '../../models/File.js'
 import log from '../../services/log.js'
+import config from '../../utils/config.js'
+import { ConfigurationError } from '../../utils/error.js'
 import { BaseFileScanningConnector, FileScanningConnectorInfo, FileScanResult } from './Base.js'
 
 export class FileScanningWrapper extends BaseFileScanningConnector {
   toolName = this.constructor.name
+  version = undefined
   scanners: BaseFileScanningConnector[] = []
 
   constructor(scanners: BaseFileScanningConnector[]) {
@@ -11,12 +14,43 @@ export class FileScanningWrapper extends BaseFileScanningConnector {
     this.scanners = scanners
   }
 
-  async info(): Promise<FileScanningConnectorInfo & { scannerNames: string[] }> {
-    const scannersInfo = await Promise.all(
-      this.scanners.map(async (scanner) => {
-        return await scanner.info()
-      }),
-    )
+  async init() {
+    for (const scanner of this.scanners) {
+      log.info(`Initialising scanner...`, { toolName: scanner.toolName })
+      let attempt = 0
+      while (attempt <= config.connectors.fileScanners.maxInitRetries) {
+        ++attempt
+        try {
+          await new Promise<void>((resolve, reject) => {
+            setTimeout(async () => {
+              try {
+                await scanner.init()
+              } catch (error) {
+                return reject(error)
+              }
+              log.info(`Scanner initialised`, { toolName: scanner.toolName })
+              return resolve()
+            }, config.connectors.fileScanners.initRetryDelay)
+          })
+          break
+        } catch (error) {
+          log.warn(`Could not initialise scanner, retrying.`, { attempt: attempt, toolName: this.toolName, error })
+        }
+      }
+      if (attempt > config.connectors.fileScanners.maxInitRetries) {
+        throw ConfigurationError(
+          `Could not initialise scanner after max attempts, make sure that it is setup and configured correctly.`,
+          { failedAttempts: attempt, toolName: this.toolName },
+        )
+      }
+    }
+  }
+
+  info(): FileScanningConnectorInfo & { scannerNames: string[] } {
+    const scannersInfo = this.scanners.map((scanner) => {
+      return scanner.info()
+    })
+
     const scannerNames = scannersInfo.map((scannerInfo) => scannerInfo.toolName)
     return { toolName: this.constructor.name, scannerNames: scannerNames }
   }

--- a/backend/src/routes/v2/filescanning/getFilescanningInfo.ts
+++ b/backend/src/routes/v2/filescanning/getFilescanningInfo.ts
@@ -10,6 +10,6 @@ interface GetFileScanningInfoResponse {
 export const getFilescanningInfo = [
   bodyParser.json(),
   async (req: Request, res: Response<GetFileScanningInfoResponse>) => {
-    return res.json({ scanners: (await scanners.info()).scannerNames })
+    return res.json({ scanners: scanners.info().scannerNames })
   },
 ]

--- a/backend/src/services/file.ts
+++ b/backend/src/services/file.ts
@@ -70,7 +70,7 @@ export async function uploadFile(user: UserInterface, modelId: string, name: str
 
   await file.save()
 
-  const scannersInfo = await scanners.info()
+  const scannersInfo = scanners.info()
   if (scannersInfo && scannersInfo.scannerNames && fileSize > 0) {
     const resultsInprogress: FileScanResult[] = scannersInfo.scannerNames.map((scannerName) => ({
       toolName: scannerName,


### PR DESCRIPTION
- Fix async bug in delayed retry logic.
- Fix async bug in initialisation of scanners.
- Remove duplication by moving retry logic into wrapper also simplifies init logic for each scanner.
- Store scanner version on init- remove dependency on scanners after initialisation.