### PR TITLE
Added API end points for creating and viewing review roles

### DIFF
--- a/backend/src/connectors/audit/Base.ts
+++ b/backend/src/connectors/audit/Base.ts
@@ -7,6 +7,7 @@ import { ModelCardInterface, ModelDoc, ModelInterface } from '../../models/Model
 import { ReleaseDoc } from '../../models/Release.js'
 import { ResponseInterface } from '../../models/Response.js'
 import { ReviewInterface } from '../../models/Review.js'
+import { ReviewRoleInterface } from '../../models/ReviewRole.js'
 import { SchemaDoc, SchemaInterface } from '../../models/Schema.js'
 import { TokenDoc } from '../../models/Token.js'
 import { ModelSearchResult } from '../../routes/v2/model/getModelsSearch.js'
@@ -122,6 +123,16 @@ export const AuditInfo = {
     description: 'Updated a comment or review response',
     auditKind: AuditKind.Update,
   },
+  CreateReviewRole: {
+    typeId: 'CreateReviewRole',
+    description: 'Created a new review role',
+    auditKind: AuditKind.Create,
+  },
+  ViewReviewRole: {
+    typeId: 'ViewReviewRole',
+    description: 'Viewed a list of review roles',
+    auditKind: AuditKind.View,
+  },
 } as const
 export type AuditInfoKeys = (typeof AuditInfo)[keyof typeof AuditInfo]
 
@@ -191,6 +202,11 @@ export abstract class BaseAuditConnector {
     exporter: string,
     importResult: MongoDocumentImportInformation | FileImportInformation,
   )
+
+  abstract onCreateReviewRole(req: Request, reviewRole: ReviewRoleInterface)
+  abstract onUpdateReviewRole(req: Request, reviewRole: ReviewRoleInterface)
+  abstract onViewReviewRole(req: Request, reviewRoles: ReviewRoleInterface)
+  abstract onViewReviewRoles(req: Request, reviewRole: ReviewRoleInterface[])
 
   abstract onError(req: Request, error: BailoError)
 

--- a/backend/src/connectors/audit/Base.ts
+++ b/backend/src/connectors/audit/Base.ts
@@ -128,20 +128,10 @@ export const AuditInfo = {
     description: 'Created a new review role',
     auditKind: AuditKind.Create,
   },
-  ViewReviewRole: {
-    typeId: 'ViewReviewRole',
-    description: 'Viewed a list of review roles',
-    auditKind: AuditKind.View,
-  },
   ViewReviewRoles: {
     typeId: 'ViewReviewRole',
     description: 'Viewed a list of review roles',
     auditKind: AuditKind.View,
-  },
-  UpdateReviewRole: {
-    typeId: 'UpdateReviewRole',
-    description: 'Updated an existing review role',
-    auditKind: AuditKind.Create,
   },
 } as const
 export type AuditInfoKeys = (typeof AuditInfo)[keyof typeof AuditInfo]
@@ -214,8 +204,6 @@ export abstract class BaseAuditConnector {
   )
 
   abstract onCreateReviewRole(req: Request, reviewRole: ReviewRoleInterface)
-  abstract onUpdateReviewRole(req: Request, reviewRole: ReviewRoleInterface)
-  abstract onViewReviewRole(req: Request, reviewRoles: ReviewRoleInterface)
   abstract onViewReviewRoles(req: Request, reviewRole: ReviewRoleInterface[])
 
   abstract onError(req: Request, error: BailoError)

--- a/backend/src/connectors/audit/Base.ts
+++ b/backend/src/connectors/audit/Base.ts
@@ -133,6 +133,16 @@ export const AuditInfo = {
     description: 'Viewed a list of review roles',
     auditKind: AuditKind.View,
   },
+  ViewReviewRoles: {
+    typeId: 'ViewReviewRole',
+    description: 'Viewed a list of review roles',
+    auditKind: AuditKind.View,
+  },
+  UpdateReviewRole: {
+    typeId: 'UpdateReviewRole',
+    description: 'Updated an existing review role',
+    auditKind: AuditKind.Create,
+  },
 } as const
 export type AuditInfoKeys = (typeof AuditInfo)[keyof typeof AuditInfo]
 

--- a/backend/src/connectors/audit/__mocks__/index.ts
+++ b/backend/src/connectors/audit/__mocks__/index.ts
@@ -52,10 +52,7 @@ const audit = {
   onUpdateResponse: vi.fn(),
 
   onCreateReviewRole: vi.fn(),
-  onViewReviewRole: vi.fn(),
   onViewReviewRoles: vi.fn(),
-  onUpdateReviewRole: vi.fn(),
-  onDeleteReviewRole: vi.fn(),
 
   onError: vi.fn(),
 }

--- a/backend/src/connectors/audit/__mocks__/index.ts
+++ b/backend/src/connectors/audit/__mocks__/index.ts
@@ -53,6 +53,7 @@ const audit = {
 
   onCreateReviewRole: vi.fn(),
   onViewReviewRole: vi.fn(),
+  onViewReviewRoles: vi.fn(),
   onUpdateReviewRole: vi.fn(),
   onDeleteReviewRole: vi.fn(),
 

--- a/backend/src/connectors/audit/__mocks__/index.ts
+++ b/backend/src/connectors/audit/__mocks__/index.ts
@@ -51,6 +51,11 @@ const audit = {
   onViewResponses: vi.fn(),
   onUpdateResponse: vi.fn(),
 
+  onCreateReviewRole: vi.fn(),
+  onViewReviewRole: vi.fn(),
+  onUpdateReviewRole: vi.fn(),
+  onDeleteReviewRole: vi.fn(),
+
   onError: vi.fn(),
 }
 export default audit

--- a/backend/src/connectors/audit/silly.ts
+++ b/backend/src/connectors/audit/silly.ts
@@ -7,6 +7,7 @@ import { ModelCardInterface, ModelDoc, ModelInterface } from '../../models/Model
 import { ReleaseDoc } from '../../models/Release.js'
 import { ResponseInterface } from '../../models/Response.js'
 import { ReviewInterface } from '../../models/Review.js'
+import { ReviewRoleInterface } from '../../models/ReviewRole.js'
 import { SchemaDoc, SchemaInterface } from '../../models/Schema.js'
 import { TokenDoc } from '../../models/Token.js'
 import { ModelSearchResult } from '../../routes/v2/model/getModelsSearch.js'
@@ -69,4 +70,8 @@ export class SillyAuditConnector extends BaseAuditConnector {
   onCreateCommentResponse(_req: Request, _responseInterface: ResponseInterface) {}
   onViewResponses(_req: Request, _responseInters: ResponseInterface[]) {}
   onUpdateResponse(_req: Request, _responseId: string) {}
+  onCreateReviewRole(_req: Request, _reviewRole: ReviewRoleInterface) {}
+  onViewReviewRole(_req: Request) {}
+  onViewReviewRoles(_req: Request) {}
+  onUpdateReviewRole(_req: Request, _reviewRole: ReviewRoleInterface) {}
 }

--- a/backend/src/connectors/audit/silly.ts
+++ b/backend/src/connectors/audit/silly.ts
@@ -71,7 +71,5 @@ export class SillyAuditConnector extends BaseAuditConnector {
   onViewResponses(_req: Request, _responseInters: ResponseInterface[]) {}
   onUpdateResponse(_req: Request, _responseId: string) {}
   onCreateReviewRole(_req: Request, _reviewRole: ReviewRoleInterface) {}
-  onViewReviewRole(_req: Request) {}
   onViewReviewRoles(_req: Request) {}
-  onUpdateReviewRole(_req: Request, _reviewRole: ReviewRoleInterface) {}
 }

--- a/backend/src/connectors/audit/stdout.ts
+++ b/backend/src/connectors/audit/stdout.ts
@@ -373,13 +373,13 @@ export class StdoutAuditConnector extends BaseAuditConnector {
   }
 
   onViewReviewRoles(req: Request) {
-    this.checkEventType(AuditInfo.ViewReviewRole, req)
+    this.checkEventType(AuditInfo.ViewReviewRoles, req)
     const event = this.generateEvent(req, {})
     req.log.info(event, req.audit.description)
   }
 
   onUpdateReviewRole(req: Request, reviewRole: ReviewRoleInterface) {
-    this.checkEventType(AuditInfo.CreateReviewRole, req)
+    this.checkEventType(AuditInfo.UpdateReviewRole, req)
     const event = this.generateEvent(req, { reviewRoleId: reviewRole.id })
     req.log.info(event, req.audit.description)
   }

--- a/backend/src/connectors/audit/stdout.ts
+++ b/backend/src/connectors/audit/stdout.ts
@@ -7,6 +7,7 @@ import { ModelCardInterface, ModelDoc, ModelInterface } from '../../models/Model
 import { ReleaseDoc } from '../../models/Release.js'
 import { ResponseInterface } from '../../models/Response.js'
 import { ReviewInterface } from '../../models/Review.js'
+import { ReviewRoleInterface } from '../../models/ReviewRole.js'
 import { SchemaDoc, SchemaInterface } from '../../models/Schema.js'
 import { TokenDoc } from '../../models/Token.js'
 import { ModelSearchResult } from '../../routes/v2/model/getModelsSearch.js'
@@ -356,6 +357,30 @@ export class StdoutAuditConnector extends BaseAuditConnector {
   ) {
     this.checkEventType(AuditInfo.CreateImport, req)
     const event = this.generateEvent(req, { mirroredModel, sourceModelId, exporter, importResult })
+    req.log.info(event, req.audit.description)
+  }
+
+  onCreateReviewRole(req: Request, reviewRole: ReviewRoleInterface) {
+    this.checkEventType(AuditInfo.CreateReviewRole, req)
+    const event = this.generateEvent(req, { reviewRoleId: reviewRole.id })
+    req.log.info(event, req.audit.description)
+  }
+
+  onViewReviewRole(req: Request) {
+    this.checkEventType(AuditInfo.ViewReviewRole, req)
+    const event = this.generateEvent(req, {})
+    req.log.info(event, req.audit.description)
+  }
+
+  onViewReviewRoles(req: Request) {
+    this.checkEventType(AuditInfo.ViewReviewRole, req)
+    const event = this.generateEvent(req, {})
+    req.log.info(event, req.audit.description)
+  }
+
+  onUpdateReviewRole(req: Request, reviewRole: ReviewRoleInterface) {
+    this.checkEventType(AuditInfo.CreateReviewRole, req)
+    const event = this.generateEvent(req, { reviewRoleId: reviewRole.id })
     req.log.info(event, req.audit.description)
   }
 }

--- a/backend/src/connectors/audit/stdout.ts
+++ b/backend/src/connectors/audit/stdout.ts
@@ -366,21 +366,9 @@ export class StdoutAuditConnector extends BaseAuditConnector {
     req.log.info(event, req.audit.description)
   }
 
-  onViewReviewRole(req: Request) {
-    this.checkEventType(AuditInfo.ViewReviewRole, req)
-    const event = this.generateEvent(req, {})
-    req.log.info(event, req.audit.description)
-  }
-
   onViewReviewRoles(req: Request) {
     this.checkEventType(AuditInfo.ViewReviewRoles, req)
     const event = this.generateEvent(req, {})
-    req.log.info(event, req.audit.description)
-  }
-
-  onUpdateReviewRole(req: Request, reviewRole: ReviewRoleInterface) {
-    this.checkEventType(AuditInfo.UpdateReviewRole, req)
-    const event = this.generateEvent(req, { reviewRoleId: reviewRole.id })
     req.log.info(event, req.audit.description)
   }
 }

--- a/backend/src/connectors/authorisation/actions.ts
+++ b/backend/src/connectors/authorisation/actions.ts
@@ -64,8 +64,6 @@ export type ResponseActionKeys = (typeof ResponseAction)[keyof typeof ResponseAc
 export const ReviewRoleAction = {
   Create: 'reviewRole:create',
   View: 'reviewRole:view',
-  Update: 'reviewRole:update',
-  Delete: 'reviewRole:delete',
 } as const
 export type ReviewRoleActionKeys = (typeof ReviewRoleAction)[keyof typeof ReviewRoleAction]
 
@@ -103,7 +101,5 @@ export const ActionLookup = {
 
   [ReviewRoleAction.Create]: TokenActions.ReviewRoleWrite.id,
   [ReviewRoleAction.View]: TokenActions.ReviewRoleWrite.id,
-  [ReviewRoleAction.Delete]: TokenActions.ReviewRoleWrite.id,
-  [ReviewRoleAction.Update]: TokenActions.ReviewRoleWrite.id,
 } as const
 export type ActionLookupKeys = (typeof ActionLookup)[keyof typeof ActionLookup]

--- a/backend/src/connectors/authorisation/actions.ts
+++ b/backend/src/connectors/authorisation/actions.ts
@@ -61,6 +61,14 @@ export const ResponseAction = {
 } as const
 export type ResponseActionKeys = (typeof ResponseAction)[keyof typeof ResponseAction]
 
+export const ReviewRoleAction = {
+  Create: 'reviewRole:create',
+  View: 'reviewRole:view',
+  Update: 'reviewRole:update',
+  Delete: 'reviewRole:delete',
+} as const
+export type ReviewRoleActionKeys = (typeof ReviewRoleAction)[keyof typeof ReviewRoleAction]
+
 export const ActionLookup = {
   [ModelAction.Create]: TokenActions.ModelWrite.id,
   [ModelAction.View]: TokenActions.ModelRead.id,
@@ -92,5 +100,10 @@ export const ActionLookup = {
   [ImageAction.List]: TokenActions.ImageRead.id,
   [ImageAction.Wildcard]: TokenActions.ImageWrite.id,
   [ImageAction.Delete]: TokenActions.ImageWrite.id,
+
+  [ReviewRoleAction.Create]: TokenActions.ReviewRoleWrite.id,
+  [ReviewRoleAction.View]: TokenActions.ReviewRoleWrite.id,
+  [ReviewRoleAction.Delete]: TokenActions.ReviewRoleWrite.id,
+  [ReviewRoleAction.Update]: TokenActions.ReviewRoleWrite.id,
 } as const
 export type ActionLookupKeys = (typeof ActionLookup)[keyof typeof ActionLookup]

--- a/backend/src/connectors/authorisation/base.ts
+++ b/backend/src/connectors/authorisation/base.ts
@@ -3,6 +3,7 @@ import { FileInterface } from '../../models/File.js'
 import { EntryVisibility, ModelDoc } from '../../models/Model.js'
 import { ReleaseDoc, ReleaseInterface } from '../../models/Release.js'
 import { ResponseDoc } from '../../models/Response.js'
+import { ReviewRoleInterface } from '../../models/ReviewRole.js'
 import { SchemaDoc } from '../../models/Schema.js'
 import { UserInterface } from '../../models/User.js'
 import { Access } from '../../routes/v1/registryAuth.js'
@@ -26,6 +27,8 @@ import {
   ReleaseActionKeys,
   ResponseAction,
   ResponseActionKeys,
+  ReviewRoleAction,
+  ReviewRoleActionKeys,
   SchemaAction,
   SchemaActionKeys,
 } from './actions.js'
@@ -62,6 +65,10 @@ export class BasicAuthorisationConnector {
 
   async release(user: UserInterface, model: ModelDoc, action: ReleaseActionKeys, release?: ReleaseDoc) {
     return (await this.releases(user, model, release ? [release] : [], action))[0]
+  }
+
+  async reviewRole(user: UserInterface, reviewRole: ReviewRoleInterface, action: ReviewRoleActionKeys) {
+    return (await this.reviewRoles(user, [reviewRole], action))[0]
   }
 
   async accessRequest(
@@ -355,6 +362,39 @@ export class BasicAuthorisationConnector {
         }
 
         return { success: true, id: access.name }
+      }),
+    )
+  }
+
+  async reviewRoles(
+    user: UserInterface,
+    reviewRoles: Array<ReviewRoleInterface>,
+    action: ReviewRoleActionKeys,
+  ): Promise<Array<Response>> {
+    return Promise.all(
+      reviewRoles.map(async (reviewRole) => {
+        // Is this a constrained user token.
+        const tokenAuth = await validateTokenForUse(user.token, ActionLookup[action])
+        if (!tokenAuth.success) {
+          return tokenAuth
+        }
+
+        if (action === ReviewRoleAction.Create || action === ReviewRoleAction.Delete || ReviewRoleAction.Update) {
+          const isAdmin = await authentication.hasRole(user, Roles.Admin)
+
+          if (!isAdmin) {
+            return {
+              id: reviewRole.id,
+              success: false,
+              info: 'You cannot upload or modify a review role if you are not an admin.',
+            }
+          }
+        }
+
+        return {
+          id: reviewRole.id,
+          success: true,
+        }
       }),
     )
   }

--- a/backend/src/connectors/authorisation/base.ts
+++ b/backend/src/connectors/authorisation/base.ts
@@ -379,7 +379,7 @@ export class BasicAuthorisationConnector {
           return tokenAuth
         }
 
-        if (action === ReviewRoleAction.Create || action === ReviewRoleAction.Delete || ReviewRoleAction.Update) {
+        if (action === ReviewRoleAction.Create) {
           const isAdmin = await authentication.hasRole(user, Roles.Admin)
 
           if (!isAdmin) {

--- a/backend/src/models/Model.ts
+++ b/backend/src/models/Model.ts
@@ -15,9 +15,17 @@ export const EntryKind = {
 
 export type EntryKindKeys = (typeof EntryKind)[keyof typeof EntryKind]
 
+export const CollaboratorRoles = {
+  Owner: 'owner',
+  Contributor: 'contributor',
+  Consumer: 'consumer',
+} as const
+
+export type CollaboratorRolesKeys = (typeof CollaboratorRoles)[keyof typeof CollaboratorRoles]
+
 export interface CollaboratorEntry {
   entity: string
-  roles: Array<'owner' | 'contributor' | 'consumer' | string>
+  roles: Array<CollaboratorRolesKeys | string>
 }
 
 export interface ModelMetadata {

--- a/backend/src/models/ReviewRole.ts
+++ b/backend/src/models/ReviewRole.ts
@@ -29,7 +29,7 @@ const ReviewRoleSchema = new Schema<ReviewRoleDoc>(
   },
   {
     timestamps: true,
-    collection: 'v2_webhooks',
+    collection: 'v2_review_roles',
   },
 )
 

--- a/backend/src/models/ReviewRole.ts
+++ b/backend/src/models/ReviewRole.ts
@@ -9,9 +9,9 @@ export interface ReviewRoleInterface {
   name: string
   short: string
   kind: RoleKindKeys
-  description: string
-  defaultEntities: string[]
-  lockEntities: boolean
+  description?: string
+  defaultEntities?: string[]
+  lockEntities?: boolean
   collaboratorRole?: CollaboratorRolesKeys
 }
 
@@ -24,8 +24,8 @@ const ReviewRoleSchema = new Schema<ReviewRoleDoc>(
     short: { type: String, required: true, unique: true, index: true },
     kind: { type: String, required: true },
     description: { type: String },
-    defaultEntities: [{ type: String, required: true, unique: true, index: true }],
-    lockEntities: { type: Boolean, required: true },
+    defaultEntities: [{ type: String }],
+    lockEntities: { type: Boolean, default: false },
   },
   {
     timestamps: true,

--- a/backend/src/models/ReviewRole.ts
+++ b/backend/src/models/ReviewRole.ts
@@ -1,0 +1,45 @@
+import { model, Schema } from 'mongoose'
+import MongooseDelete, { SoftDeleteDocument } from 'mongoose-delete'
+
+import { RoleKindKeys } from '../types/types.js'
+import { CollaboratorRolesKeys } from './Model.js'
+
+export interface ReviewRoleInterface {
+  id: string
+  name: string
+  short: string
+  kind: RoleKindKeys
+  description: string
+  defaultEntities: string[]
+  lockEntities: boolean
+  collaboratorRole?: CollaboratorRolesKeys
+}
+
+export type ReviewRoleDoc = ReviewRoleInterface & SoftDeleteDocument
+
+const ReviewRoleSchema = new Schema<ReviewRoleDoc>(
+  {
+    id: { type: String, required: true, unique: true, index: true },
+    name: { type: String, required: true, unique: true, index: true },
+    short: { type: String, required: true, unique: true, index: true },
+    kind: { type: String, required: true },
+    description: { type: String },
+    defaultEntities: [{ type: String, required: true, unique: true, index: true }],
+    lockEntities: { type: Boolean, required: true },
+  },
+  {
+    timestamps: true,
+    collection: 'v2_webhooks',
+  },
+)
+
+ReviewRoleSchema.plugin(MongooseDelete, {
+  overrideMethods: 'all',
+  deletedBy: true,
+  deletedByType: Schema.Types.ObjectId,
+  deletedAt: true,
+})
+
+const ReviewRoleModel = model<ReviewRoleDoc>('v2_Review_Role', ReviewRoleSchema)
+
+export default ReviewRoleModel

--- a/backend/src/models/Token.ts
+++ b/backend/src/models/Token.ts
@@ -36,6 +36,15 @@ export const TokenActions = {
     id: 'schema:write',
     description: 'Grants permissions to upload and modify schemas for administrators.',
   },
+
+  ReviewRoleWrite: {
+    id: 'reviewRole:write',
+    description: 'Grants permission to upload and modify review roles',
+  },
+  ReviewRoleRead: {
+    id: 'reviewRole:read',
+    description: 'Grants permission to view review roles',
+  },
 } as const
 
 export const tokenActionIds = Object.values(TokenActions).map((tokenAction) => tokenAction.id)

--- a/backend/src/routes.ts
+++ b/backend/src/routes.ts
@@ -59,9 +59,11 @@ import { putRelease } from './routes/v2/release/putRelease.js'
 import { getResponses } from './routes/v2/response/getResponses.js'
 import { patchResponse } from './routes/v2/response/patchResponse.js'
 import { patchResponseReaction } from './routes/v2/response/patchResponseReaction.js'
+import { getReviewRoles } from './routes/v2/review/getReviewRoles.js'
 import { getReviews } from './routes/v2/review/getReviews.js'
 import { postAccessRequestReviewResponse } from './routes/v2/review/postAccessRequestReviewResponse.js'
 import { postReleaseReviewResponse } from './routes/v2/review/postReleaseReviewResponse.js'
+import { postReviewRole } from './routes/v2/review/postReviewRole.js'
 import { deleteSchema } from './routes/v2/schema/deleteSchema.js'
 import { getSchema } from './routes/v2/schema/getSchema.js'
 import { getSchemas } from './routes/v2/schema/getSchemas.js'
@@ -197,6 +199,11 @@ server.get('/api/v2/specification', ...getSpecification)
 
 server.get('/api/v2/filescanning/info', ...getFilescanningInfo)
 server.put('/api/v2/filescanning/model/:modelId/file/:fileId/scan', ...putFileScan)
+
+server.get('/api/v2/review/roles', ...getReviewRoles)
+server.post('/api/v2/review/role', ...postReviewRole)
+
+// Review roles are currently WIP
 
 // Python docs
 const __filename = fileURLToPath(import.meta.url)

--- a/backend/src/routes.ts
+++ b/backend/src/routes.ts
@@ -203,8 +203,6 @@ server.put('/api/v2/filescanning/model/:modelId/file/:fileId/scan', ...putFileSc
 server.get('/api/v2/review/roles', ...getReviewRoles)
 server.post('/api/v2/review/role', ...postReviewRole)
 
-// Review roles are currently WIP
-
 // Python docs
 const __filename = fileURLToPath(import.meta.url)
 const __dirname = path.dirname(__filename)

--- a/backend/src/routes/v2/review/getReviewRoles.ts
+++ b/backend/src/routes/v2/review/getReviewRoles.ts
@@ -14,7 +14,8 @@ registerPath({
   method: 'get',
   path: '/api/v2/review/roles',
   tags: ['review'],
-  description: 'Fetch all review roles',
+  description:
+    'Fetch all review roles. Note - dynamic review roles are currently WIP and might not be fully functional.',
   schema: getReviewRolesSchema,
   responses: {
     200: {

--- a/backend/src/routes/v2/review/getReviewRoles.ts
+++ b/backend/src/routes/v2/review/getReviewRoles.ts
@@ -38,7 +38,7 @@ interface GetReviewRolesResponse {
 export const getReviewRoles = [
   bodyParser.json(),
   async (req: Request, res: Response<GetReviewRolesResponse>) => {
-    req.audit = AuditInfo.ViewReviewRole
+    req.audit = AuditInfo.ViewReviewRoles
     const reviewRoles = await findReviewRoles()
     await audit.onViewReviewRoles(req, reviewRoles)
     res.setHeader('x-count', reviewRoles.length)

--- a/backend/src/routes/v2/review/getReviewRoles.ts
+++ b/backend/src/routes/v2/review/getReviewRoles.ts
@@ -1,0 +1,46 @@
+import bodyParser from 'body-parser'
+import { Request, Response } from 'express'
+import { z } from 'zod'
+
+import { AuditInfo } from '../../../connectors/audit/Base.js'
+import audit from '../../../connectors/audit/index.js'
+import { ReviewRoleInterface } from '../../../models/ReviewRole.js'
+import { findReviewRoles } from '../../../services/review.js'
+import { registerPath, reviewRoleSchema } from '../../../services/specification.js'
+
+export const getReviewRolesSchema = z.object({})
+
+registerPath({
+  method: 'get',
+  path: '/api/v2/review/roles',
+  tags: ['review'],
+  description: 'Fetch all review roles',
+  schema: getReviewRolesSchema,
+  responses: {
+    200: {
+      description: 'An array of review roles.',
+      content: {
+        'application/json': {
+          schema: z.object({
+            reviews: z.array(reviewRoleSchema),
+          }),
+        },
+      },
+    },
+  },
+})
+
+interface GetReviewRolesResponse {
+  reviewRoles: Array<ReviewRoleInterface>
+}
+
+export const getReviewRoles = [
+  bodyParser.json(),
+  async (req: Request, res: Response<GetReviewRolesResponse>) => {
+    req.audit = AuditInfo.ViewReviewRole
+    const reviewRoles = await findReviewRoles()
+    await audit.onViewReviewRoles(req, reviewRoles)
+    res.setHeader('x-count', reviewRoles.length)
+    return res.json({ reviewRoles })
+  },
+]

--- a/backend/src/routes/v2/review/postReviewRole.ts
+++ b/backend/src/routes/v2/review/postReviewRole.ts
@@ -60,7 +60,6 @@ export const postReviewRole = [
     const { body } = parse(req, postReviewRoleSchema)
 
     const reviewRole = await createReviewRole(req.user, body)
-    console.log(reviewRole)
     await audit.onCreateReviewRole(req, reviewRole.id)
 
     return res.json({ reviewRole })

--- a/backend/src/routes/v2/review/postReviewRole.ts
+++ b/backend/src/routes/v2/review/postReviewRole.ts
@@ -1,0 +1,64 @@
+import bodyParser from 'body-parser'
+import { Request, Response } from 'express'
+import { z } from 'zod'
+
+import { AuditInfo } from '../../../connectors/audit/Base.js'
+import audit from '../../../connectors/audit/index.js'
+import { CollaboratorRoles } from '../../../models/Model.js'
+import { ReviewRoleInterface } from '../../../models/ReviewRole.js'
+import { createReviewRole } from '../../../services/review.js'
+import { registerPath, reviewRoleSchema } from '../../../services/specification.js'
+import { RoleKind } from '../../../types/types.js'
+import { getEnumValues } from '../../../utils/enum.js'
+import { parse } from '../../../utils/validate.js'
+
+export const postReviewRoleSchema = z.object({
+  body: z.object({
+    id: z.string().openapi({ example: 'reviewer' }),
+    name: z.string().openapi({ example: 'Reviewer' }),
+    short: z.string().openapi({ example: 'reviewer' }),
+    kind: z.enum(getEnumValues(RoleKind)).exclude([RoleKind.ENTRY]).openapi({ example: RoleKind.SCHEMA }),
+    description: z.string().openapi({ example: 'This is an example review role' }),
+    defaultEntities: z.array(z.string()).openapi({ example: ['user:user'] }),
+    lockEntities: z.boolean().openapi({ example: false }),
+    CollaboratorRoles: z.string().optional().openapi({ example: CollaboratorRoles.Owner }),
+  }),
+})
+
+registerPath({
+  method: 'post',
+  path: '/api/v2/review/role',
+  tags: ['review'],
+  description: 'Used for creating a new review role.',
+  schema: postReviewRoleSchema,
+  responses: {
+    200: {
+      description: 'A review role',
+      content: {
+        'application/json': {
+          schema: z.object({
+            reviewRoleSchema,
+          }),
+        },
+      },
+    },
+  },
+})
+
+interface PostReviewRoleResponse {
+  reviewRole: ReviewRoleInterface
+}
+
+export const postReviewRole = [
+  bodyParser.json(),
+  async (req: Request, res: Response<PostReviewRoleResponse>) => {
+    req.audit = AuditInfo.CreateReviewRole
+
+    const { body } = parse(req, postReviewRoleSchema)
+
+    const reviewRole = await createReviewRole(req.user, body)
+    await audit.onCreateReviewRole(req, reviewRole.id)
+
+    return res.json({ reviewRole })
+  },
+]

--- a/backend/src/routes/v2/review/postReviewRole.ts
+++ b/backend/src/routes/v2/review/postReviewRole.ts
@@ -32,7 +32,8 @@ registerPath({
   method: 'post',
   path: '/api/v2/review/role',
   tags: ['review'],
-  description: 'Used for creating a new review role.',
+  description:
+    'Used for creating a new review role. Note - dynamic review roles are currently WIP and might not be fully functional.',
   schema: postReviewRoleSchema,
   responses: {
     200: {

--- a/backend/src/routes/v2/review/postReviewRole.ts
+++ b/backend/src/routes/v2/review/postReviewRole.ts
@@ -18,9 +18,12 @@ export const postReviewRoleSchema = z.object({
     name: z.string().openapi({ example: 'Reviewer' }),
     short: z.string().openapi({ example: 'reviewer' }),
     kind: z.enum(getEnumValues(RoleKind)).exclude([RoleKind.ENTRY]).openapi({ example: RoleKind.SCHEMA }),
-    description: z.string().openapi({ example: 'This is an example review role' }),
-    defaultEntities: z.array(z.string()).openapi({ example: ['user:user'] }),
-    lockEntities: z.boolean().openapi({ example: false }),
+    description: z.string().optional().openapi({ example: 'This is an example review role' }),
+    defaultEntities: z
+      .array(z.string())
+      .optional()
+      .openapi({ example: ['user:user'] }),
+    lockEntities: z.boolean().optional().openapi({ example: false }),
     CollaboratorRoles: z.string().optional().openapi({ example: CollaboratorRoles.Owner }),
   }),
 })
@@ -57,6 +60,7 @@ export const postReviewRole = [
     const { body } = parse(req, postReviewRoleSchema)
 
     const reviewRole = await createReviewRole(req.user, body)
+    console.log(reviewRole)
     await audit.onCreateReviewRole(req, reviewRole.id)
 
     return res.json({ reviewRole })

--- a/backend/src/services/review.ts
+++ b/backend/src/services/review.ts
@@ -1,13 +1,15 @@
 import authentication from '../connectors/authentication/index.js'
-import { ModelAction } from '../connectors/authorisation/actions.js'
+import { ModelAction, ReviewRoleAction } from '../connectors/authorisation/actions.js'
 import authorisation from '../connectors/authorisation/index.js'
 import { AccessRequestDoc } from '../models/AccessRequest.js'
 import { CollaboratorEntry, ModelDoc, ModelInterface } from '../models/Model.js'
 import { ReleaseDoc } from '../models/Release.js'
 import Review, { ReviewDoc, ReviewInterface } from '../models/Review.js'
+import ReviewRoleModel, { ReviewRoleInterface } from '../models/ReviewRole.js'
 import { UserInterface } from '../models/User.js'
 import { ReviewKind, ReviewKindKeys } from '../types/enums.js'
-import { BadReq, InternalError, NotFound } from '../utils/error.js'
+import { BadReq, Forbidden, InternalError, NotFound } from '../utils/error.js'
+import { handleDuplicateKeys } from '../utils/mongo.js'
 import log from './log.js'
 import { getModelById } from './model.js'
 import { requestReviewForAccessRequest, requestReviewForRelease } from './smtp/smtp.js'
@@ -203,4 +205,29 @@ async function findUserInCollaborators(user: UserInterface) {
       ],
     },
   }
+}
+
+export async function createReviewRole(user: UserInterface, newReviewRole: ReviewRoleInterface) {
+  const reviewRole = new ReviewRoleModel({
+    ...newReviewRole,
+  })
+
+  const auth = await authorisation.reviewRole(user, reviewRole, ReviewRoleAction.Create)
+  if (!auth.success) {
+    throw Forbidden(auth.info, {
+      userDn: user.dn,
+    })
+  }
+
+  try {
+    return await reviewRole.save()
+  } catch (error) {
+    handleDuplicateKeys(error)
+    throw error
+  }
+}
+
+export async function findReviewRoles(): Promise<ReviewRoleInterface[]> {
+  const reviewRoles = await ReviewRoleModel.find()
+  return reviewRoles
 }

--- a/backend/src/services/review.ts
+++ b/backend/src/services/review.ts
@@ -225,6 +225,8 @@ export async function createReviewRole(user: UserInterface, newReviewRole: Revie
     handleDuplicateKeys(error)
     throw error
   }
+
+  return reviewRole
 }
 
 export async function findReviewRoles(): Promise<ReviewRoleInterface[]> {

--- a/backend/src/services/specification.ts
+++ b/backend/src/services/specification.ts
@@ -2,6 +2,7 @@ import { OpenAPIRegistry, RouteConfig } from '@asteasolutions/zod-to-openapi'
 import { AnyZodObject, z } from 'zod'
 
 import { ScanState } from '../connectors/fileScanning/Base.js'
+import { CollaboratorRoles } from '../models/Model.js'
 import { Decision, ResponseKind } from '../models/Response.js'
 import { ArtefactKind } from '../models/Scan.js'
 import { TokenScope } from '../models/Token.js'
@@ -329,4 +330,15 @@ export const UserInformationSchema = z.object({
   email: z.string().optional().openapi({ example: 'user@example.com' }),
   name: z.string().optional().openapi({ example: 'Joe Bloggs' }),
   organisation: z.string().optional().openapi({ example: 'Acme Corp' }),
+})
+
+export const reviewRoleSchema = z.object({
+  id: z.string().openapi({ example: 'reviewer' }),
+  name: z.string().openapi({ example: 'Reviewer' }),
+  short: z.string().openapi({ example: 'reviewer' }),
+  kind: z.string().openapi({ example: 'schema' }),
+  description: z.string().openapi({ example: 'This is an example review role' }),
+  defaultEntities: z.array(z.string()).openapi({ example: ['user:user'] }),
+  lockEntities: z.boolean().openapi({ example: false }),
+  CollaboratorRoles: z.string().optional().openapi({ example: CollaboratorRoles.Owner }),
 })

--- a/backend/test/routes/review/__snapshots__/getReviewRoles.spec.ts.snap
+++ b/backend/test/routes/review/__snapshots__/getReviewRoles.spec.ts.snap
@@ -1,0 +1,23 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`routes > review > getReviewRoles > audit > expected call 1`] = `
+[
+  {
+    "id": "my-role-125",
+    "name": "Reviewer",
+    "short": "reviewer",
+  },
+]
+`;
+
+exports[`routes > review > getReviewRoles > returns review roles 1`] = `
+{
+  "reviewRoles": [
+    {
+      "id": "my-role-125",
+      "name": "Reviewer",
+      "short": "reviewer",
+    },
+  ],
+}
+`;

--- a/backend/test/routes/review/__snapshots__/postReviewRole.spec.ts.snap
+++ b/backend/test/routes/review/__snapshots__/postReviewRole.spec.ts.snap
@@ -1,0 +1,13 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`routes > review > postReviewRole > audit > expected call 1`] = `"my-role-125"`;
+
+exports[`routes > review > postReviewRole > creates and returns new review role 1`] = `
+{
+  "reviewRole": {
+    "id": "my-role-125",
+    "name": "Reviewer",
+    "short": "reviewer",
+  },
+}
+`;

--- a/backend/test/routes/review/getReviewRoles.spec.ts
+++ b/backend/test/routes/review/getReviewRoles.spec.ts
@@ -1,0 +1,36 @@
+import { describe, expect, test, vi } from 'vitest'
+
+import audit from '../../../src/connectors/audit/__mocks__/index.js'
+import { testGet } from '../../testUtils/routes.js'
+import { testReviewRole } from '../../testUtils/testModels.js'
+
+vi.mock('../../../src/utils/user.js')
+vi.mock('../../../src/connectors/audit/index.js')
+vi.mock('../../../src/connectors/authorisation/index.js')
+
+const mockReviewService = vi.hoisted(() => {
+  return {
+    findReviewRoles: vi.fn(() => [testReviewRole]),
+  }
+})
+vi.mock('../../../src/services/review.js', () => mockReviewService)
+
+describe('routes > review > getReviewRoles', () => {
+  const endpoint = `/api/v2/review/roles`
+
+  test('audit > expected call', async () => {
+    const res = await testGet(`${endpoint}`)
+
+    expect(res.statusCode).toBe(200)
+    expect(audit.onViewReviewRoles).toBeCalled()
+    expect(audit.onViewReviewRoles.mock.calls.at(0)?.at(1)).toMatchSnapshot()
+  })
+
+  test('returns review roles', async () => {
+    const res = await testGet(`${endpoint}`)
+
+    expect(res.statusCode).toBe(200)
+    expect(res.header['x-count']).toBe('1')
+    expect(res.body).matchSnapshot()
+  })
+})

--- a/backend/test/routes/review/postReviewRole.spec.ts
+++ b/backend/test/routes/review/postReviewRole.spec.ts
@@ -1,0 +1,36 @@
+import { describe, expect, test, vi } from 'vitest'
+
+import audit from '../../../src/connectors/audit/__mocks__/index.js'
+import { createFixture, testPost } from '../../testUtils/routes.js'
+import { testReviewRole } from '../../testUtils/testModels.js'
+import { postReviewRoleSchema } from '../../../src/routes/v2/review/postReviewRole.js'
+
+vi.mock('../../../src/utils/user.js')
+vi.mock('../../../src/connectors/audit/index.js')
+vi.mock('../../../src/connectors/authorisation/index.js')
+
+const mockReviewService = vi.hoisted(() => {
+  return {
+    createReviewRole: vi.fn(() => testReviewRole),
+  }
+})
+vi.mock('../../../src/services/review.js', () => mockReviewService)
+
+describe('routes > review > postReviewRole', () => {
+  const endpoint = `/api/v2/review/role`
+
+  test('audit > expected call', async () => {
+    const res = await testPost(`${endpoint}`, createFixture(postReviewRoleSchema))
+
+    expect(res.statusCode).toBe(200)
+    expect(audit.onCreateReviewRole).toBeCalled()
+    expect(audit.onCreateReviewRole.mock.calls.at(0)?.at(1)).toMatchSnapshot()
+  })
+
+  test('creates and returns new review role', async () => {
+    const res = await testPost(`${endpoint}`, createFixture(postReviewRoleSchema))
+
+    expect(res.statusCode).toBe(200)
+    expect(res.body).matchSnapshot()
+  })
+})

--- a/backend/test/routes/review/postReviewRole.spec.ts
+++ b/backend/test/routes/review/postReviewRole.spec.ts
@@ -1,9 +1,9 @@
 import { describe, expect, test, vi } from 'vitest'
 
 import audit from '../../../src/connectors/audit/__mocks__/index.js'
+import { postReviewRoleSchema } from '../../../src/routes/v2/review/postReviewRole.js'
 import { createFixture, testPost } from '../../testUtils/routes.js'
 import { testReviewRole } from '../../testUtils/testModels.js'
-import { postReviewRoleSchema } from '../../../src/routes/v2/review/postReviewRole.js'
 
 vi.mock('../../../src/utils/user.js')
 vi.mock('../../../src/connectors/audit/index.js')

--- a/backend/test/services/__snapshots__/review.spec.ts.snap
+++ b/backend/test/services/__snapshots__/review.spec.ts.snap
@@ -68,6 +68,10 @@ exports[`services > review > findReviewsForAccessRequests > success 1`] = `
 ]
 `;
 
+exports[`services > review > getReviewRoles > returns array of review roles 1`] = `undefined`;
+
+exports[`services > review > getReviewRoles > returns array of review roles 2`] = `undefined`;
+
 exports[`services > review > removeAccessRequestReviews > successful 1`] = `
 [
   {

--- a/backend/test/services/__snapshots__/review.spec.ts.snap
+++ b/backend/test/services/__snapshots__/review.spec.ts.snap
@@ -1,5 +1,9 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
+exports[`services > review > createReviewRole > successful 1`] = `undefined`;
+
+exports[`services > review > createReviewRole > successful 2`] = `undefined`;
+
 exports[`services > review > findReviews > active reviews for a specific model 1`] = `
 [
   {

--- a/backend/test/services/review.spec.ts
+++ b/backend/test/services/review.spec.ts
@@ -6,10 +6,12 @@ import Release from '../../src/models/Release.js'
 import {
   createAccessRequestReviews,
   createReleaseReviews,
+  findReviewRoles,
   findReviews,
   findReviewsForAccessRequests,
   removeAccessRequestReviews,
 } from '../../src/services/review.js'
+import ReviewRoleModel from '../../src/models/ReviewRole.js'
 
 vi.mock('../../src/connectors/authorisation/index.js')
 vi.mock('../../src/connectors/authentication/index.js', async () => ({
@@ -46,6 +48,38 @@ const reviewModelMock = vi.hoisted(() => {
 vi.mock('../../src/models/Review.js', async () => ({
   ...((await vi.importActual('../../src/models/Review.js')) as object),
   default: reviewModelMock,
+}))
+
+const reviewRoleModelMock = vi.hoisted(() => {
+  const obj: any = {}
+
+  obj.aggregate = vi.fn(() => obj)
+  obj.match = vi.fn(() => obj)
+  obj.sort = vi.fn(() => obj)
+  obj.lookup = vi.fn(() => obj)
+  obj.append = vi.fn(() => obj)
+  obj.find = vi.fn(() => [obj])
+  obj.findOne = vi.fn(() => obj)
+  obj.findOneAndUpdate = vi.fn(() => obj)
+  obj.findByIdAndUpdate = vi.fn(() => obj)
+  obj.updateOne = vi.fn(() => obj)
+  obj.save = vi.fn(() => obj)
+  obj.delete = vi.fn(() => obj)
+  obj.limit = vi.fn(() => obj)
+  obj.unwind = vi.fn(() => obj)
+  obj.at = vi.fn(() => obj)
+  obj.map = vi.fn(() => [])
+  obj.filter = vi.fn(() => [])
+
+  const model: any = vi.fn(() => obj)
+  Object.assign(model, obj)
+
+  return model
+})
+
+vi.mock('../../src/models/ReviewRole.js', async () => ({
+  ...((await vi.importActual('../../src/models/ReviewRole.js')) as object),
+  default: reviewRoleModelMock,
 }))
 
 const smtpMock = vi.hoisted(() => ({
@@ -141,4 +175,13 @@ describe('services > review', () => {
       /^The requested access request review could not be deleted./,
     )
   })
+
+  test('getReviewRoles > returns array of review roles', async () => {
+    await findReviewRoles()
+
+    expect(reviewRoleModelMock.match.mock.calls.at(0)).toMatchSnapshot()
+    expect(reviewRoleModelMock.match.mock.calls.at(1)).toMatchSnapshot()
+  })
+
+  // post test
 })

--- a/backend/test/services/review.spec.ts
+++ b/backend/test/services/review.spec.ts
@@ -6,14 +6,23 @@ import Release from '../../src/models/Release.js'
 import {
   createAccessRequestReviews,
   createReleaseReviews,
+  createReviewRole,
   findReviewRoles,
   findReviews,
   findReviewsForAccessRequests,
   removeAccessRequestReviews,
 } from '../../src/services/review.js'
-import ReviewRoleModel from '../../src/models/ReviewRole.js'
 
-vi.mock('../../src/connectors/authorisation/index.js')
+vi.mock('../../src/connectors/authorisation/index.js', async () => ({
+  default: {
+    reviewRole: vi.fn(() => {
+      return { id: '', success: true }
+    }),
+    models: vi.fn(() => {
+      return { id: '', success: true }
+    }),
+  },
+}))
 vi.mock('../../src/connectors/authentication/index.js', async () => ({
   default: { getEntities: vi.fn(() => ['user:test']) },
 }))
@@ -183,5 +192,15 @@ describe('services > review', () => {
     expect(reviewRoleModelMock.match.mock.calls.at(1)).toMatchSnapshot()
   })
 
-  // post test
+  test('createReviewRole > successful', async () => {
+    await createReviewRole(user, {
+      id: 'test',
+      name: 'reviewer',
+      short: 'reviewer',
+      kind: 'schema',
+    })
+
+    expect(reviewRoleModelMock.match.mock.calls.at(0)).toMatchSnapshot()
+    expect(reviewRoleModelMock.match.mock.calls.at(1)).toMatchSnapshot()
+  })
 })

--- a/backend/test/testUtils/testModels.ts
+++ b/backend/test/testUtils/testModels.ts
@@ -107,3 +107,9 @@ export const testResponse = {
   createdAt: '2024-05-17T06:13:41.690Z',
   _id: '6646f5953391b094ca4f55ee',
 }
+
+export const testReviewRole = {
+  id: 'my-role-125',
+  name: 'Reviewer',
+  short: 'reviewer',
+}


### PR DESCRIPTION
Review roles are a WIP part of dynamic role work. Bailo currently relies on statically defined review roles, whereas in the future we want admins to be able to create whatever role they want for the review process.