### PR TITLE
Issue #1889: Optimise Python Client Logger Strings (Part 2)

### DIFF
--- a/lib/python/src/bailo/helper/access_request.py
+++ b/lib/python/src/bailo/helper/access_request.py
@@ -58,7 +58,7 @@ class AccessRequest:
         schema_id = json_access_request["schemaId"]
 
         logger.info(
-            f"Access request %s for model %s successfully retrieved from server.",
+            "Access request %s for model %s successfully retrieved from server.",
             access_request_id,
             model_id,
         )
@@ -99,7 +99,7 @@ class AccessRequest:
         created_by = access_request_json["createdBy"]
 
         logger.info(
-            f"Access request successfully created on server with ID %s for model %s.",
+            "Access request successfully created on server with ID %s for model %s.",
             access_request_id,
             model_id,
         )

--- a/lib/python/src/bailo/helper/model.py
+++ b/lib/python/src/bailo/helper/model.py
@@ -351,7 +351,7 @@ class Model(Entry):
 
         latest_release = max(releases)
         logger.info(
-            f"latest_release (%s) for %s retrieved successfully.",
+            "latest_release (%s) for %s retrieved successfully.",
             str(latest_release.version),
             self.model_id,
         )
@@ -513,7 +513,7 @@ class Experiment:
         runs = client.search_runs([experiment_id])
         if len(runs):
             logger.info(
-                f"Successfully retrieved MLFlow experiment %s from tracking server. %d were found.",
+                "Successfully retrieved MLFlow experiment %s from tracking server. %d were found.",
                 experiment_id,
                 len(runs),
             )
@@ -543,7 +543,7 @@ class Experiment:
                 mlflow.artifacts.download_artifacts(artifact_uri=artifact_uri, dst_path=mlflow_dir)  # type: ignore[reportPrivateImportUsage]
                 artifacts.append(mlflow_dir)
                 logger.info(
-                    f"Successfully downloaded artifacts for MLFlow experiment %s to %s.",
+                    "Successfully downloaded artifacts for MLFlow experiment %s to %s.",
                     experiment_id,
                     mlflow_dir,
                 )
@@ -631,7 +631,7 @@ class Experiment:
             release_new = self.model.create_release(version=release_new_version, minor=True, notes=notes)
 
             logger.info(
-                f"Uploading %d artifacts to version %s of model %s.",
+                "Uploading %d artifacts to version %s of model %s.",
                 len(artifacts),
                 str(release_new_version),
                 self.model.model_id,
@@ -644,7 +644,7 @@ class Experiment:
                 shutil.rmtree(self.temp_dir)
 
         logger.info(
-            f"Successfully published experiment run %s to model %s.",
+            "Successfully published experiment run %s to model %s.",
             str(run_id),
             self.model.model_id,
         )

--- a/lib/python/src/bailo/helper/release.py
+++ b/lib/python/src/bailo/helper/release.py
@@ -108,7 +108,7 @@ class Release:
             draft,
         )
         logger.info(
-            f"Release %s successfully created on server for model with ID %s.",
+            "Release %s successfully created on server for model with ID %s.",
             str(version),
             model_id,
         )
@@ -143,7 +143,7 @@ class Release:
         draft = res["draft"]
 
         logger.info(
-            f"Release %s of model ID %s successfully retrieved from server.",
+            "Release %s of model ID %s successfully retrieved from server.",
             str(version),
             model_id,
         )
@@ -171,7 +171,7 @@ class Release:
         """
         res = self.client.get_download_by_filename(self.model_id, str(self.version), filename)
         logger.info(
-            f"Downloading file %s from version %s of %s...",
+            "Downloading file %s from version %s of %s...",
             filename,
             str(self.version),
             self.model_id,
@@ -203,7 +203,7 @@ class Release:
             logger.info("File written to %s", path)
 
         logger.info(
-            f"Downloading of file %s from version %s of %s completed.",
+            "Downloading of file %s from version %s of %s completed.",
             filename,
             str(self.version),
             self.model_id,
@@ -245,7 +245,7 @@ class Release:
             ]
 
         logger.info(
-            f"Downloading %d of %%d files for version %s of %s...",
+            "Downloading %d of %%d files for version %s of %s...",
             len(file_names),
             len(orig_file_names),
             str(self.version),
@@ -266,7 +266,7 @@ class Release:
         ..note:: If path provided is a directory, it will be uploaded as a zip
         """
         logger.info(
-            f"Uploading file(s) to version %s of %s...",
+            "Uploading file(s) to version %s of %s...",
             str(self.version),
             self.model_id,
         )
@@ -281,7 +281,7 @@ class Release:
 
             if zip_required:
                 logger.info(
-                    f"Given path (%s) is a directory. This will be converted to a zip file for upload.",
+                    "Given path (%s) is a directory. This will be converted to a zip file for upload.",
                     path,
                 )
                 shutil.make_archive(name, "zip", path)
@@ -321,7 +321,7 @@ class Release:
         if to_close:
             data.close()
         logger.info(
-            f"Upload of file %s to version %s of %s complete.",
+            "Upload of file %s to version %s of %s complete.",
             name,
             str(self.version),
             self.model_id,


### PR DESCRIPTION
Fixing issue https://github.com/gchq/Bailo/issues/1889 by removing the f-string when % formatting is used. Continuation of some logs I missed from PR #2165 