### PR TITLE
Remove swcMinify flag from lib/landing

### DIFF
--- a/lib/landing/next.config.mjs
+++ b/lib/landing/next.config.mjs
@@ -19,7 +19,6 @@ const withMDX = nextMDX({
 
 export default withMDX({
   // Append the default value with md extensions
-  swcMinify: true,
   output: 'export',
   pageExtensions: ['ts', 'tsx', 'js', 'jsx', 'md', 'mdx'],
   reactStrictMode: true,


### PR DESCRIPTION
As per https://nextjs.org/docs/architecture/nextjs-compiler#minification
> Good to know: Starting with v15, minification cannot be customized using `next.config.js`. Support for the `swcMinify` flag has been removed.