### PR TITLE
Expect pytest warning

### DIFF
--- a/lib/python/tests/test_model.py
+++ b/lib/python/tests/test_model.py
@@ -62,7 +62,8 @@ def test_create_get_from_id_and_update(
 
 @pytest.mark.integration
 def test_search_models(integration_client):
-    models = Model.search(client=integration_client)
+    with pytest.warns(UserWarning):
+        models = Model.search(client=integration_client)
 
     assert all(isinstance(model, Model) for model in models)
 


### PR DESCRIPTION
Currently, when the Python tests are run in `/lib/python/` `pytest` will generate the warning `ID testmodel-<id> does not have any associated cards. If needed, create a card with the .card_from_schema() method.` This is expected behaviour, but appears as a warning under every PR in GitHub so looks like a potential problem when it is not.

This warning is generated at https://github.com/gchq/Bailo/blob/main/lib/python/src/bailo/helper/entry.py#L98 so any tests that call this function (e.g. `test_search_models`) need updating to capture the warning https://docs.pytest.org/en/7.1.x/how-to/capture-warnings.html