### PR TITLE
WIP for denying responses

### DIFF
--- a/backend/src/models/Response.ts
+++ b/backend/src/models/Response.ts
@@ -5,6 +5,7 @@ export const Decision = {
   RequestChanges: 'request_changes',
   Approve: 'approve',
   Undo: 'undo',
+  Deny: 'deny',
 } as const
 export type DecisionKeys = (typeof Decision)[keyof typeof Decision]
 

--- a/backend/src/models/Review.ts
+++ b/backend/src/models/Review.ts
@@ -2,6 +2,7 @@ import { model, Schema } from 'mongoose'
 import MongooseDelete, { SoftDeleteDocument } from 'mongoose-delete'
 
 import { ReviewKind, ReviewKindKeys } from '../types/enums.js'
+import { DecisionKeys } from './Response.js'
 
 // This interface stores information about the properties on the base object.
 // It should be used for plain object representations, e.g. for sending to the
@@ -16,6 +17,8 @@ export interface ReviewInterface {
 
   createdAt: Date
   updatedAt: Date
+
+  decision?: DecisionKeys
 }
 
 // The doc type includes all values in the plain interface, as well as all the

--- a/backend/src/routes/v2/review/getReviews.ts
+++ b/backend/src/routes/v2/review/getReviews.ts
@@ -17,6 +17,7 @@ export const getReviewsSchema = z.object({
     accessRequestId: z.string().optional(),
     kind: z.nativeEnum(ReviewKind).optional(),
     mine: strictCoerceBoolean(z.boolean().optional().default(true)),
+    decision: strictCoerceBoolean(z.boolean().optional().default(false)),
   }),
 })
 
@@ -49,10 +50,10 @@ export const getReviews = [
   async (req: Request, res: Response<GetReviewResponse>) => {
     req.audit = AuditInfo.SearchReviews
     const {
-      query: { mine, modelId, semver, accessRequestId, kind },
+      query: { mine, modelId, semver, accessRequestId, kind, decision },
     } = parse(req, getReviewsSchema)
 
-    const reviews = await findReviews(req.user, mine, modelId, semver, accessRequestId, kind)
+    const reviews = await findReviews(req.user, mine, decision, modelId, semver, accessRequestId, kind)
     await audit.onSearchReviews(req, reviews)
 
     res.setHeader('x-count', reviews.length)

--- a/backend/src/routes/v2/review/postAccessRequestReviewResponse.ts
+++ b/backend/src/routes/v2/review/postAccessRequestReviewResponse.ts
@@ -17,12 +17,12 @@ const staticProperties = z.object({
 
 const optionalComment = z.object({
   comment: z.string().optional(),
-  decision: z.enum(getEnumValues(Decision)).exclude([Decision.RequestChanges]),
+  decision: z.enum(getEnumValues(Decision)).exclude([Decision.RequestChanges, Decision.Deny]),
 })
 
 const mandatoryComment = z.object({
-  comment: z.string().min(1, 'A comment must be supplied when requesting changes'),
-  decision: z.literal(Decision.RequestChanges),
+  comment: z.string().min(1, 'A comment must be supplied when requesting changes or denying a request'),
+  decision: z.enum(getEnumValues(Decision)).exclude([Decision.Approve, Decision.Undo]),
 })
 
 export const postAccessRequestReviewResponseSchema = z.object({

--- a/backend/src/routes/v2/review/postReleaseReviewResponse.ts
+++ b/backend/src/routes/v2/review/postReleaseReviewResponse.ts
@@ -17,12 +17,12 @@ const staticProperties = z.object({
 
 const optionalComment = z.object({
   comment: z.string().optional(),
-  decision: z.enum(getEnumValues(Decision)).exclude([Decision.RequestChanges]),
+  decision: z.enum(getEnumValues(Decision)).exclude([Decision.RequestChanges, Decision.Deny]),
 })
 
 const mandatoryComment = z.object({
-  comment: z.string().min(1, 'A comment must be supplied when requesting changes'),
-  decision: z.literal(Decision.RequestChanges),
+  comment: z.string().min(1, 'A comment must be supplied when requesting changes or denying a request'),
+  decision: z.enum(getEnumValues(Decision)).exclude([Decision.Approve, Decision.Undo]),
 })
 
 export const postReleaseReviewResponseSchema = z.object({

--- a/frontend/src/common/ReviewWithComment.tsx
+++ b/frontend/src/common/ReviewWithComment.tsx
@@ -184,6 +184,7 @@ export default function ReviewWithComment({
                 )}
                 <LoadingButton
                   variant='outlined'
+                  color='warning'
                   onClick={() => submitForm(Decision.RequestChanges)}
                   loading={loading}
                   data-test='requestChangesReviewButton'
@@ -192,6 +193,16 @@ export default function ReviewWithComment({
                 </LoadingButton>
                 <LoadingButton
                   variant='contained'
+                  color='error'
+                  onClick={() => submitForm(Decision.Deny)}
+                  loading={loading}
+                  data-test='denyReviewButton'
+                >
+                  Deny
+                </LoadingButton>
+                <LoadingButton
+                  variant='contained'
+                  color='success'
                   onClick={() => submitForm(Decision.Approve)}
                   loading={loading}
                   data-test='approveReviewButton'

--- a/frontend/src/entry/model/reviews/ReviewDisplay.tsx
+++ b/frontend/src/entry/model/reviews/ReviewDisplay.tsx
@@ -5,6 +5,7 @@ import ApprovalsDisplay from 'src/entry/model/reviews/ApprovalsDisplay'
 import { Decision, ResponseInterface } from 'types/types'
 import { sortByCreatedAtDescending } from 'utils/arrayUtils'
 import { fromEntity } from 'utils/entityUtils'
+import { isFinalised } from 'utils/reviewUtils'
 import { plural } from 'utils/stringUtils'
 
 export interface ReviewDisplayProps {
@@ -32,7 +33,7 @@ export default function ReviewDisplay({
 
   return (
     <>
-      {orderedReviewResponses.length > 0 && orderedReviewResponses[0].decision === Decision.Approve && (
+      {orderedReviewResponses.length > 0 && isFinalised(orderedReviewResponses[0].decision) && (
         <ApprovalsDisplay
           modelId={modelId}
           acceptedReviewResponses={orderedReviewResponses}

--- a/frontend/src/reviews/ReviewDecisionDisplay.tsx
+++ b/frontend/src/reviews/ReviewDecisionDisplay.tsx
@@ -1,4 +1,4 @@
-import { Undo } from '@mui/icons-material'
+import { ErrorOutline, Undo } from '@mui/icons-material'
 import Done from '@mui/icons-material/Done'
 import HourglassEmpty from '@mui/icons-material/HourglassEmpty'
 import MoreHorizIcon from '@mui/icons-material/MoreHoriz'
@@ -120,11 +120,15 @@ export default function ReviewDecisionDisplay({
                 <span data-test='reviewDecisionDisplayApproved'>
                   {response.decision === Decision.Approve && 'has approved'}
                 </span>
+                <span data-test='reviewDecisionDisplayDenied'>
+                  {response.decision === Decision.Deny && 'has denied'}
+                </span>
                 <span data-test='reviewDecisionDisplayRequestChanges'>
                   {response.decision === Decision.RequestChanges && 'has requested changes'}
                 </span>
                 <span>{response.decision === Decision.Undo && 'has undone their review'}</span>
                 <span>{response.decision === Decision.Approve && <Done color='success' fontSize='small' />}</span>
+                <span>{response.decision === Decision.Deny && <ErrorOutline color='error' fontSize='small' />}</span>
                 <span>
                   {response.decision === Decision.RequestChanges && <HourglassEmpty color='warning' fontSize='small' />}
                 </span>

--- a/frontend/types/types.ts
+++ b/frontend/types/types.ts
@@ -517,6 +517,7 @@ export const Decision = {
   RequestChanges: 'request_changes',
   Approve: 'approve',
   Undo: 'undo',
+  Deny: 'deny',
 } as const
 export type DecisionKeys = (typeof Decision)[keyof typeof Decision]
 

--- a/frontend/utils/reviewUtils.ts
+++ b/frontend/utils/reviewUtils.ts
@@ -1,9 +1,15 @@
 import { groupBy } from 'lodash-es'
-import { ResponseInterface, ReviewRequestInterface } from 'types/types'
+import { DecisionKeys, ResponseInterface, ReviewRequestInterface } from 'types/types'
 import { sortByCreatedAtAscending } from 'utils/arrayUtils'
 
 interface GroupedReviewResponse {
   [user: string]: ResponseInterface[]
+}
+
+export const finalisedDecisions: Array<DecisionKeys> = ['approve', 'deny']
+
+export function isFinalised(decision: DecisionKeys | undefined) {
+  return decision && finalisedDecisions.includes(decision)
 }
 
 export function latestReviewsForEachUser(reviews: ReviewRequestInterface[], responses: ResponseInterface[]) {


### PR DESCRIPTION
Currently reviewerss can 'request changes' or 'approve' when responding to review, but there isn't any way to 'deny' and indicate that the request is unlikely to go any further regardless of changes provided by the submitter.

The most obvious addition is the 'Deny' button when on the response page. To avoid confusion, I've adjusted the colours of the 'request changes' and 'approve' buttons to more clearly highlight the difference between the actions. Definitely room for improvement here in the future. In particular, we're adding yet more frontend-filtering to figure out whether a review is 'archived' or not, which we still want to move to the backend.

There's also some work to categorise 'approve' and 'deny' as 'finalised' states which, whilst not 'locked', would usually indicate a role has provided their final response to the review. We could use this in the future to soft-lock the decision and warn the reviewer if they try to undo or otherwise change their review from a 'final' state into something else.

At the backend, there's some work to provide a 'summarised' response from the responses so far. The main path is from findReviews (used by the frontend) which will now also provide a 'decision' in the response. This decision is calculated by finding the 'latest' response for each role associated with a review, and using some basic logic to figure out what should be classed as the 'current' response for that role.

Still in draft/WIP - there's another commit to come which improves the backend filtering.