### PR TITLE
add await to vitest expect reject tests

### DIFF
--- a/backend/test/clients/cognito.spec.ts
+++ b/backend/test/clients/cognito.spec.ts
@@ -54,7 +54,7 @@ describe('clients > cognito', () => {
     vi.spyOn(configMock, 'oauth', 'get').mockReturnValueOnce({})
     const response = listUsers('dn')
 
-    expect(response).rejects.toThrowError('Cannot find userIdAttribute in oauth configuration')
+    await expect(response).rejects.toThrowError('Cannot find userIdAttribute in oauth configuration')
   })
 
   test('listUsers > do not include users with missing DN', async () => {
@@ -88,7 +88,7 @@ describe('clients > cognito', () => {
 
     const response = listUsers('dn')
 
-    expect(response).rejects.toThrowError('Error when querying Cognito for users')
+    await expect(response).rejects.toThrowError('Error when querying Cognito for users')
   })
 
   test('listUsers > exact match', async () => {
@@ -118,7 +118,7 @@ describe('clients > cognito', () => {
 
     const response = getGroupMembership('group1')
 
-    expect(response).rejects.toThrowError('Error when querying Cognito for group membership')
+    await expect(response).rejects.toThrowError('Error when querying Cognito for group membership')
   })
 
   test('getGroupMembership > no users', async () => {

--- a/backend/test/clients/inferencing.spec.ts
+++ b/backend/test/clients/inferencing.spec.ts
@@ -46,7 +46,7 @@ describe('clients > inferencing', () => {
       text: vi.fn(() => 'Unrecognised response'),
       json: vi.fn(),
     })
-    expect(() => createInferenceService({} as any)).rejects.toThrowError(
+    await expect(() => createInferenceService({} as any)).rejects.toThrowError(
       /^Unrecognised response returned by the inferencing service./,
     )
   })
@@ -54,7 +54,7 @@ describe('clients > inferencing', () => {
   test('createInferencing > rejected', async () => {
     fetchMock.default.mockRejectedValueOnce('Unable to communicate with the inferencing service.')
 
-    expect(() => createInferenceService({} as any)).rejects.toThrowError(
+    await expect(() => createInferenceService({} as any)).rejects.toThrowError(
       /^Unable to communicate with the inferencing service./,
     )
   })
@@ -62,7 +62,7 @@ describe('clients > inferencing', () => {
   test('createInferencing > no authorization token', async () => {
     vi.spyOn(configMock, 'inference', 'get').mockReturnValueOnce({ authorisationToken: '' })
 
-    expect(() => createInferenceService({} as any)).rejects.toThrowError(/^No authentication key exists./)
+    await expect(() => createInferenceService({} as any)).rejects.toThrowError(/^No authentication key exists./)
   })
 
   test('updateInferencing > success', async () => {
@@ -84,7 +84,7 @@ describe('clients > inferencing', () => {
       text: vi.fn(() => 'Unrecognised response'),
       json: vi.fn(),
     })
-    expect(() => updateInferenceService({} as any)).rejects.toThrowError(
+    await expect(() => updateInferenceService({} as any)).rejects.toThrowError(
       /^Unrecognised response returned by the inferencing service./,
     )
   })
@@ -92,7 +92,7 @@ describe('clients > inferencing', () => {
   test('updateInferencing > rejected', async () => {
     fetchMock.default.mockRejectedValueOnce('Unable to communicate with the inferencing service.')
 
-    expect(() => updateInferenceService({} as any)).rejects.toThrowError(
+    await expect(() => updateInferenceService({} as any)).rejects.toThrowError(
       /^Unable to communicate with the inferencing service./,
     )
   })
@@ -100,6 +100,6 @@ describe('clients > inferencing', () => {
   test('updateInferencing > no authorization token', async () => {
     vi.spyOn(configMock, 'inference', 'get').mockReturnValueOnce({ authorisationToken: '' })
 
-    expect(() => updateInferenceService({} as any)).rejects.toThrowError(/^No authentication key exists./)
+    await expect(() => updateInferenceService({} as any)).rejects.toThrowError(/^No authentication key exists./)
   })
 })

--- a/backend/test/clients/kms.spec.ts
+++ b/backend/test/clients/kms.spec.ts
@@ -69,7 +69,7 @@ describe('clients > s3', () => {
     expect(kmsMocks.DescribeKeyCommand).toHaveBeenCalledWith({
       KeyId: configMock.modelMirror.export.kmsSignature.keyId,
     })
-    expect(response).rejects.toThrowError(/^Cannot get key information./)
+    await expect(response).rejects.toThrowError(/^Cannot get key information./)
   })
 
   test('sign > cannot get signature', async () => {
@@ -85,6 +85,6 @@ describe('clients > s3', () => {
     expect(kmsMocks.DescribeKeyCommand).toHaveBeenCalledWith({
       KeyId: configMock.modelMirror.export.kmsSignature.keyId,
     })
-    expect(response).rejects.toThrowError(/^Cannot get signature./)
+    await expect(response).rejects.toThrowError(/^Cannot get signature./)
   })
 })

--- a/backend/test/clients/modelScan.spec.ts
+++ b/backend/test/clients/modelScan.spec.ts
@@ -51,13 +51,15 @@ describe('clients > modelScan', () => {
       json: vi.fn(),
     })
 
-    expect(() => getModelScanInfo()).rejects.toThrowError(/^Unrecognised response returned by the ModelScan service./)
+    await expect(() => getModelScanInfo()).rejects.toThrowError(
+      /^Unrecognised response returned by the ModelScan service./,
+    )
   })
 
   test('getModelScanInfo > rejected', async () => {
     fetchMock.default.mockRejectedValueOnce('Unable to communicate with the inferencing service.')
 
-    expect(() => getModelScanInfo()).rejects.toThrowError(/^Unable to communicate with the ModelScan service./)
+    await expect(() => getModelScanInfo()).rejects.toThrowError(/^Unable to communicate with the ModelScan service./)
   })
 
   test('scanStream > success', async () => {
@@ -108,7 +110,7 @@ describe('clients > modelScan', () => {
       text: vi.fn(() => 'Unrecognised response'),
       json: vi.fn(),
     })
-    expect(() => scanStream(new PassThrough(), 'safe_model.h5', 0)).rejects.toThrowError(
+    await expect(() => scanStream(new PassThrough(), 'safe_model.h5', 0)).rejects.toThrowError(
       /^Unrecognised response returned by the ModelScan service./,
     )
   })
@@ -116,7 +118,7 @@ describe('clients > modelScan', () => {
   test('scanStream > rejected', async () => {
     fetchMock.default.mockRejectedValueOnce('Unable to communicate with the ModelScan service.')
 
-    expect(() => scanStream(new PassThrough(), 'safe_model.h5', 0)).rejects.toThrowError(
+    await expect(() => scanStream(new PassThrough(), 'safe_model.h5', 0)).rejects.toThrowError(
       /^Unable to communicate with the ModelScan service./,
     )
   })

--- a/backend/test/clients/registry.spec.ts
+++ b/backend/test/clients/registry.spec.ts
@@ -52,7 +52,7 @@ describe('clients > registry', () => {
     fetchMock.default.mockRejectedValueOnce('Error')
     const response = getImageTagManifest('token', { namespace: 'modelId', image: 'image' }, 'tag1')
 
-    expect(response).rejects.toThrowError('Unable to communicate with the registry.')
+    await expect(response).rejects.toThrowError('Unable to communicate with the registry.')
   })
 
   test('getImageTagManifest > unrecognised error response', async () => {
@@ -64,7 +64,7 @@ describe('clients > registry', () => {
     })
     const response = getImageTagManifest('token', { namespace: 'modelId', image: 'image' }, 'tag1')
 
-    expect(response).rejects.toThrowError('Unrecognised response returned by the registry.')
+    await expect(response).rejects.toThrowError('Unrecognised response returned by the registry.')
   })
 
   test('getImageTagManifest > unrecognised error response', async () => {
@@ -84,7 +84,7 @@ describe('clients > registry', () => {
     })
     const response = getImageTagManifest('token', { namespace: 'modelId', image: 'image' }, 'tag1')
 
-    expect(response).rejects.toThrowError('Error response received from registry.')
+    await expect(response).rejects.toThrowError('Error response received from registry.')
   })
 
   test('getImageTagManifest > malformed response', async () => {
@@ -97,7 +97,7 @@ describe('clients > registry', () => {
 
     const response = getImageTagManifest('token', { namespace: 'modelId', image: 'image' }, 'tag1')
 
-    expect(response).rejects.toThrowError('Unrecognised response body when getting image tag manifest.')
+    await expect(response).rejects.toThrowError('Unrecognised response body when getting image tag manifest.')
   })
 
   test('getImageTagManifest > missing repositories in response', async () => {
@@ -110,7 +110,7 @@ describe('clients > registry', () => {
 
     const response = getImageTagManifest('token', { namespace: 'modelId', image: 'image' }, 'tag1')
 
-    expect(response).rejects.toThrowError('Unrecognised response body when getting image tag manifest.')
+    await expect(response).rejects.toThrowError('Unrecognised response body when getting image tag manifest.')
   })
 
   test('getImageTagManifest > throw all errors apart from unknown name', async () => {
@@ -131,7 +131,7 @@ describe('clients > registry', () => {
 
     const response = getImageTagManifest('token', { namespace: 'modelId', image: 'image' }, 'tag1')
 
-    expect(response).rejects.toThrowError('Error response received from registry.')
+    await expect(response).rejects.toThrowError('Error response received from registry.')
   })
 
   test('getRegistryLayerStream > success', async () => {
@@ -155,7 +155,7 @@ describe('clients > registry', () => {
     fetchMock.default.mockRejectedValueOnce('Error')
     const response = getRegistryLayerStream('token', { namespace: 'modelId', image: 'image' }, 'sha256:digest1')
 
-    expect(response).rejects.toThrowError('Unable to communicate with the registry.')
+    await expect(response).rejects.toThrowError('Unable to communicate with the registry.')
   })
 
   test('getRegistryLayerStream > unrecognised error response', async () => {
@@ -167,7 +167,7 @@ describe('clients > registry', () => {
     })
     const response = getRegistryLayerStream('token', { namespace: 'modelId', image: 'image' }, 'sha256:digest1')
 
-    expect(response).rejects.toThrowError('Unrecognised response returned by the registry.')
+    await expect(response).rejects.toThrowError('Unrecognised response returned by the registry.')
   })
 
   test('getRegistryLayerStream > malformed response', async () => {
@@ -182,7 +182,7 @@ describe('clients > registry', () => {
 
     const response = getRegistryLayerStream('token', { namespace: 'modelId', image: 'image' }, 'sha256:digest1')
 
-    expect(response).rejects.toThrowError('Unrecognised response body when getting image layer blob.')
+    await expect(response).rejects.toThrowError('Unrecognised response body when getting image layer blob.')
   })
 
   test('listModelRepos > only returns model repos', async () => {
@@ -204,7 +204,7 @@ describe('clients > registry', () => {
     fetchMock.default.mockRejectedValueOnce('Error')
     const response = listModelRepos('token', 'modelId')
 
-    expect(response).rejects.toThrowError('Unable to communicate with the registry.')
+    await expect(response).rejects.toThrowError('Unable to communicate with the registry.')
   })
 
   test('listModelRepos > unrecognised error response', async () => {
@@ -216,7 +216,7 @@ describe('clients > registry', () => {
     })
     const response = listModelRepos('token', 'modelId')
 
-    expect(response).rejects.toThrowError('Unrecognised response returned by the registry.')
+    await expect(response).rejects.toThrowError('Unrecognised response returned by the registry.')
   })
 
   test('listModelRepos > unrecognised error response', async () => {
@@ -236,7 +236,7 @@ describe('clients > registry', () => {
     })
     const response = listModelRepos('token', 'modelId')
 
-    expect(response).rejects.toThrowError('Error response received from registry.')
+    await expect(response).rejects.toThrowError('Error response received from registry.')
   })
 
   test('listModelRepos > malformed response', async () => {
@@ -248,7 +248,7 @@ describe('clients > registry', () => {
     })
     const response = listModelRepos('token', 'modelId')
 
-    expect(response).rejects.toThrowError('Unrecognised response body when listing model repositories.')
+    await expect(response).rejects.toThrowError('Unrecognised response body when listing model repositories.')
   })
 
   test('listModelRepos > missing repositories in response', async () => {
@@ -260,7 +260,7 @@ describe('clients > registry', () => {
     })
     const response = listModelRepos('token', 'modelId')
 
-    expect(response).rejects.toThrowError('Unrecognised response body when listing model repositories.')
+    await expect(response).rejects.toThrowError('Unrecognised response body when listing model repositories.')
   })
 
   test('listImageTags > success', async () => {
@@ -289,7 +289,7 @@ describe('clients > registry', () => {
 
     const response = listImageTags('token', { namespace: 'modelId', image: 'image' })
 
-    expect(response).rejects.toThrowError('Unrecognised response body when listing image tags.')
+    await expect(response).rejects.toThrowError('Unrecognised response body when listing image tags.')
   })
 
   test('listImageTags > missing repositories in response', async () => {
@@ -302,7 +302,7 @@ describe('clients > registry', () => {
 
     const response = listImageTags('token', { namespace: 'modelId', image: 'image' })
 
-    expect(response).rejects.toThrowError('Unrecognised response body when listing image tags.')
+    await expect(response).rejects.toThrowError('Unrecognised response body when listing image tags.')
   })
 
   test('listImageTags > unknown name return empty list', async () => {
@@ -344,6 +344,6 @@ describe('clients > registry', () => {
 
     const response = listImageTags('token', { namespace: 'modelId', image: 'image' })
 
-    expect(response).rejects.toThrowError('Error response received from registry.')
+    await expect(response).rejects.toThrowError('Error response received from registry.')
   })
 })

--- a/backend/test/clients/s3.spec.ts
+++ b/backend/test/clients/s3.spec.ts
@@ -53,7 +53,7 @@ describe('clients > s3', () => {
 
     const response = putObjectStream(bucket, key, body)
 
-    expect(response).rejects.toThrowError('Unable to upload the object to the S3 service.')
+    await expect(response).rejects.toThrowError('Unable to upload the object to the S3 service.')
   })
 
   test('getObjectStream > success', async () => {
@@ -80,7 +80,7 @@ describe('clients > s3', () => {
 
     const response = getObjectStream(bucket, key, range)
 
-    expect(response).rejects.toThrowError('Unable to retrieve the object from the S3 service.')
+    await expect(response).rejects.toThrowError('Unable to retrieve the object from the S3 service.')
   })
 
   test('objectExists > success', async () => {
@@ -119,7 +119,7 @@ describe('clients > s3', () => {
 
     const response = objectExists(bucket, key)
 
-    expect(response).rejects.toThrowError('Unable to get object metadata from the S3 service.')
+    await expect(response).rejects.toThrowError('Unable to get object metadata from the S3 service.')
   })
 
   test('ensureBucketExists > create new bucket', async () => {
@@ -144,7 +144,7 @@ describe('clients > s3', () => {
 
     const response = ensureBucketExists(bucket)
 
-    expect(response).rejects.toThrowError('There was a problem ensuring this bucket exists.')
+    await expect(response).rejects.toThrowError('There was a problem ensuring this bucket exists.')
   })
 
   test('ensureBucketExists > create bucket error', async () => {
@@ -154,6 +154,6 @@ describe('clients > s3', () => {
 
     const response = ensureBucketExists(bucket)
 
-    expect(response).rejects.toThrowError('Unable to create a new bucket.')
+    await expect(response).rejects.toThrowError('Unable to create a new bucket.')
   })
 })

--- a/backend/test/connectors/authentication/oauth.spec.ts
+++ b/backend/test/connectors/authentication/oauth.spec.ts
@@ -81,7 +81,7 @@ describe('connectors > authentication > oauth', () => {
     const connector = new OauthAuthenticationConnector()
     const response = connector.getUserInformation('group:name')
 
-    expect(response).rejects.toThrowError('Cannot get user information for a non-user entity: group:name')
+    await expect(response).rejects.toThrowError('Cannot get user information for a non-user entity: group:name')
   })
 
   test('getUserInformation > returns user information', async () => {
@@ -102,7 +102,7 @@ describe('connectors > authentication > oauth', () => {
     const connector = new OauthAuthenticationConnector()
     const response = connector.getUserInformation('user:name')
 
-    expect(response).rejects.toThrowError('Cannot get user information. Found more than one user.')
+    await expect(response).rejects.toThrowError('Cannot get user information. Found more than one user.')
   })
 
   test('getUserInformation > throws error no user is found', async () => {
@@ -111,14 +111,14 @@ describe('connectors > authentication > oauth', () => {
     const connector = new OauthAuthenticationConnector()
     const response = connector.getUserInformation('user:name')
 
-    expect(response).rejects.toThrowError('Cannot get user information. User not found.')
+    await expect(response).rejects.toThrowError('Cannot get user information. User not found.')
   })
 
   test('getEntityMembers > throws error if not a user', async () => {
     const connector = new OauthAuthenticationConnector()
     const response = connector.getEntityMembers('unknown:name')
 
-    expect(response).rejects.toThrowError('Unable to get members, entity kind not recognised')
+    await expect(response).rejects.toThrowError('Unable to get members, entity kind not recognised')
   })
 
   test('getEntityMembers > returns entity', async () => {

--- a/backend/test/models/Token.spec.ts
+++ b/backend/test/models/Token.spec.ts
@@ -38,7 +38,7 @@ describe('models > Token', () => {
 
     const result = token.compareToken('abc')
 
-    expect(result).rejects.toThrowError('Compare Error')
+    await expect(result).rejects.toThrowError('Compare Error')
   })
 
   test('compareToken > return error for unrecognised hash method', async () => {
@@ -48,7 +48,7 @@ describe('models > Token', () => {
 
     const result = token.compareToken('abc')
 
-    expect(result).rejects.toThrowError('Unexpected hash type: unknown method')
+    await expect(result).rejects.toThrowError('Unexpected hash type: unknown method')
   })
 
   test('compareToken > return true on successful bcrypt comparison', async () => {

--- a/backend/test/services/accessRequest.spec.ts
+++ b/backend/test/services/accessRequest.spec.ts
@@ -85,7 +85,7 @@ describe('services > accessRequest', () => {
     modelMocks.getModelById.mockResolvedValue(undefined)
     schemaMocks.getSchemaById.mockResolvedValue({ jsonSchema: {} })
 
-    expect(() => createAccessRequest({} as any, 'example-model', accessRequest)).rejects.toThrowError(
+    await expect(() => createAccessRequest({} as any, 'example-model', accessRequest)).rejects.toThrowError(
       /^You do not have permission/,
     )
   })
@@ -119,7 +119,7 @@ describe('services > accessRequest', () => {
       id: '',
     })
 
-    expect(() => removeAccessRequest({} as any, 'test')).rejects.toThrowError(
+    await expect(() => removeAccessRequest({} as any, 'test')).rejects.toThrowError(
       /^You do not have permission to delete this access request./,
     )
   })

--- a/backend/test/services/inference.spec.ts
+++ b/backend/test/services/inference.spec.ts
@@ -86,7 +86,7 @@ describe('services > inference', () => {
 
   test('createInference > non-existent image', async () => {
     const mockUser: any = { dn: 'test' }
-    expect(() =>
+    await expect(() =>
       createInference(mockUser, 'test', { image: 'non-existent', tag: 'image' } as any),
     ).rejects.toThrowError(/^Image non-existent:image was not found on this model./)
   })
@@ -94,7 +94,9 @@ describe('services > inference', () => {
   test('createInference > bad authorisation', async () => {
     vi.mocked(authorisation.model).mockResolvedValue({ info: 'You do not have permission', success: false, id: '' })
 
-    expect(() => createInference({} as any, 'modelId', inference)).rejects.toThrowError(/^You do not have permission/)
+    await expect(() => createInference({} as any, 'modelId', inference)).rejects.toThrowError(
+      /^You do not have permission/,
+    )
   })
 
   test('createInference > existing service', async () => {
@@ -104,7 +106,7 @@ describe('services > inference', () => {
       mockKey: 'mockValue',
     }
     inferenceModelMocks.save.mockRejectedValueOnce(mongoError)
-    expect(() => createInference({} as any, 'test', inference)).rejects.toThrowError(
+    await expect(() => createInference({} as any, 'test', inference)).rejects.toThrowError(
       /^A service with this image already exists./,
     )
   })
@@ -123,7 +125,7 @@ describe('services > inference', () => {
 
   test('updateInference > inference not found', async () => {
     vi.mocked(inferenceModelMocks.findOneAndUpdate).mockResolvedValueOnce()
-    expect(() =>
+    await expect(() =>
       updateInference({} as any, 'test', 'non-existent', 'image', {
         description: 'New description',
         settings: {
@@ -138,7 +140,7 @@ describe('services > inference', () => {
   test('updateInference > bad authorisation', async () => {
     vi.mocked(authorisation.model).mockResolvedValue({ info: 'You do not have permission', success: false, id: '' })
 
-    expect(() =>
+    await expect(() =>
       updateInference({} as any, 'test', 'nginx', 'latest', {
         description: 'New description',
         settings: {
@@ -163,13 +165,13 @@ describe('services > inference', () => {
       success: false,
       id: '',
     })
-    expect(() => getInferenceByImage({} as any, 'test', 'nginx', 'latest')).rejects.toThrowError(
+    await expect(() => getInferenceByImage({} as any, 'test', 'nginx', 'latest')).rejects.toThrowError(
       /^You do not have permission to view this inference./,
     )
   })
   test('getInferenceByImage > no inference', async () => {
     inferenceModelMocks.findOne.mockResolvedValueOnce(undefined)
-    expect(() => getInferenceByImage({} as any, 'test', 'nginx', 'latest')).rejects.toThrowError(
+    await expect(() => getInferenceByImage({} as any, 'test', 'nginx', 'latest')).rejects.toThrowError(
       /^The requested inferencing service was not found./,
     )
   })
@@ -187,6 +189,6 @@ describe('services > inference', () => {
   test('getInferenceByModel > bad authorisation', async () => {
     vi.mocked(authorisation.model).mockResolvedValue({ info: 'You do not have permission', success: false, id: '' })
 
-    expect(() => getInferencesByModel({} as any, 'modelId')).rejects.toThrowError(/^You do not have permission/)
+    await expect(() => getInferencesByModel({} as any, 'modelId')).rejects.toThrowError(/^You do not have permission/)
   })
 })

--- a/backend/test/services/model.spec.ts
+++ b/backend/test/services/model.spec.ts
@@ -103,7 +103,7 @@ describe('services > model', () => {
   test('createModel > bad authorisation', async () => {
     vi.mocked(authorisation.model).mockResolvedValueOnce({ info: 'You do not have permission', success: false, id: '' })
 
-    expect(() => createModel({} as any, {} as any)).rejects.toThrowError(/^You do not have permission/)
+    await expect(() => createModel({} as any, {} as any)).rejects.toThrowError(/^You do not have permission/)
     expect(modelMocks.save).not.toBeCalled()
   })
 
@@ -114,7 +114,7 @@ describe('services > model', () => {
       id: '',
     })
 
-    expect(() => createModel({} as any, {} as any)).rejects.toThrowError(
+    await expect(() => createModel({} as any, {} as any)).rejects.toThrowError(
       /^You cannot select both settings simultaneously./,
     )
     expect(modelMocks.save).not.toBeCalled()
@@ -124,7 +124,7 @@ describe('services > model', () => {
     authenticationMocks.getUserInformation.mockImplementation(() => {
       throw new Error('Unable to find user user:unknown_user')
     })
-    expect(() =>
+    await expect(() =>
       createModel({} as any, { collaborators: [{ entity: 'user:unknown_user', roles: [] }] } as any),
     ).rejects.toThrowError(/^Unable to find user user:unknown_user/)
   })
@@ -142,13 +142,13 @@ describe('services > model', () => {
     modelMocks.findOne.mockResolvedValueOnce({})
     vi.mocked(authorisation.model).mockResolvedValue({ info: 'You do not have permission', success: false, id: '' })
 
-    expect(() => getModelById({} as any, {} as any)).rejects.toThrowError(/^You do not have permission/)
+    await expect(() => getModelById({} as any, {} as any)).rejects.toThrowError(/^You do not have permission/)
   })
 
   test('getModelById > no model', async () => {
     modelMocks.findOne.mockResolvedValueOnce(undefined)
 
-    expect(() => getModelById({} as any, {} as any)).rejects.toThrowError(/^The requested entry was not found/)
+    await expect(() => getModelById({} as any, {} as any)).rejects.toThrowError(/^The requested entry was not found/)
   })
 
   test('canUserActionModelById > allowed', async () => {
@@ -293,7 +293,9 @@ describe('services > model', () => {
       success: false,
       id: '',
     })
-    expect(() => updateModelCard({} as any, '123', {} as any)).rejects.toThrowError(/^Cannot alter a mirrored model./)
+    await expect(() => updateModelCard({} as any, '123', {} as any)).rejects.toThrowError(
+      /^Cannot alter a mirrored model./,
+    )
   })
 
   test('updateModel > should throw bad request when attempting to change a standard model to be a mirrored model', async () => {
@@ -302,7 +304,7 @@ describe('services > model', () => {
       success: false,
       id: '',
     })
-    expect(() =>
+    await expect(() =>
       updateModel({} as any, '123', { settings: { mirror: { sourceModelId: '', destinationModelId: '123' } } }),
     ).rejects.toThrowError(/^Cannot change standard model to be a mirrored model./)
   })
@@ -313,7 +315,7 @@ describe('services > model', () => {
       success: false,
       id: '',
     })
-    expect(() =>
+    await expect(() =>
       updateModel({} as any, '123', { settings: { mirror: { sourceModelId: '', destinationModelId: '123' } } }),
     ).rejects.toThrowError(/^Cannot set a destination model ID for a mirrored model./)
   })
@@ -324,7 +326,7 @@ describe('services > model', () => {
       success: false,
       id: '',
     })
-    expect(() =>
+    await expect(() =>
       updateModel({} as any, '123', { settings: { mirror: { sourceModelId: '123', destinationModelId: '234' } } }),
     ).rejects.toThrowError(/^You cannot select both mirror settings simultaneously./)
   })
@@ -333,7 +335,7 @@ describe('services > model', () => {
     authenticationMocks.getUserInformation.mockImplementation(() => {
       throw new Error('Unable to find user user:unknown_user')
     })
-    expect(() =>
+    await expect(() =>
       updateModel({} as any, '123', { collaborators: [{ entity: 'user:unknown_user', roles: [] }] }),
     ).rejects.toThrowError(/^Unable to find user user:unknown_user/)
   })
@@ -345,7 +347,7 @@ describe('services > model', () => {
       id: '',
     })
 
-    expect(() => createModelCardFromSchema({} as any, '123', 'abc')).rejects.toThrowError(
+    await expect(() => createModelCardFromSchema({} as any, '123', 'abc')).rejects.toThrowError(
       /^Cannot alter a mirrored model./,
     )
     expect(modelMocks.save).not.toBeCalled()
@@ -465,13 +467,13 @@ describe('services > model', () => {
       },
     }
     modelMocks.findOne.mockResolvedValue(testModel)
-    expect(() => createModelCardFromTemplate({} as any, 'testModel', 'testTemplateModel')).rejects.toThrowError(
+    await expect(() => createModelCardFromTemplate({} as any, 'testModel', 'testTemplateModel')).rejects.toThrowError(
       /^The template model is missing a model card/,
     )
   })
 
   test('createModelCardFromTemplate > throw bad request when supplying the same template and model id', async () => {
-    expect(() => createModelCardFromTemplate({} as any, 'testModel', 'testModel')).rejects.toThrowError(
+    await expect(() => createModelCardFromTemplate({} as any, 'testModel', 'testModel')).rejects.toThrowError(
       'The model and template ID must be different',
     )
   })
@@ -482,7 +484,7 @@ describe('services > model', () => {
       success: false,
       id: '',
     })
-    expect(() => createModelCardFromTemplate({} as any, 'testModel', 'testTemplateModel')).rejects.toThrowError(
+    await expect(() => createModelCardFromTemplate({} as any, 'testModel', 'testTemplateModel')).rejects.toThrowError(
       'User does not have access to model',
     )
   })

--- a/backend/test/services/model.spec.ts
+++ b/backend/test/services/model.spec.ts
@@ -360,7 +360,7 @@ describe('services > model', () => {
 
     const result = saveImportedModelCard({} as Omit<ModelCardRevisionDoc, '_id'>)
 
-    expect(result).rejects.toThrowError(/^Unable to validate./)
+    await expect(result).rejects.toThrowError(/^Unable to validate./)
   })
 
   test('saveImportedModelCard > successfully saves model card', async () => {

--- a/backend/test/services/release.spec.ts
+++ b/backend/test/services/release.spec.ts
@@ -163,7 +163,7 @@ describe('services > release', () => {
     registryMocks.listModelImages.mockResolvedValueOnce(existingImages)
     releaseModelMocks.findOneWithDeleted.mockResolvedValue(null)
 
-    expect(() =>
+    await expect(() =>
       createRelease(
         {} as any,
         {
@@ -177,7 +177,6 @@ describe('services > release', () => {
       ),
     ).rejects.toThrowError(/^The following images do not exist in the registry/)
     expect(releaseModelMocks.save).not.toBeCalled()
-    expect(releaseModelMocks).not.toBeCalled()
     expect(mockReviewService.createReleaseReviews).not.toBeCalled()
   })
 
@@ -185,7 +184,7 @@ describe('services > release', () => {
     fileMocks.getFileById.mockResolvedValueOnce({ modelId: 'random_model' })
     releaseModelMocks.findOneWithDeleted.mockResolvedValue(null)
 
-    expect(() =>
+    await expect(() =>
       createRelease(
         {} as any,
         {
@@ -203,7 +202,7 @@ describe('services > release', () => {
     fileMocks.getFileById.mockRejectedValueOnce(NotFound('File not found.'))
     releaseModelMocks.findOneWithDeleted.mockResolvedValue(null)
 
-    expect(() =>
+    await expect(() =>
       createRelease(
         {} as any,
         {
@@ -221,7 +220,7 @@ describe('services > release', () => {
     fileMocks.getFileById.mockRejectedValueOnce(Error('File not found.'))
     releaseModelMocks.findOneWithDeleted.mockResolvedValue(null)
 
-    expect(() =>
+    await expect(() =>
       createRelease(
         {} as any,
         {
@@ -244,7 +243,7 @@ describe('services > release', () => {
     })
     releaseModelMocks.findOneWithDeleted.mockResolvedValue(null)
 
-    expect(
+    await expect(
       async () =>
         await createRelease(
           {} as any,
@@ -277,7 +276,7 @@ describe('services > release', () => {
     vi.mocked(authorisation.release).mockResolvedValue({ info: 'You do not have permission', success: false, id: '' })
 
     releaseModelMocks.findOneWithDeleted.mockResolvedValue(null)
-    expect(() => createRelease({} as any, { semver: 'v1.0.0' } as any)).rejects.toThrowError(
+    await expect(() => createRelease({} as any, { semver: 'v1.0.0' } as any)).rejects.toThrowError(
       /^You do not have permission/,
     )
   })
@@ -303,7 +302,7 @@ describe('services > release', () => {
       settings: { mirror: { sourceModelId: '' } },
     })
 
-    expect(() => createRelease({} as any, { semver: 'v1.0.0' } as any)).rejects.toThrowError(
+    await expect(() => createRelease({} as any, { semver: 'v1.0.0' } as any)).rejects.toThrowError(
       /^This model does not have a model card associated with it/,
     )
 
@@ -317,14 +316,14 @@ describe('services > release', () => {
       settings: { mirror: { sourceModelId: '123' } },
     })
 
-    expect(() => createRelease({} as any, { semver: 'v1.0.0' } as any)).rejects.toThrowError(
+    await expect(() => createRelease({} as any, { semver: 'v1.0.0' } as any)).rejects.toThrowError(
       /^Cannot create a release from a mirrored model/,
     )
   })
 
   test('updateRelease > bad authorisation', async () => {
     vi.mocked(authorisation.release).mockResolvedValue({ info: 'You do not have permission', success: false, id: '' })
-    expect(() => updateRelease({} as any, 'model-id', 'v1.0.0', {} as any)).rejects.toThrowError(
+    await expect(() => updateRelease({} as any, 'model-id', 'v1.0.0', {} as any)).rejects.toThrowError(
       /^You do not have permission/,
     )
   })
@@ -332,7 +331,7 @@ describe('services > release', () => {
   test('updateRelease > release with bad files', async () => {
     fileMocks.getFileById.mockResolvedValueOnce({ modelId: 'random_model' })
 
-    expect(() =>
+    await expect(() =>
       updateRelease({} as any, 'model-id', 'v1.0.0', {
         semver: 'v1.0.0',
         fileIds: ['test'],
@@ -355,7 +354,7 @@ describe('services > release', () => {
       settings: { mirror: { sourceModelId: '123' } },
     })
 
-    expect(() => updateRelease({} as any, 'model-id', 'v1.0.0', {} as any)).rejects.toThrowError(
+    await expect(() => updateRelease({} as any, 'model-id', 'v1.0.0', {} as any)).rejects.toThrowError(
       /^Cannot update a release on a mirrored model./,
     )
   })
@@ -383,7 +382,7 @@ describe('services > release', () => {
       settings: { mirror: { sourceModelId: '123' } },
     })
 
-    expect(() => newReleaseComment({} as any, 'model', '1.0.0', 'This is a new comment')).rejects.toThrowError(
+    await expect(() => newReleaseComment({} as any, 'model', '1.0.0', 'This is a new comment')).rejects.toThrowError(
       /^Cannot create a new comment on a mirrored model./,
     )
     expect(releaseModelMocks.findOneAndUpdate).not.toBeCalled()
@@ -429,9 +428,9 @@ describe('services > release', () => {
   })
 
   test('convertSemverQueryToMongoQuery > convertSemverQueryToMongoQuery handles bad semver', async () => {
-    expect(async () => await getModelReleases({ dn: 'user' } as UserInterface, 'test', '^2.2v.x')).rejects.toThrowError(
-      /^Semver range is invalid./,
-    )
+    await expect(
+      async () => await getModelReleases({ dn: 'user' } as UserInterface, 'test', '^2.2v.x'),
+    ).rejects.toThrowError(/^Semver range is invalid./)
   })
 
   test('getReleaseBySemver > good', async () => {
@@ -445,7 +444,7 @@ describe('services > release', () => {
   test('getReleaseBySemver > no release', async () => {
     releaseModelMocks.findOne.mockResolvedValue(undefined)
 
-    expect(() => getReleaseBySemver({} as any, 'test', 'test')).rejects.toThrowError(
+    await expect(() => getReleaseBySemver({} as any, 'test', 'test')).rejects.toThrowError(
       /^The requested release was not found./,
     )
   })
@@ -460,7 +459,7 @@ describe('services > release', () => {
       id: '',
     })
 
-    expect(() => getReleaseBySemver({} as any, 'test', 'test')).rejects.toThrowError(
+    await expect(() => getReleaseBySemver({} as any, 'test', 'test')).rejects.toThrowError(
       /^You do not have permission to view this release./,
     )
   })
@@ -482,7 +481,7 @@ describe('services > release', () => {
       return { success: false, info: 'Unknown action.', id: '' }
     })
 
-    expect(() => deleteRelease({} as any, 'test', 'test')).rejects.toThrowError(
+    await expect(() => deleteRelease({} as any, 'test', 'test')).rejects.toThrowError(
       /^You do not have permission to delete this release./,
     )
     expect(releaseModelMocks.save).not.toBeCalled()
@@ -495,7 +494,7 @@ describe('services > release', () => {
       settings: { mirror: { sourceModelId: '123' } },
     })
 
-    expect(() => deleteRelease({} as any, 'test', 'test')).rejects.toThrowError(
+    await expect(() => deleteRelease({} as any, 'test', 'test')).rejects.toThrowError(
       /^Cannot delete a release on a mirrored model./,
     )
     expect(releaseModelMocks.save).not.toBeCalled()
@@ -540,7 +539,7 @@ describe('services > release', () => {
     const mockUser: any = { dn: 'test' }
     const mockModel: any = { id: 'test', settings: { mirror: { sourceModelId: '123' } } }
 
-    expect(() => removeFileFromReleases(mockUser, mockModel, '123')).rejects.toThrowError(
+    await expect(() => removeFileFromReleases(mockUser, mockModel, '123')).rejects.toThrowError(
       /^Cannot remove a file from a mirrored model./,
     )
     expect(releaseModelMocks.delete).not.toBeCalled()

--- a/backend/test/services/release.spec.ts
+++ b/backend/test/services/release.spec.ts
@@ -268,7 +268,7 @@ describe('services > release', () => {
         modelCardVersion: 999,
       } as any,
     )
-    expect(result).rejects.toThrowError(/is not a valid semver value./)
+    await expect(result).rejects.toThrowError(/is not a valid semver value./)
 
     expect(releaseModelMocks.save).not.toBeCalled()
   })
@@ -518,7 +518,7 @@ describe('services > release', () => {
 
     const result = removeFileFromReleases(mockUser, mockModel, '')
 
-    expect(result).rejects.toThrowError(/^You do not have permission to update these releases./)
+    await expect(result).rejects.toThrowError(/^You do not have permission to update these releases./)
     expect(releaseModelMocks.updateMany).not.toBeCalled()
   })
 
@@ -568,7 +568,7 @@ describe('services > release', () => {
     fileMocks.getFilesByIds.mockResolvedValueOnce([{ name: 'not_test.png' }])
 
     const result = getFileByReleaseFileName(mockUser, modelId, semver, fileName)
-    expect(result).rejects.toThrowError(/^The requested file name was not found on the release./)
+    await expect(result).rejects.toThrowError(/^The requested file name was not found on the release./)
   })
 
   test('getReleasesForExport > release not found', async () => {
@@ -579,7 +579,7 @@ describe('services > release', () => {
 
     const result = getReleasesForExport(mockUser, modelId, semvers)
 
-    expect(result).rejects.toThrowError(/^The following releases were not found./)
+    await expect(result).rejects.toThrowError(/^The following releases were not found./)
   })
 
   test('getReleasesForExport > release not found', async () => {
@@ -593,7 +593,7 @@ describe('services > release', () => {
 
     const result = getReleasesForExport(mockUser, modelId, semvers)
 
-    expect(result).rejects.toThrowError(/^You do not have the necessary permissions to export these releases./)
+    await expect(result).rejects.toThrowError(/^You do not have the necessary permissions to export these releases./)
   })
 
   test('getReleasesForExport > return releases', async () => {

--- a/backend/test/services/response.spec.ts
+++ b/backend/test/services/response.spec.ts
@@ -378,7 +378,7 @@ describe('services > response', () => {
       'semver',
     )
 
-    expect(result).rejects.toThrowError(`Unable to find Review to respond to`)
+    await expect(result).rejects.toThrowError(`Unable to find Review to respond to`)
     expect(responseModelMock.save).not.toBeCalled()
   })
 

--- a/backend/test/services/review.spec.ts
+++ b/backend/test/services/review.spec.ts
@@ -180,7 +180,7 @@ describe('services > review', () => {
       throw Error('Error deleting object')
     })
 
-    expect(() => removeAccessRequestReviews('')).rejects.toThrowError(
+    await expect(() => removeAccessRequestReviews('')).rejects.toThrowError(
       /^The requested access request review could not be deleted./,
     )
   })

--- a/backend/test/services/schema.spec.ts
+++ b/backend/test/services/schema.spec.ts
@@ -63,7 +63,7 @@ describe('services > schema', () => {
     })
 
     const result = () => createSchema(testUser, testModelSchema)
-    expect(result).rejects.toThrowError(/^You do not have permission to create this schema./)
+    await expect(result).rejects.toThrowError(/^You do not have permission to create this schema./)
 
     expect(mockSchema.save).not.toBeCalled()
     expect(mockSchema.deleteOne).not.toBeCalled()

--- a/backend/test/services/schema.spec.ts
+++ b/backend/test/services/schema.spec.ts
@@ -86,7 +86,7 @@ describe('services > schema', () => {
     mockSchema.save.mockRejectedValueOnce(mongoError)
     mockMongoUtils.isMongoServerError.mockReturnValueOnce(true)
 
-    expect(() => createSchema(testUser, testModelSchema)).rejects.toThrowError(
+    await expect(() => createSchema(testUser, testModelSchema)).rejects.toThrowError(
       /^The following is not unique: {"mockKey":"mockValue"}/,
     )
   })
@@ -98,6 +98,6 @@ describe('services > schema', () => {
   })
 
   test('that a schema cannot be retrieved by ID when schema does not exist', async () => {
-    expect(() => getSchemaById(testModelSchema.id)).rejects.toThrowError(/^The requested schema was not found/)
+    await expect(() => getSchemaById(testModelSchema.id)).rejects.toThrowError(/^The requested schema was not found/)
   })
 })

--- a/backend/test/services/smtp/smtp.spec.ts
+++ b/backend/test/services/smtp/smtp.spec.ts
@@ -201,6 +201,6 @@ describe('services > smtp > smtp', () => {
     transporterMock.sendMail.mockRejectedValueOnce('Failed to send email')
 
     const result: Promise<void> = requestReviewForRelease('user:user', review, release)
-    expect(result).rejects.toThrowError(`Unable to send email`)
+    await expect(result).rejects.toThrowError(`Unable to send email`)
   })
 })

--- a/backend/test/services/webhook.spec.ts
+++ b/backend/test/services/webhook.spec.ts
@@ -88,7 +88,7 @@ describe('services > webhook', () => {
 
     const result = createWebhook(user, { name: 'test', modelId: 'abc', uri: 'test/uri', insecureSSL: false })
 
-    expect(result).rejects.toThrowError(`You do not have permission to update this model.`)
+    await expect(result).rejects.toThrowError(`You do not have permission to update this model.`)
     expect(modelServiceMock.getModelById).toBeCalled()
     expect(webhookModelMock.save).not.toBeCalled()
   })
@@ -98,7 +98,7 @@ describe('services > webhook', () => {
 
     const result = updateWebhook(user, 'modelId', { name: 'test', modelId: 'abc', uri: 'test/uri', insecureSSL: false })
 
-    expect(result).rejects.toThrowError(`You do not have permission to update this model.`)
+    await expect(result).rejects.toThrowError(`You do not have permission to update this model.`)
     expect(modelServiceMock.getModelById).toBeCalled()
     expect(webhookModelMock.findOneAndUpdate).not.toBeCalled()
   })
@@ -108,7 +108,7 @@ describe('services > webhook', () => {
 
     const result = removeWebhook(user, 'model', 'webhook')
 
-    expect(result).rejects.toThrowError(`You do not have permission to update this model.`)
+    await expect(result).rejects.toThrowError(`You do not have permission to update this model.`)
     expect(modelServiceMock.getModelById).toBeCalled()
     expect(webhookModelMock.findOneAndDelete).not.toBeCalled()
   })
@@ -118,7 +118,7 @@ describe('services > webhook', () => {
 
     const result = getWebhooksByModel(user, 'model')
 
-    expect(result).rejects.toThrowError(`You do not have permission to update this model.`)
+    await expect(result).rejects.toThrowError(`You do not have permission to update this model.`)
     expect(modelServiceMock.getModelById).toBeCalled()
     expect(webhookModelMock.find).not.toBeCalled()
   })
@@ -128,7 +128,7 @@ describe('services > webhook', () => {
 
     const result = removeWebhook(user, 'model', 'webhook')
 
-    expect(result).rejects.toThrowError(`The requested webhook was not found.`)
+    await expect(result).rejects.toThrowError(`The requested webhook was not found.`)
     expect(modelServiceMock.getModelById).toBeCalled()
   })
 
@@ -137,7 +137,7 @@ describe('services > webhook', () => {
 
     const result = updateWebhook(user, 'modelId', { name: 'test', modelId: 'abc', uri: 'test/uri', insecureSSL: false })
 
-    expect(result).rejects.toThrowError(`The requested webhook was not found.`)
+    await expect(result).rejects.toThrowError(`The requested webhook was not found.`)
     expect(modelServiceMock.getModelById).toBeCalled()
   })
 


### PR DESCRIPTION
Fixes many instances of
> Promise returned by `expect(actual).rejects.toThrowError(expected)` was not awaited. Vitest currently auto-awaits hanging assertions at the end of the test, but this will cause the test to fail in Vitest 3. Please remember to await the assertion.