### PR TITLE
Add model collaborators get & set methods to python client

### DIFF
--- a/backend/src/models/Model.ts
+++ b/backend/src/models/Model.ts
@@ -19,6 +19,8 @@ export const CollaboratorRoles = {
   Owner: 'owner',
   Contributor: 'contributor',
   Consumer: 'consumer',
+  MSRO: 'msro',
+  MTR: 'mtr',
 } as const
 
 export type CollaboratorRolesKeys = (typeof CollaboratorRoles)[keyof typeof CollaboratorRoles]

--- a/backend/src/routes/v2/model/getModelsSearch.ts
+++ b/backend/src/routes/v2/model/getModelsSearch.ts
@@ -4,7 +4,8 @@ import { z } from 'zod'
 
 import { AuditInfo } from '../../../connectors/audit/Base.js'
 import audit from '../../../connectors/audit/index.js'
-import { EntryKind, EntryKindKeys } from '../../../models/Model.js'
+import { CollaboratorEntry, EntryKind, EntryKindKeys } from '../../../models/Model.js'
+import log from '../../../services/log.js'
 import { searchModels } from '../../../services/model.js'
 import { registerPath } from '../../../services/specification.js'
 import { coerceArray, parse, strictCoerceBoolean } from '../../../utils/validate.js'
@@ -60,6 +61,8 @@ export interface ModelSearchResult {
   tags: Array<string>
   kind: EntryKindKeys
   organisation?: string
+  state?: string
+  collaborators: Array<CollaboratorEntry>
   createdAt: Date
   updatedAt: Date
 }
@@ -94,9 +97,12 @@ export const getModelsSearch = [
       tags: model.card?.metadata?.overview?.tags || [],
       kind: model.kind,
       organisation: model.organisation,
+      state: model.state,
+      collaborators: model.collaborators,
       createdAt: model.createdAt,
       updatedAt: model.updatedAt,
     }))
+    log.debug('Search models', models)
 
     await audit.onSearchModel(req, models)
 

--- a/backend/src/routes/v2/model/getModelsSearch.ts
+++ b/backend/src/routes/v2/model/getModelsSearch.ts
@@ -5,7 +5,6 @@ import { z } from 'zod'
 import { AuditInfo } from '../../../connectors/audit/Base.js'
 import audit from '../../../connectors/audit/index.js'
 import { CollaboratorEntry, EntryKind, EntryKindKeys } from '../../../models/Model.js'
-import log from '../../../services/log.js'
 import { searchModels } from '../../../services/model.js'
 import { registerPath } from '../../../services/specification.js'
 import { coerceArray, parse, strictCoerceBoolean } from '../../../utils/validate.js'
@@ -102,7 +101,6 @@ export const getModelsSearch = [
       createdAt: model.createdAt,
       updatedAt: model.updatedAt,
     }))
-    log.debug('Search models', models)
 
     await audit.onSearchModel(req, models)
 

--- a/backend/test/routes/model/__snapshots__/getModelsSearch.spec.ts.snap
+++ b/backend/test/routes/model/__snapshots__/getModelsSearch.spec.ts.snap
@@ -16,12 +16,14 @@ exports[`routes > model > getModelsSearch > 200 > ok 1`] = `
 exports[`routes > model > getModelsSearch > audit > expected call 1`] = `
 [
   {
+    "collaborators": undefined,
     "createdAt": undefined,
     "description": "description",
     "id": "test",
     "kind": undefined,
     "name": "name",
     "organisation": undefined,
+    "state": undefined,
     "tags": [],
     "updatedAt": undefined,
   },

--- a/lib/python/CHANGELOG.md
+++ b/lib/python/CHANGELOG.md
@@ -8,6 +8,9 @@ All dates are formatted dd/mm/yyyy.
 
 - Rename `Client.post_review` -> `Client.post_release_review` endpoint.
 - Add `Client.post_access_request_review` endpoint.
+- Add `Entry.collaborators` attribute (inherited by `Model` and `DataCard`), and add associated optional parameter
+  `collaborators` to helper `Model.__init__`, `Model.create`, `Model.from_mlflow`, `DataCard.__init__` &
+  `DataCard.create` and core `Client.post_model` & `Client.patch_model` methods.
 
 ## 3.0.0 - 02/04/2025
 

--- a/lib/python/src/bailo/core/agent.py
+++ b/lib/python/src/bailo/core/agent.py
@@ -43,9 +43,9 @@ class Agent:
         try:
             # Give the error message issued by bailo
             raise BailoException(res.json()["error"]["message"])
-        except JSONDecodeError:
+        except JSONDecodeError as e:
             # No response given
-            raise ResponseException(f"{res.status_code} Cannot {method} to {res.request.url}")
+            raise ResponseException(f"{res.status_code} Cannot {method} to {res.request.url}") from e
 
     def get(self, *args, **kwargs):
         return self.__request("GET", *args, **kwargs)

--- a/lib/python/src/bailo/core/client.py
+++ b/lib/python/src/bailo/core/client.py
@@ -26,8 +26,8 @@ class Client:
         description: str,
         visibility: ModelVisibility | None = None,
         organisation: str | None = None,
-        collaborators: list[CollaboratorEntry] | None = None,
         state: str | None = None,
+        collaborators: list[CollaboratorEntry] | None = None,
     ):
         """Create a model.
 
@@ -51,8 +51,8 @@ class Client:
                 "description": description,
                 "visibility": _visibility,
                 "organisation": organisation,
-                "collaborators": collaborators,
                 "state": state,
+                "collaborators": collaborators,
             }
         )
 

--- a/lib/python/src/bailo/core/client.py
+++ b/lib/python/src/bailo/core/client.py
@@ -4,7 +4,7 @@ from io import BytesIO
 from typing import Any
 
 from bailo.core.agent import Agent, TokenAgent
-from bailo.core.enums import EntryKind, ModelVisibility, SchemaKind
+from bailo.core.enums import CollaboratorEntry, EntryKind, ModelVisibility, SchemaKind
 from bailo.core.utils import filter_none
 
 
@@ -26,6 +26,7 @@ class Client:
         description: str,
         visibility: ModelVisibility | None = None,
         organisation: str | None = None,
+        collaborators: list[CollaboratorEntry] | None = None,
         state: str | None = None,
     ):
         """Create a model.
@@ -33,9 +34,10 @@ class Client:
         :param name: Name of the model
         :param kind: Either a Model or a Datacard
         :param description: Description of the model
+        :param visibility: Enum to define model visibility (e.g public or private), defaults to None
         :param organisation: Organisation responsible for the model, defaults to None
         :param state: Development readiness of the model, defaults to None
-        :param visibility: Enum to define model visibility (e.g public or private), defaults to None
+        :param collaborators: list of CollaboratorEntry to define who the model's collaborators (a.k.a. model access) are, defaults to None
         :return: JSON response object
         """
         _visibility: str = "public"
@@ -49,6 +51,7 @@ class Client:
                 "description": description,
                 "visibility": _visibility,
                 "organisation": organisation,
+                "collaborators": collaborators,
                 "state": state,
             }
         )
@@ -111,16 +114,18 @@ class Client:
         visibility: str | None = None,
         organisation: str | None = None,
         state: str | None = None,
+        collaborators: list[CollaboratorEntry] | None = None,
     ):
         """Update a specific model using its unique ID.
 
         :param model_id: Unique model ID
         :param name: Name of the model, defaults to None
-        :param kind: Either a Model or a Datacard
+        :param kind: Either a Model or a Datacard, defaults to None
         :param description: Description of the model, defaults to None
+        :param visibility: Enum to define model visibility (e.g public or private), defaults to None
         :param organisation: Organisation responsible for the model, defaults to None
         :param state: Development readiness of the model, defaults to None
-        :param kind: Either a Model or a Datacard, defaults to None
+        :param collaborators: list of CollaboratorEntry to define who the model's collaborators (a.k.a. model access) are, defaults to None
         :return: JSON response object
         """
         filtered_json = filter_none(
@@ -131,6 +136,7 @@ class Client:
                 "kind": kind,
                 "description": description,
                 "visibility": visibility,
+                "collaborators": collaborators,
             }
         )
 

--- a/lib/python/src/bailo/core/enums.py
+++ b/lib/python/src/bailo/core/enums.py
@@ -28,6 +28,8 @@ class Role(ValuedEnum):
     OWNER = "owner"
     MODEL_TECHNICAL_REVIEWER = "mtr"
     MODEL_SENIOR_RESPONSIBLE_OFFICER = "msro"
+    CONTRIBUTOR = "contributor"
+    CONSUMER = "consumer"
 
 
 class EntryKind(ValuedEnum):
@@ -43,3 +45,10 @@ class MinimalSchema(ValuedEnum):
     MODEL = "minimal-general-v10"
     DATACARD = "minimal-data-card-v10"
     ACCESS_REQUEST = "minimal-access-request-general-v10"
+
+
+class CollaboratorEntry(dict):
+    """A set of roles linked to a given entity (a.k.a. user)."""
+
+    def __init__(self, entity: str, roles: list[Role | str]) -> None:
+        super().__init__(self, entity=entity, roles=roles)

--- a/lib/python/src/bailo/helper/datacard.py
+++ b/lib/python/src/bailo/helper/datacard.py
@@ -67,8 +67,8 @@ class Datacard(Entry):
         :param description: Description of datacard
         :param organisation: Organisation responsible for the model, defaults to None
         :param state: Development readiness of the model, defaults to None
-        :param visibility: Visibility of datacard, using ModelVisibility enum (e.g Public or Private), defaults to None
         :param collaborators: list of CollaboratorEntry to define who the model's collaborators (a.k.a. model access) are, defaults to None
+        :param visibility: Visibility of datacard, using ModelVisibility enum (e.g Public or Private), defaults to None
         :return: Datacard object
         """
         res = client.post_model(
@@ -119,9 +119,9 @@ class Datacard(Entry):
             datacard_id=datacard_id,
             name=res["name"],
             description=res["description"],
+            collaborators=res["collaborators"],
             organisation=res.get("organisation"),
             state=res.get("state"),
-            collaborators=res.get("collaborators"),
         )
         datacard._unpack(res)
 

--- a/lib/python/src/bailo/helper/datacard.py
+++ b/lib/python/src/bailo/helper/datacard.py
@@ -4,7 +4,7 @@ import logging
 from typing import Any
 
 from bailo.core.client import Client
-from bailo.core.enums import EntryKind, ModelVisibility
+from bailo.core.enums import CollaboratorEntry, EntryKind, ModelVisibility
 from bailo.core.exceptions import BailoException
 from bailo.helper.entry import Entry
 
@@ -20,6 +20,7 @@ class Datacard(Entry):
     :param description: Description of datacard
     :param organisation: Organisation responsible for the model, defaults to None
     :param state: Development readiness of the model, defaults to None
+    :param collaborators: list of CollaboratorEntry to define who the model's collaborators (a.k.a. model access) are, defaults to None
     :param visibility: Visibility of datacard, using ModelVisibility enum (e.g Public or Private), defaults to None
     """
 
@@ -31,6 +32,7 @@ class Datacard(Entry):
         description: str,
         organisation: str | None = None,
         state: str | None = None,
+        collaborators: list[CollaboratorEntry] | None = None,
         visibility: ModelVisibility | None = None,
     ) -> None:
         super().__init__(
@@ -41,6 +43,7 @@ class Datacard(Entry):
             kind=EntryKind.DATACARD,
             organisation=organisation,
             state=state,
+            collaborators=collaborators,
             visibility=visibility,
         )
 
@@ -54,6 +57,7 @@ class Datacard(Entry):
         description: str,
         organisation: str | None = None,
         state: str | None = None,
+        collaborators: list[CollaboratorEntry] | None = None,
         visibility: ModelVisibility | None = None,
     ) -> Datacard:
         """Build a datacard from Bailo and upload it.
@@ -64,6 +68,7 @@ class Datacard(Entry):
         :param organisation: Organisation responsible for the model, defaults to None
         :param state: Development readiness of the model, defaults to None
         :param visibility: Visibility of datacard, using ModelVisibility enum (e.g Public or Private), defaults to None
+        :param collaborators: list of CollaboratorEntry to define who the model's collaborators (a.k.a. model access) are, defaults to None
         :return: Datacard object
         """
         res = client.post_model(
@@ -73,6 +78,7 @@ class Datacard(Entry):
             visibility=visibility,
             organisation=organisation,
             state=state,
+            collaborators=collaborators,
         )
         datacard_id = res["model"]["id"]
         logger.info("Datacard successfully created on server with ID %s.", datacard_id)
@@ -84,6 +90,7 @@ class Datacard(Entry):
             description=description,
             organisation=organisation,
             state=state,
+            collaborators=collaborators,
             visibility=visibility,
         )
 
@@ -114,6 +121,7 @@ class Datacard(Entry):
             description=res["description"],
             organisation=res.get("organisation"),
             state=res.get("state"),
+            collaborators=res.get("collaborators"),
         )
         datacard._unpack(res)
 

--- a/lib/python/src/bailo/helper/entry.py
+++ b/lib/python/src/bailo/helper/entry.py
@@ -44,8 +44,8 @@ class Entry:
         self.kind = kind
         self.visibility = visibility
         self.organisation = organisation
-        self.collaborators = collaborators
         self.state = state
+        self.collaborators = collaborators
 
         self._card = None
         self._card_version = None
@@ -60,8 +60,8 @@ class Entry:
             description=self.description,
             visibility=self.visibility,
             organisation=self.organisation,
-            collaborators=self.collaborators,
             state=self.state,
+            collaborators=self.collaborators,
         )
         self._unpack(res["model"])
 

--- a/lib/python/src/bailo/helper/entry.py
+++ b/lib/python/src/bailo/helper/entry.py
@@ -5,7 +5,7 @@ import warnings
 from typing import Any
 
 from bailo.core.client import Client
-from bailo.core.enums import EntryKind, MinimalSchema, ModelVisibility
+from bailo.core.enums import CollaboratorEntry, EntryKind, MinimalSchema, ModelVisibility
 
 logger = logging.getLogger(__name__)
 
@@ -21,6 +21,7 @@ class Entry:
     :param visibility: Visibility of model, using ModelVisibility enum (i.e. Public or Private), defaults to None
     :param organisation: Organisation responsible for the model, defaults to None
     :param state: Development readiness of the model, defaults to None
+    :param collaborators: list of CollaboratorEntry to define who the model's collaborators (a.k.a. model access) are, defaults to None
     """
 
     def __init__(
@@ -33,6 +34,7 @@ class Entry:
         visibility: ModelVisibility | None = None,
         organisation: str | None = None,
         state: str | None = None,
+        collaborators: list[CollaboratorEntry] | None = None,
     ) -> None:
         self.client = client
 
@@ -42,6 +44,7 @@ class Entry:
         self.kind = kind
         self.visibility = visibility
         self.organisation = organisation
+        self.collaborators = collaborators
         self.state = state
 
         self._card = None
@@ -57,6 +60,7 @@ class Entry:
             description=self.description,
             visibility=self.visibility,
             organisation=self.organisation,
+            collaborators=self.collaborators,
             state=self.state,
         )
         self._unpack(res["model"])

--- a/lib/python/src/bailo/helper/model.py
+++ b/lib/python/src/bailo/helper/model.py
@@ -134,9 +134,9 @@ class Model(Entry):
             model_id=model_id,
             name=res["name"],
             description=res["description"],
+            collaborators=res["collaborators"],
             organisation=res.get("organisation"),
             state=res.get("state"),
-            collaborators=res.get("collaborators"),
         )
 
         model._unpack(res)
@@ -172,9 +172,9 @@ class Model(Entry):
                 model_id=model["id"],
                 name=model["name"],
                 description=model["description"],
+                collaborators=res["collaborators"],
                 organisation=res.get("organisation"),
                 state=res.get("state"),
-                collaborators=res.get("collaborators"),
             )
             model_obj._unpack(res_model)
             model_obj.get_card_latest()

--- a/lib/python/src/bailo/helper/model.py
+++ b/lib/python/src/bailo/helper/model.py
@@ -12,7 +12,7 @@ from semantic_version import Version
 # isort: split
 
 from bailo.core.client import Client
-from bailo.core.enums import EntryKind, MinimalSchema, ModelVisibility
+from bailo.core.enums import CollaboratorEntry, EntryKind, MinimalSchema, ModelVisibility
 from bailo.core.exceptions import BailoException
 from bailo.core.utils import NestedDict
 from bailo.helper.entry import Entry
@@ -37,6 +37,7 @@ class Model(Entry):
     :param description: Description of model
     :param organisation: Organisation responsible for the model, defaults to None
     :param state: Development readiness of the model, defaults to None
+    :param collaborators: list of CollaboratorEntry to define who the model's collaborators (a.k.a. model access) are, defaults to None
     :param visibility: Visibility of model, using ModelVisibility enum (e.g Public or Private), defaults to None
     """
 
@@ -48,6 +49,7 @@ class Model(Entry):
         description: str,
         organisation: str | None = None,
         state: str | None = None,
+        collaborators: list[CollaboratorEntry] | None = None,
         visibility: ModelVisibility | None = None,
     ) -> None:
         super().__init__(
@@ -59,6 +61,7 @@ class Model(Entry):
             visibility=visibility,
             organisation=organisation,
             state=state,
+            collaborators=collaborators,
         )
 
         self.model_id = model_id
@@ -71,6 +74,7 @@ class Model(Entry):
         description: str,
         organisation: str | None = None,
         state: str | None = None,
+        collaborators: list[CollaboratorEntry] | None = None,
         visibility: ModelVisibility | None = None,
     ) -> Model:
         """Build a model from Bailo and upload it.
@@ -80,6 +84,7 @@ class Model(Entry):
         :param description: Description of model
         :param organisation: Organisation responsible for the model, defaults to None
         :param state: Development readiness of the model, defaults to None
+        :param collaborators: list of CollaboratorEntry to define who the model's collaborators (a.k.a. model access) are, defaults to None
         :param visibility: Visibility of model, using ModelVisibility enum (e.g Public or Private), defaults to None
         :return: Model object
         """
@@ -90,6 +95,7 @@ class Model(Entry):
             visibility=visibility,
             organisation=organisation,
             state=state,
+            collaborators=collaborators,
         )
         model_id = res["model"]["id"]
         logger.info("Model successfully created on server with ID %s.", model_id)
@@ -102,6 +108,7 @@ class Model(Entry):
             visibility=visibility,
             organisation=organisation,
             state=state,
+            collaborators=collaborators,
         )
 
         model._unpack(res["model"])
@@ -129,6 +136,7 @@ class Model(Entry):
             description=res["description"],
             organisation=res.get("organisation"),
             state=res.get("state"),
+            collaborators=res.get("collaborators"),
         )
 
         model._unpack(res)
@@ -166,6 +174,7 @@ class Model(Entry):
                 description=model["description"],
                 organisation=res.get("organisation"),
                 state=res.get("state"),
+                collaborators=res.get("collaborators"),
             )
             model_obj._unpack(res_model)
             model_obj.get_card_latest()
@@ -185,6 +194,7 @@ class Model(Entry):
         visibility: ModelVisibility | None = None,
         organisation: str | None = None,
         state: str | None = None,
+        collaborators: list[CollaboratorEntry] | None = None,
     ) -> Model:
         """Import an MLFlow Model into Bailo.
 
@@ -197,6 +207,7 @@ class Model(Entry):
         :param visibility: Visibility of model on Bailo, using ModelVisibility enum (e.g Public or Private), defaults to None
         :param organisation: Organisation responsible for the model, defaults to None
         :param state: Development readiness of the model, defaults to None
+        :param collaborators: list of CollaboratorEntry to define who the model's collaborators (a.k.a. model access) are, defaults to None
         :return: A model object
         """
         if not ML_FLOW:
@@ -230,6 +241,7 @@ class Model(Entry):
             visibility=visibility,
             organisation=organisation,
             state=state,
+            collaborators=collaborators,
         )
         model_id = bailo_res["model"]["id"]
         logger.info("MLFlow model successfully imported to Bailo with ID %s", model_id)
@@ -242,6 +254,7 @@ class Model(Entry):
             visibility=visibility,
             organisation=organisation,
             state=state,
+            collaborators=collaborators,
         )
         model._unpack(bailo_res["model"])
 
@@ -587,7 +600,7 @@ class Experiment:
         mc = NestedDict(mc)
 
         if len(self.raw) == 0:
-            raise BailoException(f"This experiment has no runs to publish.")
+            raise BailoException("This experiment has no runs to publish.")
         if (select_by is None) and (run_id is None):
             raise BailoException(
                 "Either select_by (e.g. 'accuracy MIN|MAX') or run_id is required to publish an experiment run."

--- a/lib/python/src/bailo/helper/model.py
+++ b/lib/python/src/bailo/helper/model.py
@@ -172,9 +172,9 @@ class Model(Entry):
                 model_id=model["id"],
                 name=model["name"],
                 description=model["description"],
-                collaborators=res["collaborators"],
-                organisation=res.get("organisation"),
-                state=res.get("state"),
+                collaborators=model["collaborators"],
+                organisation=model.get("organisation"),
+                state=model.get("state"),
             )
             model_obj._unpack(res_model)
             model_obj.get_card_latest()

--- a/lib/python/tests/test_datacard.py
+++ b/lib/python/tests/test_datacard.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from bailo.core.enums import CollaboratorEntry, Role
 import pytest
 
 # isort: split
@@ -14,11 +15,18 @@ def test_datacard(local_datacard):
 
 @pytest.mark.integration
 @pytest.mark.parametrize(
-    ("name", "description", "organisation", "state", "visibility"),
+    ("name", "description", "organisation", "state", "visibility", "collaborators"),
     [
-        ("test-datacard", "test", None, None, ModelVisibility.PUBLIC),
-        ("test-datacard", "test", None, None, None),
-        ("test-datacard", "test", "Example Organisation", "Development", None),
+        ("test-datacard", "test", None, None, ModelVisibility.PUBLIC, None),
+        ("test-datacard", "test", None, None, None, [CollaboratorEntry("user:user", ["owner", "contributor"])]),
+        (
+            "test-datacard",
+            "test",
+            "Example Organisation",
+            "Development",
+            None,
+            [CollaboratorEntry("user:user", [Role.OWNER])],
+        ),
     ],
 )
 def test_create_get_from_id_and_update(
@@ -27,6 +35,7 @@ def test_create_get_from_id_and_update(
     visibility: ModelVisibility | None,
     organisation: str | None,
     state: str | None,
+    collaborators: list[CollaboratorEntry] | None,
     integration_client: Client,
 ):
     # Create model
@@ -37,6 +46,7 @@ def test_create_get_from_id_and_update(
         visibility=visibility,
         organisation=organisation,
         state=state,
+        collaborators=collaborators,
     )
     datacard.card_from_schema("minimal-data-card-v10")
     assert isinstance(datacard, Datacard)

--- a/lib/python/tests/test_datacard.py
+++ b/lib/python/tests/test_datacard.py
@@ -1,11 +1,11 @@
 from __future__ import annotations
 
-from bailo.core.enums import CollaboratorEntry, Role
 import pytest
 
 # isort: split
 
 from bailo import Client, Datacard, Model, ModelVisibility
+from bailo.core.enums import CollaboratorEntry, Role
 from bailo.core.exceptions import BailoException
 
 

--- a/lib/python/tests/test_model.py
+++ b/lib/python/tests/test_model.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import pytest
-from bailo.core.enums import CollaboratorEntry, Role, MinimalSchema
+from bailo.core.enums import CollaboratorEntry, MinimalSchema, Role
 
 # isort: split
 

--- a/lib/python/tests/test_model.py
+++ b/lib/python/tests/test_model.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import pytest
-from bailo.core.enums import MinimalSchema
+from bailo.core.enums import CollaboratorEntry, Role, MinimalSchema
 
 # isort: split
 
@@ -22,11 +22,18 @@ def test_create_experiment_from_model(local_model):
 
 @pytest.mark.integration
 @pytest.mark.parametrize(
-    ("name", "description", "organisation", "state", "visibility"),
+    ("name", "description", "organisation", "state", "visibility", "collaborators"),
     [
-        ("test-model", "test", None, None, ModelVisibility.PUBLIC),
-        ("test-model", "test", None, None, None),
-        ("test-model", "test", "Example Organisation", "Development", None),
+        ("test-model", "test", None, None, ModelVisibility.PUBLIC, None),
+        ("test-model", "test", None, None, None, [CollaboratorEntry("user:user", ["owner", "contributor"])]),
+        (
+            "test-model",
+            "test",
+            "Example Organisation",
+            "Development",
+            None,
+            [CollaboratorEntry("user:user", [Role.OWNER])],
+        ),
     ],
 )
 def test_create_get_from_id_and_update(
@@ -35,6 +42,7 @@ def test_create_get_from_id_and_update(
     visibility: ModelVisibility | None,
     organisation: str | None,
     state: str | None,
+    collaborators: list[CollaboratorEntry] | None,
     integration_client: Client,
 ):
     # Create model
@@ -45,6 +53,7 @@ def test_create_get_from_id_and_update(
         visibility=visibility,
         organisation=organisation,
         state=state,
+        collaborators=collaborators,
     )
     model.card_from_schema("minimal-general-v10")
     assert isinstance(model, Model)


### PR DESCRIPTION
As a Bailo user, I would like to be able to programmatically view and add roles for specific people to a model so that I can control who uses a model without using the UI.