### PR TITLE
BAI-1816 fix frontend setModelCardVersion set condition

### DIFF
--- a/frontend/pages/model/[modelId]/release/new.tsx
+++ b/frontend/pages/model/[modelId]/release/new.tsx
@@ -47,7 +47,7 @@ export default function NewRelease() {
   const { model, isModelLoading, isModelError } = useGetModel(modelId, EntryKind.MODEL)
 
   useEffect(() => {
-    if (model && modelCardVersion === 0) {
+    if (model && modelCardVersion !== model.card.version) {
       setModelCardVersion(model.card.version)
     }
   }, [model, setModelCardVersion, modelCardVersion])


### PR DESCRIPTION
### Problem
Given a model card that has been updated after the last model release, the "Model card version" dropdown does not automatically select the most recent version number.

### Expected behaviour
The model card version should always select the most recent version.

### Steps to reproduce

1. Create a new model from schema.
2. Update the model schema after creation (a "v2" of the schema)
3. Go to draft a release - the model card version is stuck on 1, but 2 is selectable.
4. Going back to the model and drafting a release again always fixes the issue for subsequent attempts.