### PR TITLE
Bumps docker images, bumps helm charts

### DIFF
--- a/docker-compose-prod.yml
+++ b/docker-compose-prod.yml
@@ -27,7 +27,7 @@ services:
       - minioVolume:/bitnami/minio
 
   clamd:
-    image: clamav/clamav:1.4.2_base
+    image: clamav/clamav:1.4.3_base
     healthcheck:
       test: ['CMD-SHELL', "echo 'PING' | nc -w 5 localhost 3310"]
       interval: 30s
@@ -48,13 +48,13 @@ services:
       retries: 5
 
   mailcrab:
-    image: marlonb/mailcrab:v1.5.0
+    image: marlonb/mailcrab:v1.6.1
     ports:
       - 1080:1080
       - 1025:1025
 
   nginx:
-    image: nginxinc/nginx-unprivileged:1.25.4-alpine3.18
+    image: nginxinc/nginx-unprivileged:1.28.0-alpine3.21-slim
     volumes:
       - ./infrastructure/nginx/nginx.conf:/etc/nginx/nginx.conf
     ports:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -29,7 +29,7 @@ services:
       - minioVolume:/bitnami/minio
 
   clamd:
-    image: clamav/clamav:1.4.2_base
+    image: clamav/clamav:1.4.3_base
     healthcheck:
       test: ['CMD-SHELL', "echo 'PING' | nc -w 5 localhost 3310"]
       interval: 30s
@@ -51,13 +51,13 @@ services:
       retries: 5
 
   mailcrab:
-    image: marlonb/mailcrab:v1.5.0
+    image: marlonb/mailcrab:v1.6.1
     ports:
       - 1080:1080
       - 1025:1025
 
   nginx:
-    image: nginxinc/nginx-unprivileged:1.25.4-alpine3.18
+    image: nginxinc/nginx-unprivileged:1.28.0-alpine3.21-slim
     volumes:
       - ./infrastructure/nginx/nginx.conf:/etc/nginx/nginx.conf
     ports:

--- a/infrastructure/helm/bailo/Chart.lock
+++ b/infrastructure/helm/bailo/Chart.lock
@@ -1,9 +1,9 @@
 dependencies:
 - name: minio
   repository: https://charts.bitnami.com/bitnami
-  version: 14.2.0
+  version: 14.2.1
 - name: mongodb
   repository: https://charts.bitnami.com/bitnami
-  version: 15.1.4
-digest: sha256:2e4238b5b4e1178aa1a0b7e73fe7ad3a4d2cc6b78066dbdc4ee19709d7286896
-generated: "2024-04-19T15:11:29.678367785Z"
+  version: 15.1.7
+digest: sha256:c25ba37200fbc711247f68071bac1eba68fcfb5ac4fe6165939d46cc4d6711e4
+generated: "2025-07-01T12:07:12.285121767Z"

--- a/infrastructure/helm/bailo/Chart.yaml
+++ b/infrastructure/helm/bailo/Chart.yaml
@@ -27,9 +27,9 @@ appVersion: "0.1.0"
 dependencies:
 - name: minio
   repository: "https://charts.bitnami.com/bitnami"
-  version: "~14.2.0"
+  version: "~14.2.1"
   condition: minio.enabled
 - name: mongodb
   repository: "https://charts.bitnami.com/bitnami"
-  version: "~15.1.4"
+  version: "~15.1.7"
   condition: mongodb.enabled

--- a/infrastructure/helm/bailo/values.yaml
+++ b/infrastructure/helm/bailo/values.yaml
@@ -160,7 +160,7 @@ mongodb:
   image:
     registry: docker.io
     repository: bitnami/mongodb
-    tag: 7.0.15-debian-12-r2
+    tag: 7.0.15
 
 # MinIO Dependencies
 minio:
@@ -192,7 +192,7 @@ minio:
   image:
     registry: docker.io
     repository: bitnami/minio
-    tag: 2024.4.18-debian-12-r0
+    tag: 2025.5.24
     debug: true
 
 # Registry Dependencies
@@ -213,7 +213,7 @@ registry:
 # Nginx Dependencies
 nginxAuth:
   repository: nginxinc/nginx-unprivileged # runs Nginx as non-root unprivileged user.
-  tag: latest
+  tag: 1.28.0-alpine3.21-slim
   #host: "bailo-nginx" # service name
   port: 8080
   #certDir: "/certs"
@@ -223,7 +223,7 @@ nginxAuth:
 # Mail
 mail:
   enabled: true
-  image: marlonb/mailcrab:latest
+  image: marlonb/mailcrab:v1.6.1
 
 # Openshift specific configuration
 openshift:
@@ -317,7 +317,7 @@ backend:
 clamav:
   enabled: false
   runAsUser: 1002
-  image: clamav/clamav:1.4.2_base # https://docs.clamav.net/manual/Installing/Docker.html#the-official-images-on-docker-hub
+  image: clamav/clamav:1.4.3_base # https://docs.clamav.net/manual/Installing/Docker.html#the-official-images-on-docker-hub
   port: 3310
   accessModes:
     - ReadWriteOnce


### PR DESCRIPTION
- ClamAV from 1.4.2 to 1.4.3
- Mailcrab from 1.5.0 to 1.6.1
- Nginx from 1.25.4 to 1.28.0 (and alpine 3.18 to 3.21)
- Updates default Helm values.yaml to use the same images as docker-compose
- Bumps Helm charts to latest patch versions