### PR TITLE
Soft delete reviews & responses when a release is deleted

### DIFF
--- a/backend/src/migrations/019_2426_remove_orphaned_reviews_responses.ts
+++ b/backend/src/migrations/019_2426_remove_orphaned_reviews_responses.ts
@@ -1,0 +1,41 @@
+import ReleaseModel from '../models/Release.js'
+import { ReviewDoc } from '../models/Review.js'
+import { UserInterface } from '../models/User.js'
+import { removeResponses } from '../services/response.js'
+import { removeReleaseReviews } from '../services/review.js'
+
+/**
+ * This isn't really used but needed for consistency
+ */
+const migrationUser: UserInterface = {
+  dn: 'migration',
+}
+
+export async function up() {
+  // Find all releases have already been marked as deleted
+  const deletedReleases = await ReleaseModel.find({ deleted: true }).lean()
+  const deletedReviews: ReviewDoc[] = []
+
+  // For each deleted release, deleted the reviews associated with it
+  for (const { modelId, semver } of deletedReleases) {
+    const reviews = await removeReleaseReviews(migrationUser, modelId, semver)
+    deletedReviews.push(...reviews)
+  }
+
+  const reviewIds = deletedReviews.map((r) => r.id)
+  // For each deleted review, delete the responses associated with it
+  const deletedResponses = await removeResponses(migrationUser, reviewIds)
+
+  // Store some basic metadata about the migration
+  return {
+    foundDeletedReleases: deletedReleases.length,
+    deletedReleaseReviews: deletedReviews.length,
+    deletedResponses: deletedResponses.length,
+  }
+}
+
+export async function down() {
+  /* NOOP */
+  // In theory we could save off the deleted items to metadata as they're only soft-deleted,
+  // but there's no parent review anyway
+}

--- a/backend/src/migrations/020_2426_remove_orphaned_reviews_responses.ts
+++ b/backend/src/migrations/020_2426_remove_orphaned_reviews_responses.ts
@@ -1,30 +1,22 @@
 import ReleaseModel from '../models/Release.js'
 import { ReviewDoc } from '../models/Review.js'
-import { UserInterface } from '../models/User.js'
 import { removeResponses } from '../services/response.js'
 import { removeReleaseReviews } from '../services/review.js'
 
-/**
- * This isn't really used but needed for consistency
- */
-const migrationUser: UserInterface = {
-  dn: 'migration',
-}
-
 export async function up() {
   // Find all releases have already been marked as deleted
-  const deletedReleases = await ReleaseModel.find({ deleted: true }).lean()
+  const deletedReleases = await ReleaseModel.find({ deleted: true })
   const deletedReviews: ReviewDoc[] = []
 
   // For each deleted release, deleted the reviews associated with it
   for (const { modelId, semver } of deletedReleases) {
-    const reviews = await removeReleaseReviews(migrationUser, modelId, semver)
+    const reviews = await removeReleaseReviews(modelId, semver)
     deletedReviews.push(...reviews)
   }
 
   const reviewIds = deletedReviews.map((r) => r.id)
   // For each deleted review, delete the responses associated with it
-  const deletedResponses = await removeResponses(migrationUser, reviewIds)
+  const deletedResponses = await removeResponses(reviewIds)
 
   // Store some basic metadata about the migration
   return {

--- a/backend/src/routes/v2/response/getResponses.ts
+++ b/backend/src/routes/v2/response/getResponses.ts
@@ -49,7 +49,7 @@ export const getResponses = [
       query: { parentIds },
     } = parse(req, getResponseSchema)
 
-    const responses = await getResponsesByParentIds(req.user, parentIds)
+    const responses = await getResponsesByParentIds(parentIds)
     await audit.onViewResponses(req, responses)
 
     res.json({

--- a/backend/src/services/release.ts
+++ b/backend/src/services/release.ts
@@ -536,10 +536,12 @@ export async function deleteRelease(user: UserInterface, modelId: string, semver
   // TODO: Wrap this in transactions in the future
 
   const deletedReleases = await removeReleaseReviews(user, modelId, semver)
-  await removeResponses(
-    user,
-    deletedReleases.flatMap((r) => r.id),
-  )
+  if (deletedReleases && deletedReleases.length > 0) {
+    await removeResponses(
+      user,
+      deletedReleases.flatMap((r) => r.id),
+    )
+  }
 
   await release.delete()
 

--- a/backend/src/services/release.ts
+++ b/backend/src/services/release.ts
@@ -19,7 +19,7 @@ import { getFileById, getFilesByIds } from './file.js'
 import log from './log.js'
 import { getModelById, getModelCardRevision } from './model.js'
 import { listModelImages } from './registry.js'
-import { createReleaseReviews } from './review.js'
+import { createReleaseReviews, removeReleaseReviews } from './review.js'
 import { sendWebhooks } from './webhook.js'
 
 export function isReleaseDoc(data: unknown): data is ReleaseDoc {
@@ -531,6 +531,10 @@ export async function deleteRelease(user: UserInterface, modelId: string, semver
   if (!auth.success) {
     throw Forbidden(auth.info, { userDn: user.dn, release: release._id })
   }
+
+  // TODO: Wrap this in transactions in the future
+
+  await removeReleaseReviews(user, modelId, semver)
 
   await release.delete()
 

--- a/backend/src/services/release.ts
+++ b/backend/src/services/release.ts
@@ -19,6 +19,7 @@ import { getFileById, getFilesByIds } from './file.js'
 import log from './log.js'
 import { getModelById, getModelCardRevision } from './model.js'
 import { listModelImages } from './registry.js'
+import { removeResponses } from './response.js'
 import { createReleaseReviews, removeReleaseReviews } from './review.js'
 import { sendWebhooks } from './webhook.js'
 
@@ -534,7 +535,11 @@ export async function deleteRelease(user: UserInterface, modelId: string, semver
 
   // TODO: Wrap this in transactions in the future
 
-  await removeReleaseReviews(user, modelId, semver)
+  const deletedReleases = await removeReleaseReviews(user, modelId, semver)
+  await removeResponses(
+    user,
+    deletedReleases.flatMap((r) => r.id),
+  )
 
   await release.delete()
 

--- a/backend/src/services/release.ts
+++ b/backend/src/services/release.ts
@@ -535,12 +535,9 @@ export async function deleteRelease(user: UserInterface, modelId: string, semver
 
   // TODO: Wrap this in transactions in the future
 
-  const deletedReleases = await removeReleaseReviews(user, modelId, semver)
+  const deletedReleases = await removeReleaseReviews(modelId, semver)
   if (deletedReleases && deletedReleases.length > 0) {
-    await removeResponses(
-      user,
-      deletedReleases.flatMap((r) => r.id),
-    )
+    await removeResponses(deletedReleases.flatMap((r) => r.id))
   }
 
   await release.delete()

--- a/backend/src/services/response.ts
+++ b/backend/src/services/response.ts
@@ -31,7 +31,7 @@ export async function findResponseById(responseId: string) {
   return response
 }
 
-export async function getResponsesByParentIds(_user: UserInterface, parentIds: string[]) {
+export async function getResponsesByParentIds(parentIds: string[]) {
   const responses = await ResponseModel.find({ parentId: { $in: parentIds } })
 
   if (!responses) {
@@ -62,8 +62,8 @@ export async function updateResponse(user: UserInterface, responseId: string, co
   return response
 }
 
-export async function removeResponses(user: UserInterface, parentIds: string[]) {
-  const responses = await getResponsesByParentIds(user, parentIds)
+export async function removeResponses(parentIds: string[]) {
+  const responses = await getResponsesByParentIds(parentIds)
   const responseDeletions: ResponseDoc[] = []
   for (const response of responses) {
     try {

--- a/backend/src/services/response.ts
+++ b/backend/src/services/response.ts
@@ -1,6 +1,7 @@
 import ResponseModel, {
   Decision,
   ReactionKindKeys,
+  ResponseDoc,
   ResponseInterface,
   ResponseKind,
   ResponseReaction,
@@ -59,6 +60,22 @@ export async function updateResponse(user: UserInterface, responseId: string, co
   response.save()
 
   return response
+}
+
+export async function removeResponses(user: UserInterface, parentIds: string[]) {
+  const responses = await getResponsesByParentIds(user, parentIds)
+  const responseDeletions: ResponseDoc[] = []
+  for (const response of responses) {
+    try {
+      responseDeletions.push(await response.delete())
+    } catch (error) {
+      throw InternalError('The requested response could not be deleted.', {
+        responseId: response.id,
+        error,
+      })
+    }
+  }
+  return responseDeletions
 }
 
 export async function updateResponseReaction(user: UserInterface, responseId: string, kind: ReactionKindKeys) {

--- a/backend/src/services/review.ts
+++ b/backend/src/services/review.ts
@@ -113,7 +113,7 @@ export async function removeAccessRequestReviews(accessRequestId: string) {
   return deletions
 }
 
-export async function removeReleaseReviews(user: UserInterface, modelId: string, semver: string) {
+export async function removeReleaseReviews(user: UserInterface, modelId: string, semver: string): Promise<ReviewDoc[]> {
   // finding and then calling potentially multiple deletes is inefficient but the mongoose-softdelete
   // plugin doesn't cover bulkDelete
   const reviews: ReviewDoc[] = await Review.find({

--- a/backend/src/services/review.ts
+++ b/backend/src/services/review.ts
@@ -113,7 +113,7 @@ export async function removeAccessRequestReviews(accessRequestId: string) {
   return deletions
 }
 
-export async function removeReleaseReviews(user: UserInterface, modelId: string, semver: string): Promise<ReviewDoc[]> {
+export async function removeReleaseReviews(modelId: string, semver: string): Promise<ReviewDoc[]> {
   // finding and then calling potentially multiple deletes is inefficient but the mongoose-softdelete
   // plugin doesn't cover bulkDelete
   const reviews: ReviewDoc[] = await Review.find({

--- a/backend/src/services/review.ts
+++ b/backend/src/services/review.ts
@@ -4,7 +4,6 @@ import authorisation from '../connectors/authorisation/index.js'
 import { AccessRequestDoc } from '../models/AccessRequest.js'
 import { CollaboratorEntry, ModelDoc, ModelInterface } from '../models/Model.js'
 import { ReleaseDoc } from '../models/Release.js'
-import { ResponseDoc } from '../models/Response.js'
 import Review, { ReviewDoc, ReviewInterface } from '../models/Review.js'
 import ReviewRoleModel, { ReviewRoleInterface } from '../models/ReviewRole.js'
 import { UserInterface } from '../models/User.js'
@@ -13,7 +12,6 @@ import { BadReq, Forbidden, InternalError, NotFound } from '../utils/error.js'
 import { handleDuplicateKeys } from '../utils/mongo.js'
 import log from './log.js'
 import { getModelById } from './model.js'
-import { getResponsesByParentIds } from './response.js'
 import { requestReviewForAccessRequest, requestReviewForRelease } from './smtp/smtp.js'
 
 // This should be replaced by using the dynamic schema
@@ -132,24 +130,6 @@ export async function removeReleaseReviews(user: UserInterface, modelId: string,
       throw InternalError('The requested release review could not be deleted.', {
         modelId,
         semver,
-        error,
-      })
-    }
-  }
-
-  const responses = await getResponsesByParentIds(
-    user,
-    reviews.flatMap((r) => r.id),
-  )
-  const responseDeletions: ResponseDoc[] = []
-  for (const response of responses) {
-    try {
-      responseDeletions.push(await response.delete())
-    } catch (error) {
-      throw InternalError('The requested response could not be deleted.', {
-        modelId,
-        semver,
-        responseId: response.id,
         error,
       })
     }

--- a/backend/test/services/release.spec.ts
+++ b/backend/test/services/release.spec.ts
@@ -106,6 +106,7 @@ vi.mock('../../src/models/Release.js', () => ({ default: releaseModelMocks }))
 const mockReviewService = vi.hoisted(() => {
   return {
     createReleaseReviews: vi.fn(),
+    removeReleaseReviews: vi.fn(),
   }
 })
 vi.mock('../../src/services/review.js', () => mockReviewService)

--- a/backend/test/services/response.spec.ts
+++ b/backend/test/services/response.spec.ts
@@ -117,14 +117,12 @@ describe('services > response', () => {
 
     responseModelMock.find.mockResolvedValueOnce(mockResponses)
 
-    expect(await getResponsesByParentIds({} as any, ['test'])).toBe(mockResponses)
+    expect(await getResponsesByParentIds(['test'])).toBe(mockResponses)
   })
   test('getResponsesByParentIds > response not found', async () => {
     responseModelMock.find.mockResolvedValueOnce(undefined)
 
-    await expect(getResponsesByParentIds({} as any, ['test'])).rejects.toThrowError(
-      'The requested response was not found.',
-    )
+    await expect(getResponsesByParentIds(['test'])).rejects.toThrowError('The requested response was not found.')
   })
 
   test('updateResponse > success', async () => {


### PR DESCRIPTION
Currently, when a release is deleted from a model entry, the reviews & responses are left in the system. In particular, this leads to the reviews page breaking since it can't find the related semver/model combination.

This change finds the reviews associated with a release, and any responses associated with that review, and soft deletes them before continuing to soft delete the release.

There would be some benefit to wrapping these in a transaction in the future once #1237 is merged.