### PR TITLE
Removed superfluous getReleases usage

### DIFF
--- a/frontend/src/entry/model/ModelFileManagement.tsx
+++ b/frontend/src/entry/model/ModelFileManagement.tsx
@@ -1,5 +1,6 @@
 import { Box, Button, Chip, Container, Stack, Typography } from '@mui/material'
 import { useGetModelFiles } from 'actions/model'
+import { useGetReleasesForModelId } from 'actions/release'
 import { useState } from 'react'
 import Loading from 'src/common/Loading'
 import Paginate from 'src/common/Paginate'
@@ -18,6 +19,8 @@ export default function Files({ model }: FilesProps) {
   const [isFileUploadDialogOpen, setIsFileUploadDialogOpen] = useState(false)
   const [activeFileTag, setActiveFileTag] = useState('')
 
+  const { releases, isReleasesLoading, isReleasesError } = useGetReleasesForModelId(model.id)
+
   const EntryListItem = ({ data, index }) => (
     <Box key={data[index]._id} sx={{ width: '100%' }}>
       <Stack spacing={1} p={2}>
@@ -26,6 +29,7 @@ export default function Files({ model }: FilesProps) {
           file={data[index]}
           modelId={model.id}
           mutator={mutateEntryFiles}
+          releases={releases}
         />
       </Stack>
     </Box>
@@ -35,10 +39,13 @@ export default function Files({ model }: FilesProps) {
     return <MessageAlert message={isEntryFilesError.info.message} severity='error' />
   }
 
-  if (isEntryFilesLoading) {
+  if (isEntryFilesLoading || isReleasesLoading) {
     return <Loading />
   }
 
+  if (isReleasesError) {
+    return <MessageAlert message={isReleasesError.info.message} severity='error' />
+  }
   return (
     <>
       <Container sx={{ my: 2 }}>

--- a/frontend/src/entry/model/files/FileDisplay.tsx
+++ b/frontend/src/entry/model/files/FileDisplay.tsx
@@ -19,7 +19,6 @@ import {
 import { patchFile } from 'actions/file'
 import { rerunFileScan, useGetFileScannerInfo } from 'actions/fileScanning'
 import { deleteModelFile, useGetModelFiles } from 'actions/model'
-import { useGetReleasesForModelId } from 'actions/release'
 import { useRouter } from 'next/router'
 import prettyBytes from 'pretty-bytes'
 import { CSSProperties, Fragment, MouseEvent, ReactElement, useCallback, useEffect, useMemo, useState } from 'react'
@@ -70,6 +69,7 @@ type FileDisplayProps = {
   hideTags?: boolean
   style?: CSSProperties
   key?: string
+  releases: ReleaseInterface[]
 } & ClickableFileDownloadProps
 
 interface ChipDetails {
@@ -89,6 +89,7 @@ export default function FileDisplay({
   activeFileTagOnChange,
   style = {},
   key = '',
+  releases,
 }: FileDisplayProps) {
   const [anchorElMore, setAnchorElMore] = useState<HTMLElement | null>(null)
   const [anchorElScan, setAnchorElScan] = useState<HTMLElement | null>(null)
@@ -101,7 +102,6 @@ export default function FileDisplay({
   const { mutateEntryFiles } = useGetModelFiles(modelId)
   const router = useRouter()
 
-  const { releases, isReleasesLoading, isReleasesError } = useGetReleasesForModelId(modelId)
   const [latestRelease, setLatestRelease] = useState('')
 
   const sortedAssociatedReleases = useMemo(
@@ -328,11 +328,7 @@ export default function FileDisplay({
     return <MessageAlert message={isScannersError.info.message} severity='error' />
   }
 
-  if (isReleasesError) {
-    return <MessageAlert message={isReleasesError.info.message} severity='error' />
-  }
-
-  if (isScannersLoading || isReleasesLoading) {
+  if (isScannersLoading) {
     return <Loading />
   }
 

--- a/frontend/src/entry/model/releases/ReleaseDisplay.tsx
+++ b/frontend/src/entry/model/releases/ReleaseDisplay.tsx
@@ -30,8 +30,8 @@ import FileDisplay from 'src/entry/model/files/FileDisplay'
 import CodeLine from 'src/entry/model/registry/CodeLine'
 import ReviewBanner from 'src/entry/model/reviews/ReviewBanner'
 import ReviewDisplay from 'src/entry/model/reviews/ReviewDisplay'
+import MultipleErrorWrapper from 'src/errors/MultipleErrorWrapper'
 import Link from 'src/Link'
-import MessageAlert from 'src/MessageAlert'
 import { EntryInterface, ReleaseInterface, ResponseInterface } from 'types/types'
 import { formatDateString } from 'utils/dateUtils'
 import { latestReviewsForEachUser } from 'utils/reviewUtils'
@@ -59,7 +59,7 @@ export default function ReleaseDisplay({
     semver: release.semver,
   })
 
-  const { mutateReleases } = useGetReleasesForModelId(model.id)
+  const { releases, isReleasesLoading, isReleasesError, mutateReleases } = useGetReleasesForModelId(model.id)
 
   const { scanners, isScannersLoading, isScannersError } = useGetFileScannerInfo()
   const { uiConfig, isUiConfigLoading, isUiConfigError } = useGetUiConfig()
@@ -101,32 +101,24 @@ export default function ReleaseDisplay({
       file={data[index]}
       modelId={model.id}
       mutator={mutateReleases}
+      releases={releases}
     />
   ))
 
-  if (isReviewsError) {
-    return <MessageAlert message={isReviewsError.info.message} severity='error' />
-  }
-
-  if (isScannersError) {
-    return <MessageAlert message={isScannersError.info.message} severity='error' />
-  }
-
-  if (isUiConfigError) {
-    return <MessageAlert message={isUiConfigError.info.message} severity='error' />
-  }
-
-  if (isCommentResponsesError) {
-    return <MessageAlert message={isCommentResponsesError.info.message} severity='error' />
-  }
-
-  if (isReviewResponsesError) {
-    return <MessageAlert message={isReviewResponsesError.info.message} severity='error' />
-  }
+  const error = MultipleErrorWrapper('Unable to load release', {
+    isReviewResponsesError,
+    isScannersError,
+    isReviewsError,
+    isUiConfigError,
+    isCommentResponsesError,
+    isReleasesError,
+  })
+  if (error) return error
 
   return (
     <>
       {(isReviewsLoading ||
+        isReleasesLoading ||
         isUiConfigLoading ||
         isCommentResponsesLoading ||
         isReviewResponsesLoading ||

--- a/frontend/src/entry/model/releases/ReleaseForm.tsx
+++ b/frontend/src/entry/model/releases/ReleaseForm.tsx
@@ -33,6 +33,7 @@ import RichTextEditor from 'src/common/RichTextEditor'
 import FileDisplay from 'src/entry/model/files/FileDisplay'
 import ModelImageList from 'src/entry/model/ModelImageList'
 import ExistingFileSelector from 'src/entry/model/releases/ExistingFileSelector'
+import MultipleErrorWrapper from 'src/errors/MultipleErrorWrapper'
 import ReadOnlyAnswer from 'src/Form/ReadOnlyAnswer'
 import Link from 'src/Link'
 import MessageAlert from 'src/MessageAlert'
@@ -172,6 +173,7 @@ export default function ReleaseForm({
         showMenuItems={{ rescanFile: true }}
         mutator={mutateReleases}
         style={{ padding: 1 }}
+        releases={releases}
       />
     ) : (
       <></>
@@ -185,6 +187,12 @@ export default function ReleaseForm({
   if (isModelCardRevisionsError) {
     return <MessageAlert message={isModelCardRevisionsError.info.message} severity='error' />
   }
+
+  const error = MultipleErrorWrapper('Unable to load release form', {
+    isModelCardRevisionsError,
+    isReleasesError,
+  })
+  if (error) return error
 
   return (
     <Stack spacing={2}>


### PR DESCRIPTION
Seems as if next js recognises the multiple getReleases calls and ignores them, but for tidyness' sake I have removed them