### PR TITLE
Make docker-compose backend build docs for the local python version

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -11,8 +11,9 @@ RUN apt-get update && apt-get install -y pandoc && rm -rf /var/lib/apt/lists/*
 WORKDIR /app/docs
 
 COPY docs .
+COPY --from=python . /app/python
 
-RUN --mount=type=cache,target=/root/.cache/pip pip install --upgrade bailo -r requirements.txt
+RUN --mount=type=cache,target=/root/.cache/pip pip install -e /app/python -r requirements.txt
 
 RUN make dirhtml
 

--- a/backend/Dockerfile.dev
+++ b/backend/Dockerfile.dev
@@ -10,8 +10,9 @@ RUN apt-get update && apt-get install -y pandoc && rm -rf /var/lib/apt/lists/*
 WORKDIR /app/docs
 
 COPY docs .
+COPY --from=python . /app/python
 
-RUN --mount=type=cache,target=/root/.cache/pip pip install --upgrade bailo -r requirements.txt
+RUN --mount=type=cache,target=/root/.cache/pip pip install -e /app/python -r requirements.txt
 
 RUN make dirhtml
 

--- a/docker-compose-prod.yml
+++ b/docker-compose-prod.yml
@@ -99,6 +99,8 @@ services:
     build:
       context: ./backend/
       dockerfile: ./Dockerfile
+      additional_contexts:
+        python: ./lib/python
     ports:
       - 3001:3001
     volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -103,6 +103,8 @@ services:
   backend:
     build:
       context: ./backend/
+      additional_contexts:
+        python: ./lib/python
       dockerfile: ./Dockerfile.dev
     volumes:
       - ./backend/src:/app/src

--- a/lib/python/.dockerignore
+++ b/lib/python/.dockerignore
@@ -1,0 +1,136 @@
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+pip-wheel-metadata/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+.pypirc
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+*.py,cover
+.hypothesis/
+.pytest_cache/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+db.sqlite3
+db.sqlite3-journal
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# IPython
+profile_default/
+ipython_config.py
+
+# pyenv
+.python-version
+
+# pipenv
+#   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control.
+#   However, in case of collaboration, if having platform-specific dependencies or dependencies
+#   having no cross-platform support, pipenv may install dependencies that don't work, or not
+#   install all needed dependencies.
+#Pipfile.lock
+
+# PEP 582; used by e.g. github.com/David-OConnor/pyflow
+__pypackages__/
+
+# Celery stuff
+celerybeat-schedule
+celerybeat.pid
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+.dmypy.json
+dmypy.json
+
+# Pyre type checker
+.pyre/
+
+# VS Code
+.vscode/
+
+#resnet
+resnet50_weights.pth


### PR DESCRIPTION
Contributes towards #2453.
Backend docs now pull in the latest local version of the python bailo client `/lib/python` rather than building the most recently published version on PyPI. This means that any fork that modififies the python client will include their own version of the docs for their own Bailo instance, rather than the latest version on PyPI.

Note that this _does not_ change the docs built as part of the GitHub Action as the Action pulls the latest version of the bailo package from PyPI https://github.com/gchq/Bailo/blob/dev/build-python-docs-using-local-files/.github/workflows/web.yml#L44. This is intentional as we want the public docs for Open Source to match up with the current published version of bailo on PyPI.