### PR TITLE
Release review with incorrect semver causes hang

### DIFF
--- a/frontend/pages/model/[modelId]/release/[semver]/review.tsx
+++ b/frontend/pages/model/[modelId]/release/[semver]/review.tsx
@@ -116,16 +116,16 @@ export default function ReleaseReview() {
     }
   }, [release, model, uiConfig])
 
-  if (!release || !model || !uiConfig || isReleaseLoading || isModelLoading || isUiConfigLoading) {
-    return <Loading />
-  }
-
-  const error = MultipleErrorWrapper(`Unable to load release review page`, {
+  const error = MultipleErrorWrapper('Unable to load release review page', {
     isReleaseError,
     isModelError,
     isUiConfigError,
   })
   if (error) return error
+
+  if (!release || !model || !uiConfig || isReleaseLoading || isModelLoading || isUiConfigLoading) {
+    return <Loading />
+  }
 
   return (
     <>


### PR DESCRIPTION
**What is the problem:** When reviewing a release, if the semver in the URL is incorrect, it causes the page to hang.

**How do I reproduce it:** Make sure to have msro/mtr perms on model, then review a release. Edit the url so the semver value is valid, but non-existent on this model.

**Expected behaviour:** It should error, displaying something along the lines of - "Error - Could not find release"

**Fix:** Problem seems to be at https://github.com/gchq/Bailo/blob/e1c6aa92e3c65b3d0f127ecb30047f63c7616b5f/frontend/pages/model/%5BmodelId%5D/release/%5Bsemver%5D/review.tsx#L119-L121

This is basically saying, if no release is found (you've supplied a non-existent semver) then display the loading animation (hangs).

A possible fix could be to just remove this, and also the `!model` and `!uiConfig` checks as these are handled below by their respective `isError` values.