### PR TITLE
Improve API `POST` `/api/v2/model/{modelId}/export/s3` endpoint time

### DIFF
--- a/backend/src/services/mirroredModel.ts
+++ b/backend/src/services/mirroredModel.ts
@@ -826,7 +826,7 @@ async function addReleaseToZip(
     zip.append(JSON.stringify(file), { name: `files/${file._id.toString()}.json` })
   }
 
-  // Fire-and-forget upload of artifacts so that the endpoint is able to return without awaiting lots of uploads
+  // Fire-and-forget upload of artefacts so that the endpoint is able to return without awaiting lots of uploads
   uploadReleaseFiles(user, model, release, files, mirroredModelId)
   uploadReleaseImages(user, model, release, mirroredModelId)
 

--- a/backend/src/services/mirroredModel.ts
+++ b/backend/src/services/mirroredModel.ts
@@ -758,13 +758,16 @@ async function uploadReleaseFiles(
         },
       )
     } catch (error: any) {
-      throw InternalError('Error when uploading Release File to S3.', {
-        error,
-        modelId: model.id,
-        releaseSemver: release.semver,
-        fileId: file.id,
-        mirroredModelId,
-      })
+      log.error(
+        {
+          error,
+          modelId: model.id,
+          releaseSemver: release.semver,
+          fileId: file.id,
+          mirroredModelId,
+        },
+        'Error when uploading Release File to S3.',
+      )
     }
   }
 }
@@ -799,13 +802,16 @@ async function uploadReleaseImages(user: UserInterface, model: ModelDoc, release
           imageLogData,
         )
       } catch (error: any) {
-        throw InternalError('Error when uploading Release Image to S3.', {
-          error,
-          modelId: model.id,
-          releaseSemver: release.semver,
-          distributionPackageName,
-          mirroredModelId,
-        })
+        log.error(
+          {
+            error,
+            modelId: model.id,
+            releaseSemver: release.semver,
+            distributionPackageName,
+            mirroredModelId,
+          },
+          'Error when uploading Release Image to S3.',
+        )
       }
     }
   }

--- a/backend/test/services/mirroredModel.spec.ts
+++ b/backend/test/services/mirroredModel.spec.ts
@@ -515,28 +515,20 @@ describe('services > mirroredModel', () => {
       config: { mediaType: 'application/vnd.docker.container.image.v1+json', size: 4, digest: 'sha256:0' },
       layers: [],
     })
-    registryMocks.listModelImages.mockReturnValueOnce([
-      { name: 'image1', tags: ['tag1', 'tag2'] },
-      { name: 'image2', tags: [] },
-      { name: 'image3', tags: ['tag3'] },
-    ])
+    registryMocks.listModelImages.mockReturnValueOnce([{ name: 'image1', tags: ['tag1', 'tag2'] }])
     releaseMocks.getReleasesForExport.mockResolvedValueOnce([
       {
         toJSON: vi.fn(),
-        images: [
-          { repository: '', name: 'image1', tag: 'tag1', toObject: vi.fn() },
-          { repository: '', name: 'image1', tag: 'tag3', toObject: vi.fn() },
-          { repository: '', name: 'image4', tag: 'tag3', toObject: vi.fn() },
-        ],
+        images: [{ repository: '', name: 'image1', tag: 'tag1', toObject: vi.fn() }],
       },
     ])
 
     await exportModel({} as UserInterface, 'modelId', true, ['1.2.3'])
 
-    expect(s3Mocks.putObjectStream).toBeCalledTimes(5)
+    expect(s3Mocks.putObjectStream).toBeCalledTimes(3)
     expect(archiverMocks.append).toBeCalledTimes(3)
-    expect(zlibMocks.createGzip).toBeCalledTimes(3)
-    expect(tarMocks.pack).toBeCalledTimes(3)
+    expect(zlibMocks.createGzip).toBeCalledTimes(1)
+    expect(tarMocks.pack).toBeCalledTimes(1)
   })
 
   test('exportModel > unable to upload to tmp S3 location', async () => {


### PR DESCRIPTION
The endpoint was set up to wait for each artefact to be uploaded to S3 before completing. This is problematic when there are a large number of artefacts being uploaded as the connection may be open for a long time (and therefore risks being cut off).
This PR changes the functionality to no longer wait for each release artefact to be uploaded before returning the response.