### PR TITLE
Python client `Release.download_all` fix

### DIFF
--- a/backend/.dockerignore
+++ b/backend/.dockerignore
@@ -7,3 +7,8 @@ node_modules
 .gitignore
 dist
 config/local.cjs
+
+# Python Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -15,7 +15,10 @@ RUN --mount=type=cache,target=/var/cache/apt --mount=type=cache,target=/var/lib/
 WORKDIR /app/docs
 
 COPY docs .
-COPY --from=python . /app/python
+# Only get the required dirs & files (ignore tests etc.)
+COPY --from=python pyproject.toml /app/python
+COPY --from=python README.md /app/python
+COPY --from=python src /app/python/src
 
 RUN --mount=type=cache,target=/root/.cache/pip pip install -e /app/python -r requirements.txt
 

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -16,8 +16,8 @@ WORKDIR /app/docs
 
 COPY docs .
 # Only get the required dirs & files (ignore tests etc.)
-COPY --from=python pyproject.toml /app/python
-COPY --from=python README.md /app/python
+COPY --from=python pyproject.toml /app/python/
+COPY --from=python README.md /app/python/
 COPY --from=python src /app/python/src
 
 RUN --mount=type=cache,target=/root/.cache/pip pip install -e /app/python -r requirements.txt

--- a/lib/modelscan_api/.dockerignore
+++ b/lib/modelscan_api/.dockerignore
@@ -19,8 +19,10 @@ Dockerfile
 
 # Test files
 .pytest_cache/
+tests/
 
 # Misc
 README.md
 .pre-commit-config.yaml
 requirements-dev.txt
+pytest.ini

--- a/lib/python/CHANGELOG.md
+++ b/lib/python/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All dates are formatted dd/mm/yyyy.
 
+## 3.1.1 - 27/08/2025
+
+### Changes
+
+- Fix `Release.download_all` method's bad `include` & `exclude` logic.
+- Update package dependencies.
+
 ## 3.1.0 - 21/08/2025
 
 ### Breaking Changes

--- a/lib/python/src/bailo/__init__.py
+++ b/lib/python/src/bailo/__init__.py
@@ -9,8 +9,8 @@ from __future__ import annotations
 
 import logging
 
-# Package Version 3.1.0
-__version__ = "3.1.0"
+# Package Version
+__version__ = "3.1.1"
 
 
 from bailo.core.agent import Agent, PkiAgent, TokenAgent

--- a/lib/python/src/bailo/helper/release.py
+++ b/lib/python/src/bailo/helper/release.py
@@ -214,8 +214,8 @@ class Release:
     def download_all(
         self,
         path: str = os.getcwd(),
-        include: list | str = "",
-        exclude: list | str = "",
+        include: list | str | None = None,
+        exclude: list | str | None = None,
     ):
         """Writes all files in a release to disk at the given path, applying inclusion/exclusion filters.
 

--- a/lib/python/tests/test_files.py
+++ b/lib/python/tests/test_files.py
@@ -75,7 +75,7 @@ def test_file_download_filter(example_model: Model, tmp_path: Path):
     downloads_path.mkdir()
     example_release.download_all(path=str(downloads_path.absolute()), include=["*.txt"], exclude=["to_exclude.txt"])
 
-    assert set(os.listdir(downloads_path)) == set(["test2.txt"])
+    assert set(os.listdir(downloads_path)) == {"test2.txt"}
 
 
 @pytest.mark.integration

--- a/lib/python/tests/test_files.py
+++ b/lib/python/tests/test_files.py
@@ -56,7 +56,7 @@ def test_file_download_all(example_model: Model, tmp_path: Path):
     downloads_path.mkdir()
     example_release.download_all(path=str(downloads_path.absolute()))
 
-    assert set(os.listdir(downloads_path)).issubset(filenames)
+    assert set(os.listdir(downloads_path)) == set(filenames)
 
 
 @pytest.mark.integration
@@ -75,7 +75,7 @@ def test_file_download_filter(example_model: Model, tmp_path: Path):
     downloads_path.mkdir()
     example_release.download_all(path=str(downloads_path.absolute()), include=["*.txt"], exclude=["to_exclude.txt"])
 
-    assert os.listdir(downloads_path) == ["test2.txt"]
+    assert set(os.listdir(downloads_path)) == set(["test2.txt"])
 
 
 @pytest.mark.integration


### PR DESCRIPTION
Python client's `Release.download_all()` did not download any files nor display any errors. Investigation shows that the problem was due to bad logic with the `include` and `exclude` filters.

This PR also includes minor improvements to the python related Dockerfiles to no longer pull in extra, unnecessary files (e.g. the tests dir and cache artefacts), and bumps the Bailo Python client package version. The new package will automatically be released upon merging this PR.