### PR TITLE
Improve .dockerignore and .gitignore to exclude unwanted files

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,10 +1,32 @@
-node_modules
+# Docker artefacts
+Dockerfile
+.dockerignore
+
+# Git artefacts
+.git
+.gitignore
+
+# Dependency directories
+node_modules/
+
+# Test artefacts
+.pytest_cache
+
+# Byte-compiled / optimized / DLL files
+**/__pycache__/
+**/*.py[cod]
+**$py.class
 
 backend/.git
+backend/coverage
 backend/dist
 backend/node_modules
 
 frontend/.git
 frontend/.next
 frontend/.swc
+frontend/.turbo
+frontend/coverage
+frontend/cypress/screenshots/
+frontend/cypress/downloads/
 frontend/node_modules

--- a/backend/.dockerignore
+++ b/backend/.dockerignore
@@ -1,14 +1,34 @@
+# Docker artefacts
 Dockerfile
 .dockerignore
-npm-debug.log
-README.md
-node_modules
+
+# Git artefacts
 .git
 .gitignore
-dist
-config/local.cjs
 
-# Python Byte-compiled / optimized / DLL files
-__pycache__/
-*.py[cod]
-*$py.class
+# Logs
+logs
+*.log
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+lerna-debug.log*
+.pnpm-debug.log*
+
+# Coverage directory used by tools like istanbul
+coverage
+*.lcov
+
+# Dependency directories
+node_modules/
+
+# build / generate output
+dist
+
+# Byte-compiled / optimized / DLL files
+**/__pycache__/
+**/*.py[cod]
+**$py.class
+
+# Extras
+README.md

--- a/frontend/.dockerignore
+++ b/frontend/.dockerignore
@@ -1,11 +1,41 @@
+# Docker artefacts
 Dockerfile
 .dockerignore
-npm-debug.log
-.next
-.swc
-.turbo
-coverage
-cache
-node_modules
+
+# Git artefacts
 .git
 .gitignore
+
+# Logs
+logs
+*.log
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+lerna-debug.log*
+.pnpm-debug.log*
+
+# Coverage directory used by tools like istanbul
+coverage
+*.lcov
+
+# Dependency directories
+node_modules/
+
+# Next.js build output
+.next
+out
+
+# cache
+cache
+
+# vercel
+.vercel
+.turbo
+
+# swc
+.swc
+
+# cypress
+cypress/screenshots/
+cypress/downloads/

--- a/frontend/.gitignore
+++ b/frontend/.gitignore
@@ -22,9 +22,11 @@
 *.pem
 
 # debug
+logs
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+lerna-debug.log*
 .pnpm-debug.log*
 
 # local env files

--- a/lib/modelscan_api/README.md
+++ b/lib/modelscan_api/README.md
@@ -62,7 +62,7 @@ View the swagger docs: `http://127.0.0.1:8000/docs`
 Alternatively, build and run [Dockerfile](./Dockerfile).
 
 ```bash
-docker build -t modelscan_rest_api:latest -f ./Dockerfile .
+docker build -t modelscan_rest_api:latest .
 docker run -p 0.0.0.0:3311:3311 modelscan_rest_api:latest
 ```
 

--- a/lib/python/.dockerignore
+++ b/lib/python/.dockerignore
@@ -1,7 +1,7 @@
 # Byte-compiled / optimized / DLL files
-__pycache__/
-*.py[cod]
-*$py.class
+**/__pycache__/
+**/*.py[cod]
+**$py.class
 
 # C extensions
 *.so
@@ -134,3 +134,7 @@ dmypy.json
 
 #resnet
 resnet50_weights.pth
+
+# MLFlow
+mlartifacts/
+mlruns/


### PR DESCRIPTION
This should make builds slightly smaller, as well as improve build times by no longer pulling in unwanted files which may change and `COPY`/`ADD` commands, helping to better utilise the cached layers.