### PR TITLE
Replace relative URL with absolute URL

### DIFF
--- a/lib/python/README.md
+++ b/lib/python/README.md
@@ -101,7 +101,7 @@ Documentation is rendered with Sphinx and served [here](https://gchq.github.io/B
 
 ### Building locally
 
-Refer to [backend/docs/README.md](../../backend/docs/README.md) for local build steps.
+Refer to [backend/docs/README.md](https://github.com/gchq/Bailo/blob/main/backend/docs/README.md) for local build steps.
 
 ## Development
 


### PR DESCRIPTION
The python README is copied to https://pypi.org/project/bailo/ so requires having absolute URLs rather than relative URLs.