### PR TITLE
Queue Scans to avoid timeout Error when handling many large files

### DIFF
--- a/backend/config/default.cjs
+++ b/backend/config/default.cjs
@@ -184,11 +184,13 @@ module.exports = {
 
   avScanning: {
     clamdscan: {
+      concurrency: 4,
       host: '127.0.0.1',
       port: 3310,
     },
 
     modelscan: {
+      concurrency: 4,
       protocol: 'http',
       host: '127.0.0.1',
       port: 3311,

--- a/backend/src/connectors/fileScanning/Base.ts
+++ b/backend/src/connectors/fileScanning/Base.ts
@@ -1,6 +1,9 @@
+import PQueue from 'p-queue'
+
 import { FileInterface } from '../../models/File.js'
 import { ScanInterface } from '../../models/Scan.js'
 import log from '../../services/log.js'
+
 export type FileScanResult = Pick<
   ScanInterface,
   'toolName' | 'scannerVersion' | 'state' | 'isInfected' | 'viruses' | 'lastRunAt'
@@ -37,5 +40,25 @@ export abstract class BaseFileScanningConnector {
         lastRunAt: new Date(),
       },
     ]
+  }
+}
+
+export abstract class BaseQueueFileScanningConnector extends BaseFileScanningConnector {
+  abstract readonly queue: PQueue
+
+  abstract _scan(file: FileInterface): Promise<FileScanResult[]>
+
+  async scan(file: FileInterface): Promise<FileScanResult[]> {
+    log.debug({ file, toolName: this.toolName, ...(this.version && { version: this.version }) }, 'Queueing scan.')
+    const scanResult = await this.queue
+      .add(async () => this._scan(file))
+      .catch((error) => {
+        return this.scanError('Queued scan threw an error.', { error, file })
+      })
+    // return type of `queue.add()` is Promise<void | ...> so reject void responses
+    if (scanResult === null || typeof scanResult !== 'object') {
+      return this.scanError('Queued scan failed to correctly return.', { file })
+    }
+    return scanResult
   }
 }

--- a/backend/src/connectors/fileScanning/modelScan.ts
+++ b/backend/src/connectors/fileScanning/modelScan.ts
@@ -1,12 +1,15 @@
+import PQueue from 'p-queue'
 import { Readable } from 'stream'
 
 import { getModelScanInfo, scanStream } from '../../clients/modelScan.js'
 import { getObjectStream } from '../../clients/s3.js'
 import { FileInterfaceDoc } from '../../models/File.js'
 import log from '../../services/log.js'
-import { BaseFileScanningConnector, FileScanResult, ScanState } from './Base.js'
+import config from '../../utils/config.js'
+import { BaseQueueFileScanningConnector, FileScanResult, ScanState } from './Base.js'
 
-export class ModelScanFileScanningConnector extends BaseFileScanningConnector {
+export class ModelScanFileScanningConnector extends BaseQueueFileScanningConnector {
+  queue: PQueue = new PQueue({ concurrency: config.avScanning.modelscan.concurrency })
   toolName: string = 'ModelScan'
   version: string | undefined = undefined
 
@@ -20,7 +23,7 @@ export class ModelScanFileScanningConnector extends BaseFileScanningConnector {
     return this
   }
 
-  async scan(file: FileInterfaceDoc): Promise<FileScanResult[]> {
+  async _scan(file: FileInterfaceDoc): Promise<FileScanResult[]> {
     await this.init()
     const scannerInfo = this.info()
     if (!scannerInfo.scannerVersion) {

--- a/backend/src/utils/config.ts
+++ b/backend/src/utils/config.ts
@@ -158,11 +158,13 @@ export interface Config {
 
   avScanning: {
     clamdscan: {
+      concurrency: number
       host: string
       port: number
     }
 
     modelscan: {
+      concurrency: number
       protocol: string
       host: string
       port: number


### PR DESCRIPTION
Add `BaseQueueFileScanningConnector` for queued scans and update `ClamAvFileScanningConnector` and `ModelScanFileScanningConnector` to use this.

Modified files currently have no tests hence no additional test coverage.