### PR TITLE
ModelScan - detect Pickle files

### DIFF
--- a/lib/modelscan_api/Dockerfile
+++ b/lib/modelscan_api/Dockerfile
@@ -33,6 +33,7 @@ CMD ["python3", "/venv/bin/fastapi", "run", "bailo_modelscan_api/main.py", "--po
 FROM base AS dev
 
 COPY --from=build /venv /venv
+CMD ["python3", "/venv/bin/fastapi", "dev", "bailo_modelscan_api/main.py", "--port", "3311"]
 
 FROM base AS prod
 

--- a/lib/modelscan_api/README.md
+++ b/lib/modelscan_api/README.md
@@ -13,7 +13,8 @@ This directory provides all of the necessary functionality to interact with
 > model formats. ModelScan currently supports: H5, Pickle, and SavedModel formats. This protects you when using PyTorch,
 > TensorFlow, Keras, Sklearn, XGBoost, with more on the way.
 
-This API is used as a filescanner and is not published to PyPI.
+This API is used as a filescanner and is not published to PyPI. The built image is published to
+[GHCR bailo_modelscan](https://github.com/gchq/Bailo/pkgs/container/bailo_modelscan).
 
 ## Docker
 
@@ -49,21 +50,21 @@ Optionally, create and populate a `.env` file to override and set any [Settings]
 variables, including sensitive properties as per
 [FastAPI's Reading a .env file docs](https://fastapi.tiangolo.com/advanced/settings/#reading-a-env-file).
 
-Run:
+Build and run [Dockerfile](./Dockerfile).
 
 ```bash
-fastapi run bailo_modelscan_api/main.py
+docker build -t modelscan_rest_api:latest .
+docker run -p 0.0.0.0:3311:3311 modelscan_rest_api:latest
 ```
 
 Connect via the local endpoint: `http://127.0.0.1:8000`
 
 View the swagger docs: `http://127.0.0.1:8000/docs`
 
-Alternatively, build and run [Dockerfile](./Dockerfile).
+Alternatively, run:
 
 ```bash
-docker build -t modelscan_rest_api:latest .
-docker run -p 0.0.0.0:3311:3311 modelscan_rest_api:latest
+fastapi run bailo_modelscan_api/main.py
 ```
 
 ## Development
@@ -98,16 +99,18 @@ refer to [test_integration](./tests/test_integration/README.md) for details.
 
 To run in [dev mode](https://fastapi.tiangolo.com/fastapi-cli/#fastapi-dev):
 
-```bash
-fastapi dev bailo_modelscan_api/main.py
-```
-
-Alternatively, build and run [Dockerfile](./Dockerfile) using `--target dev` which mounts the `bailo_modelscan_api`
-directory as a volume, so allows for real-time changes with FastAPI running in dev mode.
+Build and run [Dockerfile](./Dockerfile) using `--target dev` which mounts the `bailo_modelscan_api` directory as a
+volume, so allows for real-time changes with FastAPI running in dev mode.
 
 ```bash
 docker build -t modelscan_rest_api:latest --target dev .
 docker run -v ./bailo_modelscan_api:/app/bailo_modelscan_api -p 0.0.0.0:3311:3311 modelscan_rest_api:latest
+```
+
+Alternatively, run:
+
+```bash
+fastapi dev bailo_modelscan_api/main.py
 ```
 
 <!-- MARKDOWN LINKS & IMAGES -->

--- a/lib/modelscan_api/bailo_modelscan_api/config.py
+++ b/lib/modelscan_api/bailo_modelscan_api/config.py
@@ -20,7 +20,7 @@ class Settings(BaseSettings):
     Bailo ModelScan API allows for easy programmatic interfacing with ProtectAI's ModelScan package to scan and detect potential threats within files stored in Bailo.
 
     You can upload files and view modelscan's result."""
-    app_version: str = "2.0.4"
+    app_version: str = "3.0.0"
     modelscan_settings: dict[str, Any] = DEFAULT_SETTINGS
     block_size: int = 1024
     maximum_filesize: int = 4 * 1024**3  # 4GB

--- a/lib/modelscan_api/requirements.txt
+++ b/lib/modelscan_api/requirements.txt
@@ -1,6 +1,6 @@
 content-size-limit-asgi==0.1.5
 fastapi[standard-no-fastapi-cloud-cli]==0.117.1
-modelscan[tensorflow,h5py]==0.8.6
+modelscan[tensorflow,h5py]==0.8.7
 pydantic_settings==2.10.1
 python-multipart==0.0.20
 uvicorn==0.36.0

--- a/lib/modelscan_api/tests/test_integration.py
+++ b/lib/modelscan_api/tests/test_integration.py
@@ -34,8 +34,9 @@ app.add_middleware(
 client = TestClient(app)
 
 
-BIG_CONTENTS = b"\0" * 1024
+BIG_CONTENTS = b"\0" * 1001
 H5_MIME_TYPE = "application/x-hdf5"
+TXT_MIME_TYPE = "text/plain"
 OCTET_STREAM_TYPE = "application/octet-stream"
 
 
@@ -46,7 +47,7 @@ OCTET_STREAM_TYPE = "application/octet-stream"
         (
             "empty.txt",
             rb"",
-            "text/plain",
+            TXT_MIME_TYPE,
             {
                 "errors": [],
                 "issues": [],
@@ -176,6 +177,39 @@ OCTET_STREAM_TYPE = "application/octet-stream"
                     },
                 ],
                 "errors": [],
+            },
+        ),
+        (
+            "license.dat",
+            Path().cwd().joinpath("tests/test_integration/license.dat"),
+            TXT_MIME_TYPE,
+            {
+                "errors": [],
+                "issues": [],
+                "summary": {
+                    "absolute_path": ANY,
+                    "input_path": ANY,
+                    "modelscan_version": modelscan.__version__,
+                    "scanned": {"total_scanned": 0},
+                    "skipped": {
+                        "skipped_files": [
+                            {
+                                "category": "SCAN_NOT_SUPPORTED",
+                                "description": "Model Scan did not scan file",
+                                "source": ANY,
+                            }
+                        ],
+                        "total_skipped": 1,
+                    },
+                    "timestamp": ANY,
+                    "total_issues": 0,
+                    "total_issues_by_severity": {
+                        "CRITICAL": 0,
+                        "HIGH": 0,
+                        "LOW": 0,
+                        "MEDIUM": 0,
+                    },
+                },
             },
         ),
     ],

--- a/lib/modelscan_api/tests/test_integration/license.dat
+++ b/lib/modelscan_api/tests/test_integration/license.dat
@@ -1,0 +1,7 @@
+SERVER pat   17003456 1700
+SERVER lee   17004355 1700
+SERVER terry 17007ea8 1700
+DAEMON GSI /etc/mydaemon
+FEATURE great_program gsi 1.000 01-jan-1989 10 1EF890030EABF324 ""
+FEATURE greater_program gsi 1.000 01-jan-1989 10 0784561FE98BA073 ""
+# from https://public.dhe.ibm.com/software/rational/docs/documentation/manuals/man_47/man5html/license.dat.htm#:~:text=SERVER%20pat%2017003456%201700%20SERVER,%2C%20license.options(5)

--- a/lib/modelscan_api/tests/test_main.py
+++ b/lib/modelscan_api/tests/test_main.py
@@ -28,6 +28,7 @@ app.dependency_overrides[get_settings] = get_settings_override
 
 EMPTY_CONTENTS = rb""
 H5_MIME_TYPE = "application/x-hdf5"
+TXT_MIME_TYPE = "text/plain"
 
 
 def test_info():
@@ -74,4 +75,27 @@ def test_scan_file_exception(mock_scan: Mock, file_name: str, file_content: Any,
 
     assert response.status_code == 500
     assert response.json() == {"detail": "An error occurred: Mocked error!"}
+    mock_scan.assert_called_once()
+
+
+@patch("bailo_modelscan_api.main.is_valid_pickle")
+@patch("modelscan.modelscan.ModelScan.scan")
+@pytest.mark.parametrize(
+    ("file_name", "file_content", "file_mime_type"),
+    [
+        ("license.dat", "# License\nExample license.", TXT_MIME_TYPE),
+    ],
+)
+def test_scan_invalid_pickle_file(
+    mock_scan: Mock, mock_is_valid_pickle: Mock, file_name: str, file_content: Any, file_mime_type: str
+):
+    mock_scan.return_value = {}
+    mock_is_valid_pickle.return_value = False
+    files = {"in_file": (file_name, file_content, file_mime_type)}
+
+    response = client.post("/scan/file", files=files)
+
+    assert response.status_code == 200
+    assert ".dat" not in str(response.content)
+    mock_is_valid_pickle.assert_called_once()
     mock_scan.assert_called_once()


### PR DESCRIPTION
The modelscan package runs checks against specific file types based on their file extension [as defined in config](https://github.com/protectai/modelscan/blob/abc4b1510315ba1ba162e3ae002e5d394db32200/modelscan/settings.py#L59). This naive approach does not always work well as the file `license.dat` is unlikely to be a Pickle file. ModelScan tries and fails to treat the file as being a pickle which it is not, so fails to complete the operations, resulting in an error which prevents the file (and hence the release) from being mirrored.