### PR TITLE
Revert config map value to be a boolean rather than string

### DIFF
--- a/infrastructure/helm/bailo/templates/bailo/bailo.configmap.yaml
+++ b/infrastructure/helm/bailo/templates/bailo/bailo.configmap.yaml
@@ -234,7 +234,7 @@ data:
       instrumentation: {
         enabled: {{ .Values.instrumentation.enabled }},
         endpoint: '{{ .Values.instrumentation.endpoint }}',
-        debug: '{{ .Values.instrumentation.debug }}',
+        debug: {{ .Values.instrumentation.debug }},
       },
 
       s3: {


### PR DESCRIPTION
Gets rid of lots of noisy opentelemetry logs