### PR TITLE
Update compose to use published images

### DIFF
--- a/compose.modelscan.yaml
+++ b/compose.modelscan.yaml
@@ -1,0 +1,11 @@
+name: bailo-prod
+
+services:
+  modelscan:
+    volumes:
+      - ./lib/modelscan_api/bailo_modelscan_api:/app/bailo_modelscan_api
+    image: bailo_modelscan:${INSTANCE_NAME}
+    pull_policy: build
+    build:
+      context: ./lib/modelscan_api
+      target: dev

--- a/compose.override.yaml
+++ b/compose.override.yaml
@@ -26,18 +26,16 @@ services:
       - ./backend/src:/app/src
     build:
       target: dev
+    image: bailo_backend:${INSTANCE_NAME}
+    pull_policy: build
 
   frontend:
     volumes:
       - ./frontend:/app
     build:
       target: dev
-
-  modelscan:
-    volumes:
-      - ./lib/modelscan_api/bailo_modelscan_api:/app/bailo_modelscan_api
-    build:
-      target: dev
+    image: bailo_frontend:${INSTANCE_NAME}
+    pull_policy: build
 
   minio:
     environment:

--- a/compose.prod.yaml
+++ b/compose.prod.yaml
@@ -2,8 +2,8 @@ name: bailo-prod
 
 services:
   frontend:
-    image: ghcr.io/gchq/bailo_frontend:v2.10.0
+    image: ghcr.io/gchq/bailo_frontend:latest
     pull_policy: missing
   backend:
-    image: ghcr.io/gchq/bailo_backend:v2.10.0
+    image: ghcr.io/gchq/bailo_backend:latest
     pull_policy: missing

--- a/compose.prod.yaml
+++ b/compose.prod.yaml
@@ -1,1 +1,9 @@
 name: bailo-prod
+
+services:
+  frontend:
+    image: ghcr.io/gchq/bailo_frontend:v2.10.0
+    pull_policy: missing
+  backend:
+    image: ghcr.io/gchq/bailo_backend:v2.10.0
+    pull_policy: missing

--- a/compose.yaml
+++ b/compose.yaml
@@ -51,7 +51,7 @@ services:
     networks:
       internal:
     healthcheck:
-      test: ['CMD-SHELL', "echo 'PING' | nc -w 5 localhost 3310"]
+      test: ["CMD-SHELL", "echo 'PING' | nc -w 5 localhost 3310"]
       interval: 30s
       timeout: 10s
       retries: 5
@@ -59,13 +59,11 @@ services:
   modelscan:
     networks:
       internal:
-    image: bailo_modelscan:${INSTANCE_NAME}
-    build:
-      context: ./lib/modelscan_api
+    image: ghcr.io/gchq/bailo_modelscan:3.0.0
     volumes:
       - ./lib/modelscan_api/bailo_modelscan_api:/app/bailo_modelscan_api
     healthcheck:
-      test: ['CMD-SHELL', 'curl --fail http://127.0.0.1:3311/info || exit 1']
+      test: ["CMD-SHELL", "curl --fail http://127.0.0.1:3311/info || exit 1"]
       interval: 30s
       timeout: 10s
       retries: 5
@@ -107,7 +105,6 @@ services:
   frontend:
     networks:
       internal:
-    image: bailo_frontend:${INSTANCE_NAME}
     build:
       context: ./frontend/
     depends_on:
@@ -116,7 +113,6 @@ services:
   backend:
     networks:
       internal:
-    image: bailo_backend:${INSTANCE_NAME}
     build:
       context: ./backend/
       additional_contexts:

--- a/compose.yaml
+++ b/compose.yaml
@@ -51,7 +51,7 @@ services:
     networks:
       internal:
     healthcheck:
-      test: ["CMD-SHELL", "echo 'PING' | nc -w 5 localhost 3310"]
+      test: ['CMD-SHELL', "echo 'PING' | nc -w 5 localhost 3310"]
       interval: 30s
       timeout: 10s
       retries: 5
@@ -63,7 +63,7 @@ services:
     volumes:
       - ./lib/modelscan_api/bailo_modelscan_api:/app/bailo_modelscan_api
     healthcheck:
-      test: ["CMD-SHELL", "curl --fail http://127.0.0.1:3311/info || exit 1"]
+      test: ['CMD-SHELL', 'curl --fail http://127.0.0.1:3311/info || exit 1']
       interval: 30s
       timeout: 10s
       retries: 5

--- a/compose.yaml
+++ b/compose.yaml
@@ -59,7 +59,7 @@ services:
   modelscan:
     networks:
       internal:
-    image: ghcr.io/gchq/bailo_modelscan:3.0.0
+    image: ghcr.io/gchq/bailo_modelscan:latest
     volumes:
       - ./lib/modelscan_api/bailo_modelscan_api:/app/bailo_modelscan_api
     healthcheck:

--- a/lib/modelscan_api/README.md
+++ b/lib/modelscan_api/README.md
@@ -24,6 +24,10 @@ by using `--target dev` or `--target prod` respectively (targeting prod is optio
 
 Note that the Docker containers run on port `3311` rather than `8000`, so adjust URLs accordingly.
 
+When using with the wider project's docker compose structure, you can use the
+[compose.modelscan.yaml](../../compose.modelscan.yaml) profile (`compose [...] -f compose.modelscan.yaml`) to switch to
+the local/live development version.
+
 ## Setup
 
 <!-- prettier-ignore-start -->


### PR DESCRIPTION
Updated the base compose file to use the published modelscan image since most of the time that should be the default. If you're developing the modelscan container, you can just add `-f compose.modelscan.yaml` to tell compose it should build and use that image.

By default, docker compose up/build/pull will use the published modelscan image, and the 'local' dev containers for frontend/backend.

If you add `-f compose.modelscan.yaml` it will also use the 'local' dev container for modelscan.

I also updated the prod compose file to reference the (current) published images for frontend/backend.

This also fixes the current main revision where if you do `compose pull` it will not find the bailo containers (understandably), and should instead say 'skipped'.