### PR TITLE
Update python client to include Entry tags

### DIFF
--- a/backend/src/services/specification.ts
+++ b/backend/src/services/specification.ts
@@ -79,9 +79,7 @@ export const modelCardInterfaceSchema = z.object({
   version: z.number().openapi({ example: 5 }),
   createdBy: z.string().openapi({ example: 'user' }),
   metadata: z.object({
-    overview: z.object({
-      tags: z.array(z.string()).openapi({ example: ['tag', 'tagb'] }),
-    }),
+    overview: z.object({}),
   }),
 })
 
@@ -91,9 +89,7 @@ export const modelCardRevisionInterfaceSchema = z.object({
 
   version: z.number().openapi({ example: 5 }),
   metadata: z.object({
-    overview: z.object({
-      tags: z.array(z.string()).openapi({ example: ['tag', 'tagb'] }),
-    }),
+    overview: z.object({}),
   }),
 
   createdBy: z.string().openapi({ example: 'user' }),
@@ -107,6 +103,9 @@ export const modelInterfaceSchema = z.object({
   name: z.string().openapi({ example: 'Yolo v4' }),
   kind: z.string().openapi({ example: 'model' }),
   description: z.string().openapi({ example: 'You only look once' }),
+  organisation: z.string().openapi({ example: 'Acme Corp' }),
+  state: z.string().openapi({ example: 'development' }),
+  tags: z.array(z.string()).openapi({ example: ['tag', 'tagb'] }),
   card: modelCardInterfaceSchema,
 
   collaborators: z.array(

--- a/lib/python/CHANGELOG.md
+++ b/lib/python/CHANGELOG.md
@@ -2,9 +2,13 @@
 
 All dates are formatted dd/mm/yyyy.
 
+## 3.2.1 30/10/2025
+
+- Add `tags` property to `Entry` (and inherited classes `Model`, `MirroredModel` and `Datacard`)
+
 ## 3.2.0 29/10/2025
 
-- Added new kind property for mirrored models
+- Added new `MirroredModel` class.
 
 ## 3.1.2 30/09/2025
 

--- a/lib/python/src/bailo/__init__.py
+++ b/lib/python/src/bailo/__init__.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 import logging
 
 # Package Version
-__version__ = "3.2.0"
+__version__ = "3.2.1"
 
 
 from bailo.core.agent import Agent, PkiAgent, TokenAgent
@@ -18,8 +18,8 @@ from bailo.core.client import Client
 from bailo.core.enums import EntryKind, ModelVisibility, Role, SchemaKind
 from bailo.helper.access_request import AccessRequest
 from bailo.helper.datacard import Datacard
-from bailo.helper.model import Experiment, Model
 from bailo.helper.mirroredModel import MirroredModel
+from bailo.helper.model import Experiment, Model
 from bailo.helper.release import Release
 from bailo.helper.schema import Schema
 

--- a/lib/python/src/bailo/core/client.py
+++ b/lib/python/src/bailo/core/client.py
@@ -33,6 +33,7 @@ class Client:
         visibility: ModelVisibility | None = None,
         organisation: str | None = None,
         state: str | None = None,
+        tags: list[str] | None = None,
         collaborators: list[CollaboratorEntry] | None = None,
     ):
         """Create a model.
@@ -44,6 +45,7 @@ class Client:
         :param visibility: Enum to define model visibility (e.g public or private), defaults to None
         :param organisation: Organisation responsible for the model, defaults to None
         :param state: Development readiness of the model, defaults to None
+        :param tags: Tags to assign to the model, defaults to None
         :param collaborators: list of CollaboratorEntry to define who the model's collaborators (a.k.a. model access) are, defaults to None
         :return: JSON response object
         """
@@ -73,6 +75,7 @@ class Client:
                     "visibility": _visibility,
                     "organisation": organisation,
                     "state": state,
+                    "tags": tags,
                     "collaborators": collaborators,
                 }
             )
@@ -85,6 +88,7 @@ class Client:
                     "visibility": _visibility,
                     "organisation": organisation,
                     "state": state,
+                    "tags": tags,
                     "collaborators": collaborators,
                 }
             )
@@ -147,6 +151,7 @@ class Client:
         visibility: str | None = None,
         organisation: str | None = None,
         state: str | None = None,
+        tags: list[str] | None = None,
         collaborators: list[CollaboratorEntry] | None = None,
     ):
         """Update a specific model using its unique ID.
@@ -158,6 +163,7 @@ class Client:
         :param visibility: Enum to define model visibility (e.g public or private), defaults to None
         :param organisation: Organisation responsible for the model, defaults to None
         :param state: Development readiness of the model, defaults to None
+        :param tags: Tags to assign to the model, defaults to None
         :param collaborators: list of CollaboratorEntry to define who the model's collaborators (a.k.a. model access) are, defaults to None
         :return: JSON response object
         """
@@ -170,6 +176,7 @@ class Client:
                 "description": description,
                 "visibility": visibility,
                 "collaborators": collaborators,
+                "tags": tags,
             }
         )
 

--- a/lib/python/src/bailo/helper/datacard.py
+++ b/lib/python/src/bailo/helper/datacard.py
@@ -18,9 +18,10 @@ class Datacard(Entry):
     :param datacard_id: A unique ID for the datacard
     :param name: Name of datacard
     :param description: Description of datacard
-    :param organisation: Organisation responsible for the model, defaults to None
-    :param state: Development readiness of the model, defaults to None
-    :param collaborators: list of CollaboratorEntry to define who the model's collaborators (a.k.a. model access) are, defaults to None
+    :param organisation: Organisation responsible for the datacard, defaults to None
+    :param state: Development readiness of the datacard, defaults to None
+    :param tags: Tags to assign to the datacard, defaults to None
+    :param collaborators: list of CollaboratorEntry to define who the datacard's collaborators (a.k.a. model access) are, defaults to None
     :param visibility: Visibility of datacard, using ModelVisibility enum (e.g Public or Private), defaults to None
     """
 
@@ -32,6 +33,7 @@ class Datacard(Entry):
         description: str,
         organisation: str | None = None,
         state: str | None = None,
+        tags: list[str] | None = None,
         collaborators: list[CollaboratorEntry] | None = None,
         visibility: ModelVisibility | None = None,
     ) -> None:
@@ -43,6 +45,7 @@ class Datacard(Entry):
             kind=EntryKind.DATACARD,
             organisation=organisation,
             state=state,
+            tags=tags,
             collaborators=collaborators,
             visibility=visibility,
         )
@@ -57,6 +60,7 @@ class Datacard(Entry):
         description: str,
         organisation: str | None = None,
         state: str | None = None,
+        tags: list[str] | None = None,
         collaborators: list[CollaboratorEntry] | None = None,
         visibility: ModelVisibility | None = None,
     ) -> Datacard:
@@ -65,9 +69,10 @@ class Datacard(Entry):
         :param client: A client object used to interact with Bailo
         :param name: Name of datacard
         :param description: Description of datacard
-        :param organisation: Organisation responsible for the model, defaults to None
-        :param state: Development readiness of the model, defaults to None
-        :param collaborators: list of CollaboratorEntry to define who the model's collaborators (a.k.a. model access) are, defaults to None
+        :param organisation: Organisation responsible for the datacard, defaults to None
+        :param state: Development readiness of the datacard, defaults to None
+        :param tags: Tags to assign to the datacard, defaults to None
+        :param collaborators: list of CollaboratorEntry to define who the datacard's collaborators (a.k.a. datacard access) are, defaults to None
         :param visibility: Visibility of datacard, using ModelVisibility enum (e.g Public or Private), defaults to None
         :return: Datacard object
         """
@@ -78,6 +83,7 @@ class Datacard(Entry):
             visibility=visibility,
             organisation=organisation,
             state=state,
+            tags=tags,
             collaborators=collaborators,
         )
         datacard_id = res["model"]["id"]
@@ -90,6 +96,7 @@ class Datacard(Entry):
             description=description,
             organisation=organisation,
             state=state,
+            tags=tags,
             collaborators=collaborators,
             visibility=visibility,
         )
@@ -122,6 +129,7 @@ class Datacard(Entry):
             collaborators=res["collaborators"],
             organisation=res.get("organisation"),
             state=res.get("state"),
+            tags=res.get("tags"),
         )
         datacard._unpack(res)
 

--- a/lib/python/src/bailo/helper/entry.py
+++ b/lib/python/src/bailo/helper/entry.py
@@ -18,10 +18,11 @@ class Entry:
     :param name: Name of the entry
     :param description: Description of the entry
     :param kind: Represents whether entry type (i.e. Model, Mirrored Model or Datacard)
-    :param visibility: Visibility of model, using ModelVisibility enum (i.e. Public or Private), defaults to None
-    :param organisation: Organisation responsible for the model, defaults to None
-    :param state: Development readiness of the model, defaults to None
-    :param collaborators: list of CollaboratorEntry to define who the model's collaborators (a.k.a. model access) are, defaults to None
+    :param visibility: Visibility of entry, using ModelVisibility enum (i.e. Public or Private), defaults to None
+    :param organisation: Organisation responsible for the entry, defaults to None
+    :param state: Development readiness of the entry, defaults to None
+    :param tags: Tags to assign to the entry, defaults to None
+    :param collaborators: list of CollaboratorEntry to define who the entry's collaborators (a.k.a. entry access) are, defaults to None
     """
 
     def __init__(
@@ -34,6 +35,7 @@ class Entry:
         visibility: ModelVisibility | None = None,
         organisation: str | None = None,
         state: str | None = None,
+        tags: list[str] | None = None,
         collaborators: list[CollaboratorEntry] | None = None,
     ) -> None:
         self.client = client
@@ -45,6 +47,7 @@ class Entry:
         self.visibility = visibility
         self.organisation = organisation
         self.state = state
+        self.tags = tags
         self.collaborators = collaborators
 
         self._card = None
@@ -61,6 +64,7 @@ class Entry:
             visibility=self.visibility,
             organisation=self.organisation,
             state=self.state,
+            tags=self.tags,
             collaborators=self.collaborators,
         )
         self._unpack(res["model"])

--- a/lib/python/src/bailo/helper/mirroredModel.py
+++ b/lib/python/src/bailo/helper/mirroredModel.py
@@ -25,6 +25,7 @@ class MirroredModel(Entry):
     :param sourceModelId: Used for linking a mirrored model to its source model
     :param organisation: Organisation responsible for the mirrored model, defaults to None
     :param state: Development readiness of the mirrored model, defaults to None
+    :param tags: Tags to assign to the mirrored model, defaults to None
     :param collaborators: list of CollaboratorEntry to define who the mirrored model's collaborators (a.k.a. mirrored model access) are, defaults to None
     :param visibility: Visibility of the mirrored model, using ModelVisibility enum (e.g Public or Private), defaults to None
     """
@@ -38,6 +39,7 @@ class MirroredModel(Entry):
         sourceModelId: str,
         organisation: str | None = None,
         state: str | None = None,
+        tags: list[str] | None = None,
         collaborators: list[CollaboratorEntry] | None = None,
         visibility: ModelVisibility | None = None,
     ) -> None:
@@ -50,6 +52,7 @@ class MirroredModel(Entry):
             visibility=visibility,
             organisation=organisation,
             state=state,
+            tags=tags,
             collaborators=collaborators,
         )
         self.sourceModelId = sourceModelId
@@ -64,8 +67,9 @@ class MirroredModel(Entry):
         sourceModelId: str,
         organisation: str | None = None,
         state: str | None = None,
+        tags: list[str] | None = None,
         collaborators: list[CollaboratorEntry] | None = None,
-        visibility: ModelVisibility | None = None
+        visibility: ModelVisibility | None = None,
     ) -> MirroredModel:
         """Build a mirrored model from Bailo and upload it.
 
@@ -75,6 +79,7 @@ class MirroredModel(Entry):
         :param sourceModelId: Used for linking a mirrored model to its source model
         :param organisation: Organisation responsible for the mirrored model, defaults to None
         :param state: Development readiness of the mirrored model, defaults to None
+        :param tags: Tags to assign to the mirrored model, defaults to None
         :param collaborators: list of CollaboratorEntry to define who the mirrored model's collaborators (a.k.a. model access) are, defaults to None
         :param visibility: Visibility of the mirrored model, using ModelVisibility enum (e.g Public or Private), defaults to None
         :return: Model object
@@ -87,6 +92,7 @@ class MirroredModel(Entry):
             visibility=visibility,
             organisation=organisation,
             state=state,
+            tags=tags,
             collaborators=collaborators,
         )
         model_id = res["model"]["id"]
@@ -101,6 +107,7 @@ class MirroredModel(Entry):
             visibility=visibility,
             organisation=organisation,
             state=state,
+            tags=tags,
             collaborators=collaborators,
         )
 
@@ -118,7 +125,9 @@ class MirroredModel(Entry):
         """
         res = client.get_model(model_id=model_id)["model"]
         if res["kind"] != EntryKind.MIRRORED_MODEL:
-            raise BailoException(f"ID {model_id} does not belong to a mirrored model. Did you mean to use MirroredModel.from_id()?")
+            raise BailoException(
+                f"ID {model_id} does not belong to a mirrored model. Did you mean to use MirroredModel.from_id()?"
+            )
 
         logger.info("Model %s successfully retrieved from server.", model_id)
 
@@ -131,6 +140,7 @@ class MirroredModel(Entry):
             collaborators=res["collaborators"],
             organisation=res.get("organisation"),
             state=res.get("state"),
+            tags=res.get("tags"),
         )
 
         model._unpack(res)
@@ -170,6 +180,7 @@ class MirroredModel(Entry):
                 collaborators=model["collaborators"],
                 organisation=model.get("organisation"),
                 state=model.get("state"),
+                tags=model.get("tags"),
             )
             model_obj._unpack(res_model)
             model_obj.get_card_latest()

--- a/lib/python/src/bailo/helper/model.py
+++ b/lib/python/src/bailo/helper/model.py
@@ -37,6 +37,7 @@ class Model(Entry):
     :param description: Description of model
     :param organisation: Organisation responsible for the model, defaults to None
     :param state: Development readiness of the model, defaults to None
+    :param tags: Tags to assign to the model, defaults to None
     :param collaborators: list of CollaboratorEntry to define who the model's collaborators (a.k.a. model access) are, defaults to None
     :param visibility: Visibility of model, using ModelVisibility enum (e.g Public or Private), defaults to None
     """
@@ -49,6 +50,7 @@ class Model(Entry):
         description: str,
         organisation: str | None = None,
         state: str | None = None,
+        tags: list[str] | None = None,
         collaborators: list[CollaboratorEntry] | None = None,
         visibility: ModelVisibility | None = None,
     ) -> None:
@@ -61,6 +63,7 @@ class Model(Entry):
             visibility=visibility,
             organisation=organisation,
             state=state,
+            tags=tags,
             collaborators=collaborators,
         )
 
@@ -74,6 +77,7 @@ class Model(Entry):
         description: str,
         organisation: str | None = None,
         state: str | None = None,
+        tags: list[str] | None = None,
         collaborators: list[CollaboratorEntry] | None = None,
         visibility: ModelVisibility | None = None,
     ) -> Model:
@@ -84,6 +88,7 @@ class Model(Entry):
         :param description: Description of model
         :param organisation: Organisation responsible for the model, defaults to None
         :param state: Development readiness of the model, defaults to None
+        :param tags: Tags to assign to the model, defaults to None
         :param collaborators: list of CollaboratorEntry to define who the model's collaborators (a.k.a. model access) are, defaults to None
         :param visibility: Visibility of model, using ModelVisibility enum (e.g Public or Private), defaults to None
         :return: Model object
@@ -108,6 +113,7 @@ class Model(Entry):
             visibility=visibility,
             organisation=organisation,
             state=state,
+            tags=tags,
             collaborators=collaborators,
         )
 
@@ -137,6 +143,7 @@ class Model(Entry):
             collaborators=res["collaborators"],
             organisation=res.get("organisation"),
             state=res.get("state"),
+            tags=res.get("tags"),
         )
 
         model._unpack(res)
@@ -175,6 +182,7 @@ class Model(Entry):
                 collaborators=model["collaborators"],
                 organisation=model.get("organisation"),
                 state=model.get("state"),
+                tags=res.get("tags"),
             )
             model_obj._unpack(res_model)
             model_obj.get_card_latest()
@@ -194,6 +202,7 @@ class Model(Entry):
         visibility: ModelVisibility | None = None,
         organisation: str | None = None,
         state: str | None = None,
+        tags: list[str] | None = None,
         collaborators: list[CollaboratorEntry] | None = None,
     ) -> Model:
         """Import an MLFlow Model into Bailo.
@@ -207,6 +216,7 @@ class Model(Entry):
         :param visibility: Visibility of model on Bailo, using ModelVisibility enum (e.g Public or Private), defaults to None
         :param organisation: Organisation responsible for the model, defaults to None
         :param state: Development readiness of the model, defaults to None
+        :param tags: Tags to assign to the model, defaults to None
         :param collaborators: list of CollaboratorEntry to define who the model's collaborators (a.k.a. model access) are, defaults to None
         :return: A model object
         """
@@ -241,6 +251,7 @@ class Model(Entry):
             visibility=visibility,
             organisation=organisation,
             state=state,
+            tags=tags,
             collaborators=collaborators,
         )
         model_id = bailo_res["model"]["id"]
@@ -254,6 +265,7 @@ class Model(Entry):
             visibility=visibility,
             organisation=organisation,
             state=state,
+            tags=tags,
             collaborators=collaborators,
         )
         model._unpack(bailo_res["model"])

--- a/lib/python/tests/test_client.py
+++ b/lib/python/tests/test_client.py
@@ -7,7 +7,7 @@ import pytest
 # isort: split
 
 from bailo import Client, ModelVisibility, SchemaKind
-from bailo.core.enums import EntryKind
+from bailo.core.enums import CollaboratorEntry, EntryKind, Role
 from bailo.core.exceptions import BailoException, ResponseException
 
 mock_result = {"success": True}
@@ -42,6 +42,8 @@ def test_post_model(requests_mock):
         visibility=ModelVisibility.PUBLIC,
         organisation="Example Organisation",
         state="Development",
+        tags=["taga", "tagb"],
+        collaborators=[CollaboratorEntry("user:user", [Role.OWNER])],
     )
 
     assert result == {"success": True}
@@ -81,6 +83,7 @@ def test_patch_model(requests_mock):
         name="test",
         organisation="Example Organisation",
         state="Development",
+        tags=["taga", "tagb", "tagc"],
     )
 
     assert result == {"success": True}

--- a/lib/python/tests/test_datacard.py
+++ b/lib/python/tests/test_datacard.py
@@ -15,15 +15,16 @@ def test_datacard(local_datacard):
 
 @pytest.mark.integration
 @pytest.mark.parametrize(
-    ("name", "description", "organisation", "state", "visibility", "collaborators"),
+    ("name", "description", "organisation", "state", "tags", "visibility", "collaborators"),
     [
-        ("test-datacard", "test", None, None, ModelVisibility.PUBLIC, None),
-        ("test-datacard", "test", None, None, None, [CollaboratorEntry("user:user", ["owner", "contributor"])]),
+        ("test-datacard", "test", None, None, None, ModelVisibility.PUBLIC, None),
+        ("test-datacard", "test", None, None, None, None, [CollaboratorEntry("user:user", ["owner", "contributor"])]),
         (
             "test-datacard",
             "test",
             "Example Organisation",
             "Development",
+            ["taga", "tagb"],
             None,
             [CollaboratorEntry("user:user", [Role.OWNER])],
         ),
@@ -35,6 +36,7 @@ def test_create_get_from_id_and_update(
     visibility: ModelVisibility | None,
     organisation: str | None,
     state: str | None,
+    tags: list[str] | None,
     collaborators: list[CollaboratorEntry] | None,
     integration_client: Client,
 ):
@@ -46,6 +48,7 @@ def test_create_get_from_id_and_update(
         visibility=visibility,
         organisation=organisation,
         state=state,
+        tags=tags,
         collaborators=collaborators,
     )
     datacard.card_from_schema("minimal-data-card-v10")

--- a/lib/python/tests/test_mirrored_model.py
+++ b/lib/python/tests/test_mirrored_model.py
@@ -5,7 +5,7 @@ from bailo.core.enums import CollaboratorEntry, MinimalSchema, Role
 
 # isort: split
 
-from bailo import Client, Datacard, Experiment, MirroredModel, MirroredModel, ModelVisibility
+from bailo import Client, Datacard, Experiment, MirroredModel, ModelVisibility
 from bailo.core.exceptions import BailoException
 from bailo.core.utils import NestedDict
 
@@ -13,18 +13,29 @@ from bailo.core.utils import NestedDict
 def test_mirrored_model(local_mirrored_model):
     assert isinstance(local_mirrored_model, MirroredModel)
 
+
 @pytest.mark.integration
 @pytest.mark.parametrize(
-    ("name", "description", "sourceModelId", "organisation", "state", "visibility", "collaborators"),
+    ("name", "description", "sourceModelId", "organisation", "state", "tags", "visibility", "collaborators"),
     [
-        ("test-mirrored-model", "test", "test-1234", None, None, ModelVisibility.PUBLIC, None),
-        ("test-mirrored-model", "test", "test-1234", None, None, None, [CollaboratorEntry("user:user", ["owner", "contributor"])]),
+        ("test-mirrored-model", "test", "test-1234", None, None, None, ModelVisibility.PUBLIC, None),
+        (
+            "test-mirrored-model",
+            "test",
+            "test-1234",
+            None,
+            None,
+            None,
+            None,
+            [CollaboratorEntry("user:user", ["owner", "contributor"])],
+        ),
         (
             "test-mirrored-model",
             "test",
             "test-1234",
             "Example Organisation",
             "Development",
+            ["taga", "tagb"],
             None,
             [CollaboratorEntry("user:user", [Role.OWNER])],
         ),
@@ -37,6 +48,7 @@ def test_create_get_from_id_and_update(
     visibility: ModelVisibility | None,
     organisation: str | None,
     state: str | None,
+    tags: list[str] | None,
     collaborators: list[CollaboratorEntry] | None,
     integration_client: Client,
 ):
@@ -49,6 +61,7 @@ def test_create_get_from_id_and_update(
         visibility=visibility,
         organisation=organisation,
         state=state,
+        tags=tags,
         collaborators=collaborators,
     )
     assert isinstance(mirroredModel, MirroredModel)
@@ -85,4 +98,3 @@ def test_get_releases(integration_client):
 
     with pytest.raises(BailoException):
         model.get_latest_release()
-

--- a/lib/python/tests/test_model.py
+++ b/lib/python/tests/test_model.py
@@ -22,15 +22,16 @@ def test_create_experiment_from_model(local_model):
 
 @pytest.mark.integration
 @pytest.mark.parametrize(
-    ("name", "description", "organisation", "state", "visibility", "collaborators"),
+    ("name", "description", "organisation", "state", "tags", "visibility", "collaborators"),
     [
-        ("test-model", "test", None, None, ModelVisibility.PUBLIC, None),
-        ("test-model", "test", None, None, None, [CollaboratorEntry("user:user", ["owner", "contributor"])]),
+        ("test-model", "test", None, None, None, ModelVisibility.PUBLIC, None),
+        ("test-model", "test", None, None, None, None, [CollaboratorEntry("user:user", ["owner", "contributor"])]),
         (
             "test-model",
             "test",
             "Example Organisation",
             "Development",
+            ["taga", "tagb"],
             None,
             [CollaboratorEntry("user:user", [Role.OWNER])],
         ),
@@ -42,6 +43,7 @@ def test_create_get_from_id_and_update(
     visibility: ModelVisibility | None,
     organisation: str | None,
     state: str | None,
+    tags: list[str] | None,
     collaborators: list[CollaboratorEntry] | None,
     integration_client: Client,
 ):
@@ -53,6 +55,7 @@ def test_create_get_from_id_and_update(
         visibility=visibility,
         organisation=organisation,
         state=state,
+        tags=tags,
         collaborators=collaborators,
     )
     model.card_from_schema("minimal-general-v10")


### PR DESCRIPTION
The backend no longer stores tags in the model card, so the Python client requires the Entry's `tags` be exposed via the classes.