### PR TITLE
Fix mailcrab being inaccessible to backend

### DIFF
--- a/compose.override.yaml
+++ b/compose.override.yaml
@@ -13,6 +13,7 @@ services:
   mailcrab:
     networks:
       default:
+      internal:
     ports:
       - 1080:1080
       - 1025:1025


### PR DESCRIPTION
mailcrab was exposed on the default network (so the user could see the UI) but not on 'internal', so the backend couldn't resolve/connect to it.