### PR TITLE
Improve `tarball.ts` errors & logs

### DIFF
--- a/backend/src/services/mirroredModel/tarball.ts
+++ b/backend/src/services/mirroredModel/tarball.ts
@@ -112,8 +112,6 @@ export async function extractTarGzStream(
     let importer: BaseImporter
     const { ungzipStream, untarStream } = createUnTarGzStreams()
 
-    tarGzStream.pipe(ungzipStream).pipe(untarStream)
-
     // this error event is expected to always call `reject`
     async function onErrorHandler(error: unknown) {
       if (importer?.errorListener) {
@@ -126,6 +124,12 @@ export async function extractTarGzStream(
         }
       }
     }
+
+    ungzipStream.on('error', async (error) => {
+      log.error({ error, ...logData }, 'Error occurred in `zlib.Gunzip` stream. Aborting extraction.')
+      // Pass the error into the untarStream to trigger the error listener
+      untarStream.destroy(error)
+    })
 
     untarStream.on('error', async (error) => {
       await onErrorHandler(error)
@@ -184,5 +188,7 @@ export async function extractTarGzStream(
         await onErrorHandler(error)
       }
     })
+
+    tarGzStream.pipe(ungzipStream).pipe(untarStream)
   })
 }


### PR DESCRIPTION
Improves trace logs and also propagates errors from the gzip stream to the tar stream.