### PR TITLE
Duplicate scans stuck as 'inProgress'

### DIFF
--- a/backend/src/models/Scan.ts
+++ b/backend/src/models/Scan.ts
@@ -83,12 +83,12 @@ const ScanSchema = new Schema<ScanInterfaceDoc>(
 ScanSchema.plugin(softDeletionPlugin)
 // Image index
 ScanSchema.index(
-  { artefactKind: 1, layerDigest: 1, toolName: 1, state: 1 },
+  { artefactKind: 1, layerDigest: 1, toolName: 1 },
   { unique: true, partialFilterExpression: { artefactKind: 'image', state: 'InProgress' } },
 )
 // File index
 ScanSchema.index(
-  { artefactKind: 1, fileId: 1, toolName: 1, state: 1 },
+  { artefactKind: 1, fileId: 1, toolName: 1 },
   { unique: true, partialFilterExpression: { artefactKind: 'file', state: 'InProgress' } },
 )
 

--- a/backend/src/scripts/removeDuplicateScans.ts
+++ b/backend/src/scripts/removeDuplicateScans.ts
@@ -1,0 +1,51 @@
+import ScanModel from '../models/Scan.js'
+import log from '../services/log.js'
+import { connectToMongoose, disconnectFromMongoose } from '../utils/database.js'
+
+const STATE_PRIORITY: Record<string, number> = {
+  complete: 0,
+  error: 1,
+  inProgress: 2,
+  notScanned: 3,
+}
+
+async function script() {
+  await connectToMongoose()
+
+  const duplicates = await ScanModel.aggregate([
+    { $match: { artefactKind: 'image', layerDigest: { $exists: true, $ne: null } } },
+    {
+      $group: {
+        _id: { layerDigest: '$layerDigest', toolName: '$toolName' },
+        ids: { $push: '$_id' },
+        count: { $sum: 1 },
+      },
+    },
+    { $match: { count: { $gt: 1 } } },
+  ])
+
+  for (const dup of duplicates) {
+    const scans = await ScanModel.find({ _id: { $in: dup.ids } })
+
+    scans.sort((a, b) => {
+      const pA = STATE_PRIORITY[a.state] ?? 99
+      const pB = STATE_PRIORITY[b.state] ?? 99
+      if (pA !== pB) {
+        return pA - pB
+      }
+      return new Date(b.updatedAt).getTime() - new Date(a.updatedAt).getTime()
+    })
+
+    const keep = scans[0]
+    const remove = scans.slice(1).map((s) => s._id)
+
+    if (remove.length > 0) {
+      await ScanModel.deleteMany({ _id: { $in: remove } })
+      log.debug(`layerDigest=${dup._id.layerDigest} tool=${dup._id.toolName} kept=${keep._id} removed=${remove.length}`)
+    }
+  }
+
+  setTimeout(disconnectFromMongoose, 50)
+}
+
+script()

--- a/backend/src/scripts/removeDuplicateScans.ts
+++ b/backend/src/scripts/removeDuplicateScans.ts
@@ -1,12 +1,13 @@
+import { ArtefactScanState, ArtefactScanStateKeys } from '../connectors/artefactScanning/Base.js'
 import ScanModel from '../models/Scan.js'
 import log from '../services/log.js'
 import { connectToMongoose, disconnectFromMongoose } from '../utils/database.js'
 
-const STATE_PRIORITY: Record<string, number> = {
-  complete: 0,
-  error: 1,
-  inProgress: 2,
-  notScanned: 3,
+const STATE_PRIORITY: Record<ArtefactScanStateKeys, number> = {
+  [ArtefactScanState.Complete]: 0,
+  [ArtefactScanState.Error]: 1,
+  [ArtefactScanState.InProgress]: 2,
+  [ArtefactScanState.NotScanned]: 3,
 }
 
 async function script() {
@@ -41,7 +42,16 @@ async function script() {
 
     if (remove.length > 0) {
       await ScanModel.deleteMany({ _id: { $in: remove } })
-      log.debug(`layerDigest=${dup._id.layerDigest} tool=${dup._id.toolName} kept=${keep._id} removed=${remove.length}`)
+      log.info(
+        {
+          layerDigest: dup._id.layerDigest,
+          toolName: dup._id.toolName,
+          kept: keep._id,
+          removed: remove.length,
+          removedIds: remove,
+        },
+        'Removed duplicate scans',
+      )
     }
   }
 

--- a/backend/src/services/scan.ts
+++ b/backend/src/services/scan.ts
@@ -51,8 +51,10 @@ export async function updateArtefactScanWithResults(
           toolName: result.toolName,
           ...(isInProgress
             ? {
-                state: ArtefactScanState.InProgress,
-                lastRunAt: { $lt: new Date(Date.now() - 30 * 60 * 1000) }, // age off old results (in case of crash or SIGKILL)
+                $or: [
+                  { state: { $ne: ArtefactScanState.InProgress } },
+                  { lastRunAt: { $lt: new Date(Date.now() - 30 * 60 * 1000) } }, // age off old results (in case of crash or SIGKILL)
+                ],
               }
             : {}),
         },

--- a/backend/src/services/scan.ts
+++ b/backend/src/services/scan.ts
@@ -15,7 +15,7 @@ import { ImageRef } from '../models/Release.js'
 import ScanModel, { ArtefactKind, ArtefactKindKeys } from '../models/Scan.js'
 import { UserInterface } from '../models/User.js'
 import { issueAccessToken } from '../routes/v1/registryAuth.js'
-import { dedupe } from '../utils/array.js'
+import { dedupeByKey } from '../utils/array.js'
 import config from '../utils/config.js'
 import { BadReq, Conflict, Forbidden, InternalError, NotFound } from '../utils/error.js'
 import { plural } from '../utils/string.js'
@@ -35,7 +35,7 @@ type ArtefactScanIdentifier =
       layerDigest: string
     }
 
-async function updateArtefactScanWithResults(
+export async function updateArtefactScanWithResults(
   scanIdentifier: ArtefactScanIdentifier,
   results: ArtefactScanResult[],
   session?: ClientSession,
@@ -51,10 +51,8 @@ async function updateArtefactScanWithResults(
           toolName: result.toolName,
           ...(isInProgress
             ? {
-                $or: [
-                  { state: { $ne: ArtefactScanState.InProgress } },
-                  { lastRunAt: { $lt: new Date(Date.now() - 30 * 60 * 1000) } }, // age off old results (in case of crash or SIGKILL)
-                ],
+                state: ArtefactScanState.InProgress,
+                lastRunAt: { $lt: new Date(Date.now() - 30 * 60 * 1000) }, // age off old results (in case of crash or SIGKILL)
               }
             : {}),
         },
@@ -229,7 +227,7 @@ export async function rerunImageScanNoAuth(image: ImageRef, repositoryToken: str
     // TODO: add support for manifest lists/fat manifests
     throw InternalError('Bailo backend does not currently support scanning images with manifest lists.', { image })
   }
-  const imageLayers = dedupe(await getImageLayers(repositoryToken, image))
+  const imageLayers = dedupeByKey(await getImageLayers(repositoryToken, image), (d) => d.digest)
   const imageName = `${image.repository}/${image.name}${'tag' in image ? ':' + image.tag : '@' + image.digest}`
 
   // Only check timing for the config (which is effectively unique per manifest)

--- a/backend/src/utils/array.ts
+++ b/backend/src/utils/array.ts
@@ -11,16 +11,17 @@ export function findDuplicates<T>(arr: Array<T>): Array<T> {
 }
 
 /**
- * Deduplicate an array while preserving order.
+ * Deduplicate an array while preserving order, using a custom key function.
  * Uses SameValueZero equality (as per Set).
  */
-export function dedupe<T>(input: readonly T[]): T[] {
-  const seen = new Set<T>()
+export function dedupeByKey<T, K>(input: readonly T[], keyFn: (item: T) => K = (item) => item as unknown as K): T[] {
+  const seen = new Set<K>()
   const result: T[] = []
 
   for (const item of input) {
-    if (!seen.has(item)) {
-      seen.add(item)
+    const key = keyFn(item)
+    if (!seen.has(key)) {
+      seen.add(key)
       result.push(item)
     }
   }

--- a/backend/test/services/scan.spec.ts
+++ b/backend/test/services/scan.spec.ts
@@ -412,11 +412,12 @@ describe('services > scan', () => {
   })
 
   describe('updateArtefactScanWithResults', () => {
-    test('create only one inProgress scan for concurrent attempts', async () => {
+    test('creates only one InProgress scan when called concurrently', async () => {
       const scanIdentifier = {
         artefactKind: ArtefactKind.IMAGE,
         layerDigest: 'sha256:test-layer',
       }
+
       const result: ArtefactScanResult = {
         toolName: 'Trivy',
         scannerVersion: '1',
@@ -424,8 +425,11 @@ describe('services > scan', () => {
         state: ArtefactScanState.InProgress,
         lastRunAt: new Date(),
       }
-      ScanModelMock.bulkWrite.mockResolvedValue(undefined)
-      const attempts = 20
+
+      // First call succeeds, subsequent calls simulate duplicate key error
+      ScanModelMock.bulkWrite.mockResolvedValueOnce(undefined).mockRejectedValue({ code: 11000 })
+
+      const attempts = 5
 
       await Promise.all(
         Array.from({ length: attempts }).map(() =>
@@ -433,21 +437,10 @@ describe('services > scan', () => {
         ),
       )
 
-      const bulkOps = ScanModelMock.bulkWrite.mock.calls.flatMap((call) => call[0])
-      const inProgressOps: any[] = bulkOps.filter(
-        (op: any) => op.updateOne?.update?.$set?.state === ArtefactScanState.InProgress,
-      )
-      expect(inProgressOps.length).toBeGreaterThan(0)
-      for (const op of inProgressOps) {
-        expect(op.updateOne.filter).toMatchObject({
-          ...scanIdentifier,
-          toolName: 'Trivy',
-          state: ArtefactScanState.InProgress,
-        })
-      }
+      expect(ScanModelMock.bulkWrite).toHaveBeenCalled()
     })
 
-    test('update stale inProgress scan instead of inserting a new one', async () => {
+    test('updates existing non-InProgress scan instead of inserting new one', async () => {
       const scanIdentifier = {
         artefactKind: ArtefactKind.IMAGE,
         layerDigest: 'sha256:test-layer',
@@ -463,21 +456,16 @@ describe('services > scan', () => {
 
       await updateArtefactScanWithResults(scanIdentifier, [result])
 
-      const bulkOps = ScanModelMock.bulkWrite.mock.calls.flatMap((call) => call[0])
-      const op = bulkOps.find((o: any) => o.updateOne?.update?.$set?.state === ArtefactScanState.InProgress)
-      expect(op).toMatchObject({
-        updateOne: {
-          filter: expect.objectContaining({
-            ...scanIdentifier,
-            toolName: 'Trivy',
-            state: ArtefactScanState.InProgress,
-          }),
-          upsert: true,
-        },
+      const bulkOps = ScanModelMock.bulkWrite.mock.calls.flatMap((c) => c[0])
+      const op: any = bulkOps[0]
+      expect(op.updateOne.filter).toMatchObject({
+        ...scanIdentifier,
+        toolName: 'Trivy',
       })
+      expect(op.updateOne.upsert).toBe(true)
     })
 
-    test('creating inProgress does not match complete scan documents', async () => {
+    test('reuses stale InProgress scan', async () => {
       const scanIdentifier = {
         artefactKind: ArtefactKind.IMAGE,
         layerDigest: 'sha256:test-layer',
@@ -493,10 +481,54 @@ describe('services > scan', () => {
 
       await updateArtefactScanWithResults(scanIdentifier, [result])
 
-      const bulkOps = ScanModelMock.bulkWrite.mock.calls.flatMap((call) => call[0])
-      const op: any = bulkOps.find((o: any) => o.updateOne?.update?.$set?.state === ArtefactScanState.InProgress)
-      expect(op?.updateOne?.filter).not.toHaveProperty('$or')
-      expect(op?.updateOne?.filter?.state).toBe(ArtefactScanState.InProgress)
+      const bulkOps: any = ScanModelMock.bulkWrite.mock.calls.flatMap((c) => c[0])
+      const filter = bulkOps[0].updateOne.filter
+      expect(filter.$or).toBeDefined()
+      expect(filter.$or).toHaveLength(2)
+      expect(filter.$or[0]).toHaveProperty('state')
+      expect(filter.$or[1]).toHaveProperty('lastRunAt')
+    })
+
+    test('does not upsert when state is not InProgress', async () => {
+      const scanIdentifier = {
+        artefactKind: ArtefactKind.IMAGE,
+        layerDigest: 'sha256:test-layer',
+      }
+      const result: ArtefactScanResult = {
+        toolName: 'Trivy',
+        scannerVersion: '1',
+        artefactKind: ArtefactKind.IMAGE,
+        state: ArtefactScanState.Complete,
+        lastRunAt: new Date(),
+      }
+      ScanModelMock.bulkWrite.mockResolvedValue(undefined)
+
+      await updateArtefactScanWithResults(scanIdentifier, [result])
+
+      const bulkOps = ScanModelMock.bulkWrite.mock.calls.flatMap((c) => c[0])
+      const op: any = bulkOps[0]
+      expect(op.updateOne.upsert).toBe(false)
+      expect(op.updateOne.filter).not.toHaveProperty('$or')
+    })
+
+    test('sets result fields in update payload', async () => {
+      const scanIdentifier = {
+        artefactKind: ArtefactKind.IMAGE,
+        layerDigest: 'sha256:test-layer',
+      }
+      const result: ArtefactScanResult = {
+        toolName: 'Trivy',
+        scannerVersion: '1.2.3',
+        artefactKind: ArtefactKind.IMAGE,
+        state: ArtefactScanState.InProgress,
+        lastRunAt: new Date(),
+      }
+      ScanModelMock.bulkWrite.mockResolvedValue(undefined)
+
+      await updateArtefactScanWithResults(scanIdentifier, [result])
+      const bulkOps: any = ScanModelMock.bulkWrite.mock.calls.flatMap((c) => c[0])
+      const update = bulkOps[0].updateOne.update
+      expect(update.$set).toMatchObject(result)
     })
   })
 })

--- a/backend/test/services/scan.spec.ts
+++ b/backend/test/services/scan.spec.ts
@@ -2,7 +2,13 @@ import { describe, expect, test, vi } from 'vitest'
 
 import { ArtefactScanResult, ArtefactScanState } from '../../src/connectors/artefactScanning/Base.js'
 import { ArtefactKind } from '../../src/models/Scan.js'
-import { rerunFileScan, rerunImageScan, rerunImageScanNoAuth, scanFile } from '../../src/services/scan.js'
+import {
+  rerunFileScan,
+  rerunImageScan,
+  rerunImageScanNoAuth,
+  scanFile,
+  updateArtefactScanWithResults,
+} from '../../src/services/scan.js'
 import { getTypedModelMock } from '../testUtils/setupMongooseModelMocks.js'
 
 vi.mock('../../src/connectors/artefactScanning/index.js')
@@ -402,6 +408,95 @@ describe('services > scan', () => {
       expect(authMocks.default.image).not.toHaveBeenCalled()
       expect(authMocks.default.model).not.toHaveBeenCalled()
       expect(registryAuthMocks.issueAccessToken).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('updateArtefactScanWithResults', () => {
+    test('create only one inProgress scan for concurrent attempts', async () => {
+      const scanIdentifier = {
+        artefactKind: ArtefactKind.IMAGE,
+        layerDigest: 'sha256:test-layer',
+      }
+      const result: ArtefactScanResult = {
+        toolName: 'Trivy',
+        scannerVersion: '1',
+        artefactKind: ArtefactKind.IMAGE,
+        state: ArtefactScanState.InProgress,
+        lastRunAt: new Date(),
+      }
+      ScanModelMock.bulkWrite.mockResolvedValue(undefined)
+      const attempts = 20
+
+      await Promise.all(
+        Array.from({ length: attempts }).map(() =>
+          updateArtefactScanWithResults(scanIdentifier, [result]).catch(() => undefined),
+        ),
+      )
+
+      const bulkOps = ScanModelMock.bulkWrite.mock.calls.flatMap((call) => call[0])
+      const inProgressOps: any[] = bulkOps.filter(
+        (op: any) => op.updateOne?.update?.$set?.state === ArtefactScanState.InProgress,
+      )
+      expect(inProgressOps.length).toBeGreaterThan(0)
+      for (const op of inProgressOps) {
+        expect(op.updateOne.filter).toMatchObject({
+          ...scanIdentifier,
+          toolName: 'Trivy',
+          state: ArtefactScanState.InProgress,
+        })
+      }
+    })
+
+    test('update stale inProgress scan instead of inserting a new one', async () => {
+      const scanIdentifier = {
+        artefactKind: ArtefactKind.IMAGE,
+        layerDigest: 'sha256:test-layer',
+      }
+      const result: ArtefactScanResult = {
+        toolName: 'Trivy',
+        scannerVersion: '1',
+        artefactKind: ArtefactKind.IMAGE,
+        state: ArtefactScanState.InProgress,
+        lastRunAt: new Date(),
+      }
+      ScanModelMock.bulkWrite.mockResolvedValue(undefined)
+
+      await updateArtefactScanWithResults(scanIdentifier, [result])
+
+      const bulkOps = ScanModelMock.bulkWrite.mock.calls.flatMap((call) => call[0])
+      const op = bulkOps.find((o: any) => o.updateOne?.update?.$set?.state === ArtefactScanState.InProgress)
+      expect(op).toMatchObject({
+        updateOne: {
+          filter: expect.objectContaining({
+            ...scanIdentifier,
+            toolName: 'Trivy',
+            state: ArtefactScanState.InProgress,
+          }),
+          upsert: true,
+        },
+      })
+    })
+
+    test('creating inProgress does not match complete scan documents', async () => {
+      const scanIdentifier = {
+        artefactKind: ArtefactKind.IMAGE,
+        layerDigest: 'sha256:test-layer',
+      }
+      const result: ArtefactScanResult = {
+        toolName: 'Trivy',
+        scannerVersion: '1',
+        artefactKind: ArtefactKind.IMAGE,
+        state: ArtefactScanState.InProgress,
+        lastRunAt: new Date(),
+      }
+      ScanModelMock.bulkWrite.mockResolvedValue(undefined)
+
+      await updateArtefactScanWithResults(scanIdentifier, [result])
+
+      const bulkOps = ScanModelMock.bulkWrite.mock.calls.flatMap((call) => call[0])
+      const op: any = bulkOps.find((o: any) => o.updateOne?.update?.$set?.state === ArtefactScanState.InProgress)
+      expect(op?.updateOne?.filter).not.toHaveProperty('$or')
+      expect(op?.updateOne?.filter?.state).toBe(ArtefactScanState.InProgress)
     })
   })
 })

--- a/backend/test/services/scan.spec.ts
+++ b/backend/test/services/scan.spec.ts
@@ -417,7 +417,6 @@ describe('services > scan', () => {
         artefactKind: ArtefactKind.IMAGE,
         layerDigest: 'sha256:test-layer',
       }
-
       const result: ArtefactScanResult = {
         toolName: 'Trivy',
         scannerVersion: '1',
@@ -425,10 +424,8 @@ describe('services > scan', () => {
         state: ArtefactScanState.InProgress,
         lastRunAt: new Date(),
       }
-
       // First call succeeds, subsequent calls simulate duplicate key error
       ScanModelMock.bulkWrite.mockResolvedValueOnce(undefined).mockRejectedValue({ code: 11000 })
-
       const attempts = 5
 
       await Promise.all(

--- a/backend/test/utils/array.spec.ts
+++ b/backend/test/utils/array.spec.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from 'vitest'
 
-import { asyncFilter, dedupe, findDuplicates } from '../../src/utils/array.js'
+import { asyncFilter, dedupeByKey, findDuplicates } from '../../src/utils/array.js'
 
 describe('utils > array', () => {
   test('asyncFilter', async () => {
@@ -15,11 +15,34 @@ describe('utils > array', () => {
     expect(findDuplicates([1, 1, 1])).toStrictEqual([1, 1])
   })
 
-  test('dedupe', () => {
-    expect(dedupe([1, 2, 3, 4])).toStrictEqual([1, 2, 3, 4])
-    expect(dedupe([1, 1, 2, 3])).toStrictEqual([1, 2, 3])
-    expect(dedupe([])).toStrictEqual([])
-    expect(dedupe([1, 1, 1])).toStrictEqual([1])
-    expect(dedupe([1, 2, 1])).toStrictEqual([1, 2])
+  test('dedupeByKey', () => {
+    expect(dedupeByKey([1, 2, 3, 4])).toStrictEqual([1, 2, 3, 4])
+    expect(dedupeByKey([1, 1, 2, 3])).toStrictEqual([1, 2, 3])
+    expect(dedupeByKey([])).toStrictEqual([])
+    expect(dedupeByKey([1, 1, 1])).toStrictEqual([1])
+    expect(dedupeByKey([1, 2, 1])).toStrictEqual([1, 2])
+
+    expect(dedupeByKey([{ a: 1 }, { a: 2 }, { a: 1 }, { a: 3 }], (i) => i.a)).toStrictEqual([
+      { a: 1 },
+      { a: 2 },
+      { a: 3 },
+    ])
+    const o1 = { a: 1 }
+    const o2 = { a: 1 }
+    expect(dedupeByKey([o1, o2, o1])).toStrictEqual([o1, o2])
+    expect(
+      dedupeByKey(
+        [
+          { id: 'a', v: 1 },
+          { id: 'b', v: 2 },
+          { id: 'a', v: 3 },
+        ],
+        (i) => i.id,
+      ),
+    ).toStrictEqual([
+      { id: 'a', v: 1 },
+      { id: 'b', v: 2 },
+    ])
+    expect(dedupeByKey(['aa', 'b', 'cc', 'd'], (s) => s.length)).toStrictEqual(['aa', 'b'])
   })
 })

--- a/frontend/src/entry/model/registry/ModelImageTagDisplay.tsx
+++ b/frontend/src/entry/model/registry/ModelImageTagDisplay.tsx
@@ -53,7 +53,7 @@ export default function ModelImageTagDisplay({ modelImage, tag, mutate }: ModelI
         <VulnerabilityResult
           results={tagResults}
           warningOnly
-          detailedViewUrl={`/model/${modelImage.repository}/registry/${modelImage.name}/${imageTag}`}
+          detailedViewUrl={`/model/${modelImage.repository}/registry/${encodeURIComponent(modelImage.name)}/${imageTag}`}
         />
       )
     }


### PR DESCRIPTION
- Fixes `dedupe` function on image layers.
- Provides a script to remove duplicate mongo image scan documents.
- Correctly resolves image names when linking to details page.