### PR TITLE
Fix misquoted stroom config & add missing Audit

### DIFF
--- a/backend/src/routes/v2/artefactScanning/getArtefactScanningInfo.ts
+++ b/backend/src/routes/v2/artefactScanning/getArtefactScanningInfo.ts
@@ -2,6 +2,7 @@ import { Request, Response } from 'express'
 
 import { ArtefactScanningConnectorInfo } from '../../../connectors/artefactScanning/Base.js'
 import scanners from '../../../connectors/artefactScanning/index.js'
+import { AuditInfo } from '../../../connectors/audit/Base.js'
 import audit from '../../../connectors/audit/index.js'
 import { z } from '../../../lib/zod.js'
 import { artefactScanningConnectorInfo, registerPath } from '../../../services/specification.js'
@@ -33,6 +34,7 @@ interface GetArtefactScanningInfoResponse {
 
 export const getArtefactScanningInfo = [
   async (req: Request, res: Response<GetArtefactScanningInfoResponse>): Promise<void> => {
+    req.audit = AuditInfo.ViewScanners
     const _ = parse(req, getArtefactScanningInfoSchema)
 
     const scannersInfo = scanners.scannersInfo()

--- a/frontend/src/entry/model/files/FileDisplay.tsx
+++ b/frontend/src/entry/model/files/FileDisplay.tsx
@@ -238,7 +238,7 @@ export default function FileDisplay({
     return (
       scanners &&
       !isScannersError &&
-      scanners.length > 0 && (
+      scanners.some((scanner) => scanner.artefactKind === ArtefactKind.FILE) && (
         <MenuItem hidden={!showMenuItems.rescanFile} onClick={handleRerunFileScanOnClick}>
           <ListItemIcon>
             <Refresh color='primary' fontSize='small' />

--- a/frontend/src/entry/model/files/FileDisplay.tsx
+++ b/frontend/src/entry/model/files/FileDisplay.tsx
@@ -39,7 +39,6 @@ import AssociatedReleasesDialog from 'src/entry/model/releases/AssociatedRelease
 import AssociatedReleasesList from 'src/entry/model/releases/AssociatedReleasesList'
 import EntryTagSelector from 'src/entry/model/releases/EntryTagSelector'
 import useNotification from 'src/hooks/useNotification'
-import MessageAlert from 'src/MessageAlert'
 import { KeyedMutator } from 'swr'
 import {
   ArtefactKind,
@@ -238,6 +237,7 @@ export default function FileDisplay({
   const rerunFileScanButton = useMemo(() => {
     return (
       scanners &&
+      !isScannersError &&
       scanners.length > 0 && (
         <MenuItem hidden={!showMenuItems.rescanFile} onClick={handleRerunFileScanOnClick}>
           <ListItemIcon>
@@ -247,7 +247,7 @@ export default function FileDisplay({
         </MenuItem>
       )
     )
-  }, [handleRerunFileScanOnClick, scanners, showMenuItems.rescanFile])
+  }, [handleRerunFileScanOnClick, scanners, isScannersError, showMenuItems.rescanFile])
 
   const scanResultChip = useMemo(() => {
     if (!chipDisplay) {
@@ -363,10 +363,6 @@ export default function FileDisplay({
 
   const showMenu = () => {
     return Object.keys(showMenuItems).length > 0 && Object.values(showMenuItems).some((item) => item === true)
-  }
-
-  if (isScannersError) {
-    return <MessageAlert message={isScannersError.info.message} severity='error' />
   }
 
   if (isScannersLoading) {

--- a/frontend/src/entry/model/registry/ModelImageTagDisplay.tsx
+++ b/frontend/src/entry/model/registry/ModelImageTagDisplay.tsx
@@ -63,9 +63,6 @@ export default function ModelImageTagDisplay({ modelImage, tag, mutate }: ModelI
     return <MessageAlert message={isUiConfigError.info.message} severity='error' />
   }
 
-  if (isScannersError) {
-    return <MessageAlert message={isScannersError.info.message} severity='error' />
-  }
   if (isUiConfigLoading || isScannersLoading) {
     return <Loading />
   }
@@ -80,7 +77,7 @@ export default function ModelImageTagDisplay({ modelImage, tag, mutate }: ModelI
             />
           </Box>
         </Stack>
-        {scanners && scanners.some((scanner) => scanner.artefactKind === ArtefactKind.IMAGE) && (
+        {scanners && !isScannersError && scanners.some((scanner) => scanner.artefactKind === ArtefactKind.IMAGE) && (
           <Stack direction='row' spacing={2} alignItems='center'>
             {reportDisplay(tag)}
             <IconButton

--- a/frontend/src/entry/model/releases/ReleaseAssetsAccordion.tsx
+++ b/frontend/src/entry/model/releases/ReleaseAssetsAccordion.tsx
@@ -7,7 +7,7 @@ import { useState } from 'react'
 import Paginate from 'src/common/Paginate'
 import FileDisplay from 'src/entry/model/files/FileDisplay'
 import CodeLine from 'src/entry/model/registry/CodeLine'
-import { EntryInterface, ReleaseInterface } from 'types/types'
+import { ArtefactKind, EntryInterface, ReleaseInterface } from 'types/types'
 import { plural } from 'utils/stringUtils'
 
 export interface ReleaseAssetsAccordionProps {
@@ -38,7 +38,11 @@ export default function ReleaseAssetsAccordion({
       file={data}
       modelId={model.id}
       releases={[release]}
-      showMenuItems={mode === 'interactive' ? { rescanFile: scanners.length > 0 } : {}}
+      showMenuItems={
+        mode === 'interactive'
+          ? { rescanFile: scanners.some((scanner) => scanner.artefactKind === ArtefactKind.FILE) }
+          : {}
+      }
     />
   ))
 

--- a/frontend/src/entry/model/releases/ReleaseDisplay.tsx
+++ b/frontend/src/entry/model/releases/ReleaseDisplay.tsx
@@ -33,11 +33,10 @@ export default function ReleaseDisplay({
 
   const { isReleasesLoading, isReleasesError } = useGetReleasesForModelId(model.id)
 
-  const { isScannersLoading, isScannersError } = useGetArtefactScannerInfo()
+  const { isScannersLoading } = useGetArtefactScannerInfo()
   const { isUiConfigLoading, isUiConfigError } = useGetUiConfig()
 
   const error = MultipleErrorWrapper('Unable to load release', {
-    isScannersError,
     isReviewsError,
     isUiConfigError,
     isReleasesError,

--- a/frontend/src/entry/model/releases/ReleaseForm.tsx
+++ b/frontend/src/entry/model/releases/ReleaseForm.tsx
@@ -171,7 +171,7 @@ export default function ReleaseForm({
 
   // We can assume that all the displayed files will be interfaces when the form is in read only
   const FileRowItem = memoize(({ data }) =>
-    isFileInterface(data) && !isScannersLoading ? (
+    isFileInterface(data) && !isScannersLoading && !isScannersError ? (
       <FileDisplay
         key={data.name}
         file={data}
@@ -192,10 +192,6 @@ export default function ReleaseForm({
 
   if (isEntryCardRevisionsError) {
     return <MessageAlert message={isEntryCardRevisionsError.info.message} severity='error' />
-  }
-
-  if (isScannersError) {
-    return <MessageAlert message={isScannersError.info.message} severity='error' />
   }
 
   const error = MultipleErrorWrapper('Unable to load release form', {

--- a/frontend/src/entry/model/releases/ReleaseForm.tsx
+++ b/frontend/src/entry/model/releases/ReleaseForm.tsx
@@ -39,6 +39,7 @@ import ReadOnlyAnswer from 'src/Form/ReadOnlyAnswer'
 import Link from 'src/Link'
 import MessageAlert from 'src/MessageAlert'
 import {
+  ArtefactKind,
   EntryInterface,
   FileInterface,
   FileWithMetadataAndTags,
@@ -176,7 +177,7 @@ export default function ReleaseForm({
         key={data.name}
         file={data}
         modelId={model.id}
-        showMenuItems={{ rescanFile: scanners.length > 0 }}
+        showMenuItems={{ rescanFile: scanners.some((scanner) => scanner.artefactKind === ArtefactKind.FILE) }}
         mutator={mutateReleases}
         style={{ padding: 1 }}
         releases={releases}

--- a/infrastructure/helm/bailo/templates/bailo/bailo.configmap.yaml
+++ b/infrastructure/helm/bailo/templates/bailo/bailo.configmap.yaml
@@ -292,13 +292,13 @@ data:
       },
 
       stroom: {
-        logOnlyMode: '{{ .Values.stroom.logOnlyMode }}',
+        logOnlyMode: {{ .Values.stroom.logOnlyMode }},
         feed: '{{ .Values.stroom.feed }}',
         url: '{{ .Values.stroom.url }}',
         environment: '{{ .Values.stroom.environment }}',
-        interval: '{{ .Values.stroom.interval }}',
+        interval: {{ .Values.stroom.interval }},
         generator: '{{ .Values.stroom.generator }}',
-        rejectUnauthorized: '{{ .Values.stroom.rejectUnauthorized }}',
+        rejectUnauthorized: {{ .Values.stroom.rejectUnauthorized }},
         xmlns: '{{ .Values.stroom.xmlns }}',
         schemaLocation: '{{ .Values.stroom.schemaLocation }}',
         version: '{{ .Values.stroom.version }}',


### PR DESCRIPTION
- Remove quotes from `boolean` and `number` typed config values
- Add missing `req.audit` to `getArtefactScanningInfo`
- Express scanner errors silently on the frontend