### PR TITLE
Add Model Export action to Tokens

### DIFF
--- a/backend/src/connectors/authorisation/actions.ts
+++ b/backend/src/connectors/authorisation/actions.ts
@@ -83,11 +83,13 @@ export const ActionLookup = {
   [ModelAction.Update]: TokenActions.ModelWrite.id,
   [ModelAction.Write]: TokenActions.ModelWrite.id,
   [ModelAction.Delete]: TokenActions.ModelWrite.id,
+  [ModelAction.Export]: TokenActions.ModelExport.id,
 
   [ReleaseAction.Create]: TokenActions.ReleaseWrite.id,
   [ReleaseAction.View]: TokenActions.ReleaseRead.id,
   [ReleaseAction.Delete]: TokenActions.ReleaseWrite.id,
   [ReleaseAction.Update]: TokenActions.ReleaseWrite.id,
+  [ReleaseAction.Export]: TokenActions.ReleaseExport.id,
 
   [AccessRequestAction.Create]: TokenActions.AccessRequestWrite.id,
   [AccessRequestAction.View]: TokenActions.AccessRequestRead.id,

--- a/backend/src/models/Token.ts
+++ b/backend/src/models/Token.ts
@@ -18,14 +18,18 @@ export const TokenActions = {
     id: 'model:write',
     description: 'Grants write access to creation and updating of model/data card settings.',
   },
+  ModelExport: { id: 'model:export', description: 'Grants access to export model/data card settings.' },
+
   ReleaseRead: { id: 'release:read', description: 'Grants access to view releases.' },
   ReleaseWrite: { id: 'release:write', description: 'Grants access to create and update releases.' },
+  ReleaseExport: { id: 'release:export', description: 'Grants access to export releases.' },
 
   AccessRequestRead: { id: 'access_request:read', description: 'Grant access to list access requests' },
   AccessRequestWrite: {
     id: 'access_request:write',
     description: 'Grants access to create, approve and comment on access requests.',
   },
+
   FileRead: { id: 'file:read', description: 'Grant access to download and view files.' },
   FileWrite: { id: 'file:write', description: 'Grant access to upload and delete files.' },
 

--- a/backend/src/services/mirroredModel/exporters/documents.ts
+++ b/backend/src/services/mirroredModel/exporters/documents.ts
@@ -61,8 +61,7 @@ export class DocumentsExporter extends BaseExporter {
         }
       }
 
-      const scannersInfo = scanners.scannersInfo() ?? []
-      if (Array.isArray(scannersInfo) && scannersInfo.length > 0) {
+      if (scanners.scannersInfo().length > 0) {
         const scanErrors: {
           missingScan: Array<{ name: string; id: string }>
           incompleteScan: Array<{ name: string; id: string }>

--- a/backend/src/services/mirroredModel/exporters/documents.ts
+++ b/backend/src/services/mirroredModel/exporters/documents.ts
@@ -61,7 +61,7 @@ export class DocumentsExporter extends BaseExporter {
         }
       }
 
-      if (scanners.scannersInfo()) {
+      if (scanners.scannersInfo().length > 0) {
         const scanErrors: {
           missingScan: Array<{ name: string; id: string }>
           incompleteScan: Array<{ name: string; id: string }>

--- a/backend/src/services/mirroredModel/exporters/documents.ts
+++ b/backend/src/services/mirroredModel/exporters/documents.ts
@@ -61,7 +61,8 @@ export class DocumentsExporter extends BaseExporter {
         }
       }
 
-      if (scanners.scannersInfo().length > 0) {
+      const scannersInfo = scanners.scannersInfo() ?? []
+      if (Array.isArray(scannersInfo) && scannersInfo.length > 0) {
         const scanErrors: {
           missingScan: Array<{ name: string; id: string }>
           incompleteScan: Array<{ name: string; id: string }>

--- a/backend/src/services/mirroredModel/exporters/file.ts
+++ b/backend/src/services/mirroredModel/exporters/file.ts
@@ -32,7 +32,8 @@ export class FileExporter extends BaseExporter {
       })
     }
 
-    if (scanners.scannersInfo().length > 0) {
+    const scannersInfo = scanners.scannersInfo() ?? []
+    if (Array.isArray(scannersInfo) && scannersInfo.length > 0) {
       if (!this.file.scanResults || this.file.scanResults.length === 0) {
         throw BadReq('The file is missing vulnerability scan(s).', { filename: this.file.name, fileId: this.file.id })
       } else if (this.file.scanResults.some((scanResult) => scanResult.state !== ArtefactScanState.Complete)) {

--- a/backend/src/services/mirroredModel/exporters/file.ts
+++ b/backend/src/services/mirroredModel/exporters/file.ts
@@ -32,8 +32,7 @@ export class FileExporter extends BaseExporter {
       })
     }
 
-    const scannersInfo = scanners.scannersInfo() ?? []
-    if (Array.isArray(scannersInfo) && scannersInfo.length > 0) {
+    if (scanners.scannersInfo().length > 0) {
       if (!this.file.scanResults || this.file.scanResults.length === 0) {
         throw BadReq('The file is missing vulnerability scan(s).', { filename: this.file.name, fileId: this.file.id })
       } else if (this.file.scanResults.some((scanResult) => scanResult.state !== ArtefactScanState.Complete)) {

--- a/backend/src/services/mirroredModel/mirroredModel.ts
+++ b/backend/src/services/mirroredModel/mirroredModel.ts
@@ -80,6 +80,11 @@ export async function exportModel(
     'Request checks complete, starting export.',
   )
 
+  const files = documentsExporter.getFiles()
+  if (!files) {
+    throw InternalError('DocumentsExporter returned no files after init()', { exportId })
+  }
+
   // Not `await`ed for fire-and-forget approach
   exportQueue
     .add(async () => {
@@ -91,8 +96,7 @@ export async function exportModel(
       if (releases && releases.length > 0) {
         addAndFinaliseExporters(
           await Promise.all(
-            // `documentsExporter.getFiles()` always returns after calling `documentsExporter.init()`
-            documentsExporter.getFiles()!.map((file) =>
+            files.map((file) =>
               new FileExporter(user, model, file, {
                 fileId: file.id,
                 fileName: file.name,

--- a/backend/src/services/mirroredModel/mirroredModel.ts
+++ b/backend/src/services/mirroredModel/mirroredModel.ts
@@ -82,6 +82,7 @@ export async function exportModel(
 
   const files = documentsExporter.getFiles()
   if (!files) {
+    // TS type narrowing - this should never be thrown as `files` will always be a list (even if only an empty list) after calling `.init()`
     throw InternalError('DocumentsExporter returned no files after init()', { exportId })
   }
 

--- a/backend/src/services/mirroredModel/mirroredModel.ts
+++ b/backend/src/services/mirroredModel/mirroredModel.ts
@@ -6,12 +6,14 @@ import fetch, { Response } from 'node-fetch'
 import PQueue from 'p-queue'
 import { Pack } from 'tar-stream'
 
+import { ModelAction } from '../../connectors/authorisation/actions.js'
+import authorisation from '../../connectors/authorisation/index.js'
 import { EntryKind, ModelInterface } from '../../models/Model.js'
 import { ReleaseDoc } from '../../models/Release.js'
 import { UserInterface } from '../../models/User.js'
 import { MirrorExportLogData, MirrorImportLogData, MirrorKind, MirrorMetadata } from '../../types/types.js'
 import config from '../../utils/config.js'
-import { BadReq, InternalError } from '../../utils/error.js'
+import { BadReq, Forbidden, InternalError } from '../../utils/error.js'
 import { shortId } from '../../utils/id.js'
 import { getHttpsAgent } from '../http.js'
 import log from '../log.js'
@@ -45,6 +47,11 @@ export async function exportModel(
 
   const exportId = shortId()
   const model = await getModelById(user, modelId, EntryKind.Model)
+
+  const modelAuth = await authorisation.model(user, model, ModelAction.Export)
+  if (!modelAuth.success) {
+    throw Forbidden(modelAuth.info, { userDn: user.dn, modelId })
+  }
 
   if (!model.card) {
     throw BadReq('Cannot export a model that does have a valid model card.', { modelId: model.id })
@@ -82,24 +89,24 @@ export async function exportModel(
       log.debug({ exportId, sourceModelId: modelId, mirroredModelId, semvers }, 'Successfully finalized Tarball file.')
 
       if (releases && releases.length > 0) {
-        for (const release of releases) {
-          addAndFinaliseExporters(
-            await Promise.all(
-              documentsExporter.getFiles()!.map((file) =>
-                new FileExporter(user, model, file, {
-                  fileId: file.id,
-                  fileName: file.name,
-                  exportId,
-                }).init(),
-              ),
+        addAndFinaliseExporters(
+          await Promise.all(
+            // `documentsExporter.getFiles()` always returns after calling `documentsExporter.init()`
+            documentsExporter.getFiles()!.map((file) =>
+              new FileExporter(user, model, file, {
+                fileId: file.id,
+                fileName: file.name,
+                exportId,
+              }).init(),
             ),
-            {
-              modelId,
-              mirroredModelId: mirroredModelId,
-              release: release.semver,
-              exportId,
-            },
-          )
+          ),
+          {
+            modelId,
+            mirroredModelId: mirroredModelId,
+            exportId,
+          },
+        )
+        for (const release of releases) {
           addAndFinaliseExporters(
             await Promise.all(
               release.images.map((image) =>

--- a/backend/test/services/mirroredModel/exporters/documents.spec.ts
+++ b/backend/test/services/mirroredModel/exporters/documents.spec.ts
@@ -91,7 +91,7 @@ describe('services > mirroredModel > exporters > DocumentsExporter', () => {
     fileServiceMocks.getTotalFileSize.mockResolvedValue(500)
     modelServiceMocks.getModelCardRevisions.mockResolvedValue([{ version: 'v1', toJSON: () => ({}) }])
     releaseServiceMocks.getAllFileIds.mockResolvedValue(['fileId'])
-    scannersMocks.default.scannersInfo.mockReturnValue(false)
+    scannersMocks.default.scannersInfo.mockReturnValue([])
     authMocks.default.model.mockResolvedValue({ success: true })
   })
 
@@ -140,7 +140,7 @@ describe('services > mirroredModel > exporters > DocumentsExporter', () => {
   })
 
   test('_init throws BadReq if scan issues (missing scan)', async () => {
-    scannersMocks.default.scannersInfo.mockReturnValue(true)
+    scannersMocks.default.scannersInfo.mockReturnValue(['item1'])
     const badFile = { id: 'f', name: 'name', scanResults: [] }
     fileServiceMocks.getFilesByIds.mockResolvedValueOnce([badFile as any])
     const exporter = new DocumentsExporter(mockUser, mockModel, [mockRelease], mockLogData)
@@ -154,7 +154,7 @@ describe('services > mirroredModel > exporters > DocumentsExporter', () => {
   })
 
   test('_init throws BadReq if scan incomplete', async () => {
-    scannersMocks.default.scannersInfo.mockReturnValue(true)
+    scannersMocks.default.scannersInfo.mockReturnValue(['item1'])
     const incompleteFile = {
       id: 'f',
       name: 'name',
@@ -172,7 +172,7 @@ describe('services > mirroredModel > exporters > DocumentsExporter', () => {
   })
 
   test('_init throws BadReq if scan failed', async () => {
-    scannersMocks.default.scannersInfo.mockReturnValue(true)
+    scannersMocks.default.scannersInfo.mockReturnValue(['item1'])
     const infectedFile = {
       id: 'f',
       name: 'name',

--- a/backend/test/services/mirroredModel/mirroredModel.spec.ts
+++ b/backend/test/services/mirroredModel/mirroredModel.spec.ts
@@ -12,35 +12,22 @@ import {
   importModel,
 } from '../../../src/services/mirroredModel/mirroredModel.js'
 import { MirrorKind } from '../../../src/types/types.js'
+import config from '../../../src/utils/config.js'
 import { BadReq, InternalError } from '../../../src/utils/error.js'
 
-const configMock = vi.hoisted(() => ({
-  ui: {
-    modelMirror: {
-      import: { enabled: true },
-      export: { enabled: true },
-    },
+vi.mock('../../../src/utils/config.js', async () => {
+  const actual = await vi.importActual<typeof import('../../../src/utils/config.js')>('../../../src/utils/config.js')
+  const mutableConfig = structuredClone(actual.default)
+
+  return { __esModule: true, default: mutableConfig }
+})
+config.ui = {
+  modelMirror: {
+    import: { enabled: true },
+    export: { enabled: true },
   },
-  connectors: {
-    authentication: {
-      kind: 'silly',
-    },
-    audit: {
-      kind: 'silly',
-    },
-    authorisation: {
-      kind: 'basic',
-    },
-    artefactScanners: {
-      kinds: [],
-    },
-  },
-  app: {
-    protocol: '',
-  },
-  modelMirror: { export: { concurrency: 1 }, metadataFile: 'meta.json' },
-}))
-vi.mock('../../../src/utils/config.js', () => ({ default: configMock }))
+} as any
+config.modelMirror = { export: { concurrency: 1 }, metadataFile: 'meta.json' } as any
 
 const logMock = vi.hoisted(() => ({ info: vi.fn(), debug: vi.fn(), error: vi.fn() }))
 vi.mock('../../../src/services/log.js', () => ({ default: logMock }))
@@ -78,6 +65,7 @@ const getModelByIdMock = vi.hoisted(() =>
 vi.mock('../../../src/services/model.js', () => ({
   getModelById: getModelByIdMock,
   getModelByIdNoAuth: getModelByIdMock,
+  getModelSystemRoles: vi.fn(() => ['owner']),
 }))
 
 const fetchMock = vi.hoisted(() =>
@@ -271,21 +259,21 @@ describe('services > mirroredModel', () => {
 
   describe('exportModel', () => {
     test('disabled export throws', async () => {
-      configMock.ui.modelMirror.export.enabled = false
+      config.ui.modelMirror.export.enabled = false
       await expect(exportModel({} as any, 'modelId', true)).rejects.toThrow(
         BadReq('Exporting models has not been enabled.'),
       )
     })
 
     test('missing disclaimer throws', async () => {
-      configMock.ui.modelMirror.export.enabled = true
+      config.ui.modelMirror.export.enabled = true
       await expect(exportModel({} as any, 'modelId', false)).rejects.toThrow(
         BadReq('You must agree to the disclaimer agreement before being able to export a model.'),
       )
     })
 
     test('success triggers queue', async () => {
-      configMock.ui.modelMirror.export.enabled = true
+      config.ui.modelMirror.export.enabled = true
       const id = await exportModel({} as any, 'modelId', true)
       expect(id).toBe('shortId123')
       expect(DocumentsExporterMock).toHaveBeenCalled()
@@ -293,7 +281,7 @@ describe('services > mirroredModel', () => {
     })
 
     test('success semvers', async () => {
-      configMock.ui.modelMirror.export.enabled = true
+      config.ui.modelMirror.export.enabled = true
       const id = await exportModel({} as any, 'modelId', true, ['1.0.0'])
       expect(id).toBe('shortId123')
       expect(DocumentsExporterMock).toHaveBeenCalled()
@@ -302,7 +290,7 @@ describe('services > mirroredModel', () => {
     })
 
     test('log error on exportQueue reject', async () => {
-      configMock.ui.modelMirror.export.enabled = true
+      config.ui.modelMirror.export.enabled = true
       exportQueueMock.exportQueueAddMock.mockImplementationOnce(() => Promise.reject(new Error('boom')))
 
       await exportModel({} as any, 'modelId', true)
@@ -323,12 +311,12 @@ describe('services > mirroredModel', () => {
 
   describe('importModel', () => {
     test('disabled import throws', async () => {
-      configMock.ui.modelMirror.import.enabled = false
+      config.ui.modelMirror.import.enabled = false
       await expect(importModel({} as any, 'url')).rejects.toThrow(BadReq('Importing models has not been enabled.'))
     })
 
     test('fetch rejects', async () => {
-      configMock.ui.modelMirror.import.enabled = true
+      config.ui.modelMirror.import.enabled = true
       fetchMock.mockRejectedValueOnce('err')
       await expect(importModel({} as any, 'url')).rejects.toThrow(
         InternalError('Unable to get the file.', { err: 'err', payloadUrl: 'url', importId: 'shortId123' }),
@@ -402,7 +390,7 @@ describe('services > mirroredModel', () => {
 
     test('fail > invalid importKind', () => {
       expect(() => getImporter({ importKind: 'invalid' } as any, {} as any, {} as any)).toThrowError(
-        `Unknown \`importKind\` specified in '${configMock.modelMirror.metadataFile}'.`,
+        `Unknown \`importKind\` specified in '${config.modelMirror.metadataFile}'.`,
       )
     })
   })


### PR DESCRIPTION
Enables using the token to trigger the model export endpoint.
Also fixes a bug where files were being repeatedly exported when multiple releases were selected.