### PR TITLE
Improve frontend file error handling

### DIFF
--- a/frontend/actions/file.ts
+++ b/frontend/actions/file.ts
@@ -35,26 +35,33 @@ export async function postFileForModelId(
     ...(metadata && metadata.text && { metadataText: metadata.text }),
     ...(metadata && metadata.tags.length > 0 && { tags: metadata.tags }),
   }
-  const fileResponse = await axios
-    .post(
+  try {
+    const fileResponse = await axios.post(
       `/api/v2/model/${modelId}/files/upload/simple?name=${file.name}&mime=${mime}&${qs.stringify(queryParams)}`,
       file,
-      {
-        onUploadProgress,
-      },
+      { onUploadProgress },
     )
-    .catch(function (error) {
+    return fileResponse
+  } catch (error) {
+    if (axios.isAxiosError(error)) {
       if (error.response) {
-        throw new Error(
-          `Error code ${error.response.status} received from server whilst attempting to upload file ${file.name}`,
-        )
-      } else if (error.request) {
-        throw new Error(`There was a problem with the request whilst attempting to upload file ${file.name}`)
-      } else {
-        throw new Error(`Unknown error whilst attempting to upload file ${file.name}`)
+        const serverMessage =
+          typeof error.response.data === 'string'
+            ? error.response.data
+            : error.response.data?.error?.message || JSON.stringify(error.response.data)
+
+        throw new Error(`${error.response.statusText} for "${file.name}": ${serverMessage}`)
       }
-    })
-  return fileResponse
+
+      if (error.request) {
+        throw new Error(`There was a problem with the request whilst attempting to upload file "${file.name}"`)
+      }
+
+      throw new Error(`Request setup failed while uploading "${file.name}": ${error.message}`)
+    }
+
+    throw new Error(`Unknown error whilst attempting to upload file "${file.name}"`)
+  }
 }
 
 export async function patchFile(modelId: string, fileId: string, metadata: Pick<FileInterface, 'tags'>) {

--- a/frontend/pages/model/[modelId]/release/new.tsx
+++ b/frontend/pages/model/[modelId]/release/new.tsx
@@ -134,14 +134,21 @@ export default function NewRelease() {
             setCurrentFileUploadProgress(undefined)
           }
         } catch (e) {
-          if (e instanceof Error) {
-            failedFiles.push({ fileName: file.name, error: e.message })
-            setCurrentFileUploadProgress(undefined)
-          }
+          const message = e instanceof Error ? e.message : 'Unknown upload error'
+          const failed = { fileName: file.name, error: message }
+          failedFiles.push(failed)
+
+          setFailedFileUploads((prev) => [...prev, failed])
+          setCurrentFileUploadProgress(undefined)
         }
       }
     }
-    setFailedFileUploads(failedFiles)
+
+    if (failedFiles.length > 0) {
+      setCurrentFileUploadProgress(undefined)
+      setLoading(false)
+      return
+    }
 
     const updatedSuccessfulFiles = successfulFiles.reduce(
       (updatedFiles, file) => {

--- a/frontend/src/common/MultiFileInputFileDisplay.tsx
+++ b/frontend/src/common/MultiFileInputFileDisplay.tsx
@@ -40,12 +40,23 @@ export default function MultiFileInputFileDisplay({
 
   const handleFileTagSelectorOnChange = async (newTags: string[]) => {
     setFileTagCount(newTags.length)
+    setFileTagErrorMessage('')
+    if (newTags.includes('')) {
+      setFileTagErrorMessage('Tags must have at least one character')
+      return
+    }
     if (isFileInterface(file)) {
-      setFileTagErrorMessage('')
       const res = await patchFile(file.modelId, file._id, { tags: newTags.filter((newTag) => newTag !== '') })
       mutateModelFiles()
-      if (res.status !== 200) {
-        setFileTagErrorMessage('You lack the required authorisation in order to add tags to a file.')
+
+      if (res.status && res.status >= 200 && res.status < 300) {
+        mutateModelFiles()
+        return
+      }
+      if (typeof res.data === 'string' && res.data.length > 0) {
+        setFileTagErrorMessage(res.data)
+      } else {
+        setFileTagErrorMessage('Failed to update file tags. Please try again.')
       }
     } else {
       setNewFileTags(newTags)

--- a/frontend/src/entry/model/files/FileDisplay.tsx
+++ b/frontend/src/entry/model/files/FileDisplay.tsx
@@ -338,8 +338,15 @@ export default function FileDisplay({
     }
     const res = await patchFile(modelId, file._id, { tags: newTags.filter((newTag) => newTag !== '') })
     mutateModelFiles()
-    if (res.status !== 200) {
-      setFileTagErrorMessage('You lack the required authorisation in order to add tags to a file.')
+
+    if (res.status && res.status >= 200 && res.status < 300) {
+      mutateModelFiles()
+      return
+    }
+    if (typeof res.data === 'string' && res.data.length > 0) {
+      setFileTagErrorMessage(res.data)
+    } else {
+      setFileTagErrorMessage('Failed to update file tags. Please try again.')
     }
   }
 

--- a/frontend/src/entry/model/files/FileUploadDialog.tsx
+++ b/frontend/src/entry/model/files/FileUploadDialog.tsx
@@ -1,11 +1,12 @@
 import styled from '@emotion/styled'
-import { Box, Button, Dialog, DialogContent, Divider, LinearProgress, Stack, Typography } from '@mui/material'
+import { Alert, Box, Button, Dialog, DialogContent, Divider, LinearProgress, Stack, Typography } from '@mui/material'
 import { postFileForModelId } from 'actions/file'
 import { AxiosProgressEvent } from 'axios'
 import { ChangeEvent, useCallback, useMemo, useState } from 'react'
 import FileUploadProgressDisplay, { FailedFileUpload, FileUploadProgress } from 'src/common/FileUploadProgressDisplay'
 import FileToBeUploaded from 'src/entry/model/files/FileToBeUploaded'
 import { EntryInterface, FileUploadMetadata, FileUploadWithMetadata } from 'types/types'
+import { plural } from 'utils/stringUtils'
 
 interface FileUploadDialogProps {
   model: EntryInterface
@@ -91,11 +92,12 @@ export default function FileUploadDialog({ open, onDialogClose, model, mutateMod
           setCurrentFileUploadProgress(undefined)
         }
       } catch (e) {
-        if (e instanceof Error) {
-          failedFiles.push({ fileName: fileItem.file.name, error: e.message })
-          setFailedFileUploads([...failedFileUploads, { fileName: fileItem.file.name, error: e.message }])
-          setCurrentFileUploadProgress(undefined)
-        }
+        const message = e instanceof Error ? e.message : 'Unknown upload error'
+        const failed = { fileName: fileItem.file.name, error: message }
+        failedFiles.push(failed)
+
+        setFailedFileUploads((prev) => [...prev, failed])
+        setCurrentFileUploadProgress(undefined)
       }
     }
     setUploadedFiles([])
@@ -105,7 +107,7 @@ export default function FileUploadDialog({ open, onDialogClose, model, mutateMod
       onDialogClose()
       setFilesToBeUpload([])
     }
-  }, [failedFileUploads, model.id, mutateModelFiles, filesToBeUploaded, onDialogClose])
+  }, [model.id, mutateModelFiles, filesToBeUploaded, onDialogClose])
 
   const handleDeleteFileFromUploadList = useCallback(
     (fileName: string) => {
@@ -176,7 +178,14 @@ export default function FileUploadDialog({ open, onDialogClose, model, mutateMod
               Upload files
             </Button>
           </Box>
-          {failedFileList}
+          {failedFileUploads.length > 0 && (
+            <Alert severity='error' sx={{ my: 2 }}>
+              <Stack spacing={1}>
+                <Typography>{`Unable to upload the following ${plural(failedFileUploads.length, 'file')}:`}</Typography>
+                {failedFileList}
+              </Stack>
+            </Alert>
+          )}
         </Stack>
       </DialogContent>
     </Dialog>

--- a/frontend/src/entry/model/releases/EditableRelease.tsx
+++ b/frontend/src/entry/model/releases/EditableRelease.tsx
@@ -161,13 +161,8 @@ export default function EditableRelease({ release, isEdit, onIsEditChange, readO
       if (!successfulFileUploads.find((successfulFile) => successfulFile.fileName === file.name)) {
         const fileWithMetadata = filesMetadata.find((fileWithMetadata) => fileWithMetadata.fileName === file.name)
 
-        let textMetadata = ''
-        let tags: string[] = []
-
-        if (fileWithMetadata && fileWithMetadata.metadata) {
-          textMetadata = fileWithMetadata.metadata.text
-          tags = fileWithMetadata.metadata.tags
-        }
+        const textMetadata = fileWithMetadata?.metadata?.text ?? ''
+        const tags = fileWithMetadata?.metadata?.tags ?? []
 
         const handleUploadProgress = (progressEvent: AxiosProgressEvent) => {
           if (progressEvent.total) {
@@ -178,8 +173,8 @@ export default function EditableRelease({ release, isEdit, onIsEditChange, readO
 
         try {
           const fileUploadResponse = await postFileForModelId(model.id, file, handleUploadProgress, {
-            text: textMetadata ? textMetadata : '',
-            tags: tags ? tags : [],
+            text: textMetadata,
+            tags,
           })
           setCurrentFileUploadProgress(undefined)
           if (fileUploadResponse) {
@@ -190,24 +185,31 @@ export default function EditableRelease({ release, isEdit, onIsEditChange, readO
             return setIsLoading(false)
           }
         } catch (e) {
-          if (e instanceof Error) {
-            failedFiles.push({ fileName: file.name, error: e.message })
-            setIsLoading(false)
-            setCurrentFileUploadProgress(undefined)
-          }
+          const message = e instanceof Error ? e.message : 'Unknown upload error'
+          const failed = { fileName: file.name, error: message }
+          failedFiles.push(failed)
+
+          setFailedFileUploads((prev) => [...prev, failed])
+          setCurrentFileUploadProgress(undefined)
         }
       }
     }
-    successfulFiles.forEach((file) => {
-      if (!successfulFileUploads.find((successfulFile) => successfulFile.fileName === file.fileName)) {
-        setSuccessfulFileUploads([...successfulFileUploads, file])
-      }
-    })
 
     if (failedFiles.length > 0) {
-      setFailedFileUploads(failedFiles)
+      setIsLoading(false)
+      setCurrentFileUploadProgress(undefined)
       return
     }
+
+    setSuccessfulFileUploads((prev) => {
+      const updated = [...prev]
+      successfulFiles.forEach((file) => {
+        if (!updated.find((f) => f.fileName === file.fileName)) {
+          updated.push(file)
+        }
+      })
+      return updated
+    })
 
     const updatedRelease: UpdateReleaseParams = {
       modelId: model.id,
@@ -265,7 +267,7 @@ export default function EditableRelease({ release, isEdit, onIsEditChange, readO
       {failedFileUploads.length > 0 && (
         <Alert severity='error' sx={{ my: 2 }}>
           <Stack spacing={1}>
-            <Typography>{`Unable to create release due to issues with the following ${plural(
+            <Typography>{`Unable to modify release due to issues with the following ${plural(
               failedFileUploads.length,
               'file',
             )}:`}</Typography>

--- a/frontend/src/entry/model/releases/EditableRelease.tsx
+++ b/frontend/src/entry/model/releases/EditableRelease.tsx
@@ -132,6 +132,7 @@ export default function EditableRelease({ release, isEdit, onIsEditChange, readO
   }
 
   const handleCancel = () => {
+    setFailedFileUploads([])
     setErrorMessage('')
     resetForm()
     onIsEditChange(false)

--- a/frontend/utils/axios.ts
+++ b/frontend/utils/axios.ts
@@ -5,7 +5,15 @@ export function handleAxiosError(error: AxiosError | unknown) {
     if (error.response) {
       // The request was made and the server responded with a status code
       // that falls out of the range of 2xx
-      return { status: error.response.status, data: `${error.response.status}: ${error.response.statusText}` }
+      const serverMessage =
+        typeof error.response.data === 'string'
+          ? error.response.data
+          : error.response.data?.error?.message || JSON.stringify(error.response.data)
+
+      return {
+        status: error.response.status,
+        data: `${error.response.statusText}: ${serverMessage}`,
+      }
     } else if (error.request) {
       // The request was made but no response was received
       return { status: 503, data: 'No response received from server' }


### PR DESCRIPTION
- Standardise error handling for `postFileForModelId` (File management tab, Create release page & Edit release page)
- Improve `patchFile` error handling to use server's error message rather than assume error message
- Improve `handleAxiosError` to use server's error message
- Fix a bug where files that fail to be uploaded in Create release page submit still allowed the release to be created