### PR TITLE
Set files in `DocumentsExporter` when no releases are selected

### DIFF
--- a/backend/src/services/mirroredModel/exporters/documents.ts
+++ b/backend/src/services/mirroredModel/exporters/documents.ts
@@ -84,6 +84,8 @@ export class DocumentsExporter extends BaseExporter {
           throw BadReq('The releases contain file(s) that do not have a clean scan.', { scanErrors })
         }
       }
+    } else {
+      this.files = []
     }
   }
 

--- a/backend/src/services/mirroredModel/mirroredModel.ts
+++ b/backend/src/services/mirroredModel/mirroredModel.ts
@@ -81,7 +81,7 @@ export async function exportModel(
   )
 
   const files = documentsExporter.getFiles()
-  if (!files) {
+  if (!Array.isArray(files)) {
     // TS type narrowing - this should never be thrown as `files` will always be a list (even if only an empty list) after calling `.init()`
     throw InternalError('DocumentsExporter returned no files after init()', { exportId })
   }


### PR DESCRIPTION
Fixed a bug where exporting a model with no releases selected meant that `this.files` was never set.