### PR TITLE
Restrict vitest version

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -93,7 +93,7 @@
         "@types/tar-stream": "^3.1.4",
         "@typescript-eslint/eslint-plugin": "^8.58.0",
         "@typescript-eslint/parser": "^8.31.1",
-        "@vitest/coverage-v8": "^4.0.18",
+        "@vitest/coverage-v8": "~4.0.18",
         "eslint": "^10.1.0",
         "eslint-plugin-prettier": "^5.5.5",
         "eslint-plugin-simple-import-sort": "^12.1.1",
@@ -103,7 +103,7 @@
         "supertest": "^7.2.2",
         "typescript": "^6.0.2",
         "vite-tsconfig-paths": "^6.1.1",
-        "vitest": "^4.0.14"
+        "vitest": "~4.0.18"
       }
     },
     "node_modules/@agendajs/mongo-backend": {

--- a/backend/package.json
+++ b/backend/package.json
@@ -104,7 +104,7 @@
     "@types/tar-stream": "^3.1.4",
     "@typescript-eslint/eslint-plugin": "^8.58.0",
     "@typescript-eslint/parser": "^8.31.1",
-    "@vitest/coverage-v8": "^4.0.18",
+    "@vitest/coverage-v8": "~4.0.18",
     "eslint": "^10.1.0",
     "eslint-plugin-prettier": "^5.5.5",
     "eslint-plugin-simple-import-sort": "^12.1.1",
@@ -114,7 +114,7 @@
     "supertest": "^7.2.2",
     "typescript": "^6.0.2",
     "vite-tsconfig-paths": "^6.1.1",
-    "vitest": "^4.0.14"
+    "vitest": "~4.0.18"
   },
   "overrides": {
     "mv": "npm:dry-uninstall"


### PR DESCRIPTION
Prevent bugs from #3511 by restricting backend vitest versions to 4.0.x only.