### PR TITLE
Drop jsrsasign package ahead of deprecation

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -41,7 +41,6 @@
         "grant": "^5.4.23",
         "jsonschema": "^1.5.0",
         "jsonwebtoken": "^9.0.3",
-        "jsrsasign": "^11.1.1",
         "lodash-es": "^4.18.1",
         "mjml": "5.1.0",
         "mongodb": "^7.1.1",
@@ -10531,15 +10530,6 @@
       "engines": {
         "node": ">=12",
         "npm": ">=6"
-      }
-    },
-    "node_modules/jsrsasign": {
-      "version": "11.1.1",
-      "resolved": "https://registry.npmjs.org/jsrsasign/-/jsrsasign-11.1.1.tgz",
-      "integrity": "sha512-6w95OOXH8DNeGxakqLndBEqqwQ6A70zGaky1oxfg8WVLWOnghTfJsc5Tknx+Z88MHSb1bGLcqQHImOF8Lk22XA==",
-      "license": "MIT",
-      "funding": {
-        "url": "https://github.com/kjur/jsrsasign#donations"
       }
     },
     "node_modules/juice": {

--- a/backend/package.json
+++ b/backend/package.json
@@ -52,7 +52,6 @@
     "grant": "^5.4.23",
     "jsonschema": "^1.5.0",
     "jsonwebtoken": "^9.0.3",
-    "jsrsasign": "^11.1.1",
     "lodash-es": "^4.18.1",
     "mjml": "5.1.0",
     "mongodb": "^7.1.1",

--- a/backend/src/clients/kms.ts
+++ b/backend/src/clients/kms.ts
@@ -1,5 +1,4 @@
 import { DescribeKeyCommand, KMSClient, SignCommand, SignCommandOutput } from '@aws-sdk/client-kms'
-import { ASN1HEX } from 'jsrsasign'
 
 import config from '../utils/config.js'
 import { InternalError } from '../utils/error.js'
@@ -32,18 +31,50 @@ export async function sign(hash: string) {
     MessageType: 'DIGEST',
   })
   const signResponse = await client.send(signCommand)
-  const values = await getSignatureValues(signResponse)
-  return values
+  return await getSignatureValues(signResponse)
 }
 
 async function getSignatureValues(signResponse: SignCommandOutput) {
   if (!signResponse.Signature) {
     throw InternalError('Cannot get signature.', { response: signResponse })
   }
-  const hex = Buffer.from(signResponse.Signature).toString('hex')
-  const intIdx = ASN1HEX.getChildIdx(hex, 0)
-  const rBigInt = BigInt('0x' + ASN1HEX.getV(hex, intIdx[0])) // Convert r/s values from hex to big integers
-  const sBigInt = BigInt('0x' + ASN1HEX.getV(hex, intIdx[1]))
+  const { r, s } = parseEcdsaDerSignature(signResponse.Signature)
 
-  return { 'sig-r': rBigInt.toString(), 'sig-s': sBigInt.toString() }
+  return {
+    'sig-r': r.toString(),
+    'sig-s': s.toString(),
+  }
+}
+
+function parseEcdsaDerSignature(sig: Uint8Array) {
+  let offset = 0
+
+  if (sig[offset++] !== 0x30) {
+    throw new Error('Invalid DER signature')
+  }
+
+  const seqLen = sig[offset++]
+  if (seqLen + 2 !== sig.length) {
+    throw new Error('Malformed DER sequence')
+  }
+
+  if (sig[offset++] !== 0x02) {
+    throw new Error('Invalid DER: missing r integer')
+  }
+
+  const rLen = sig[offset++]
+  const r = sig.slice(offset, offset + rLen)
+  offset += rLen
+
+  if (sig[offset++] !== 0x02) {
+    throw new Error('Invalid DER: missing s integer')
+  }
+
+  const sLen = sig[offset++]
+  const s = sig.slice(offset, offset + sLen)
+
+  return {
+    r: BigInt('0x' + Buffer.from(r).toString('hex')),
+    s: BigInt('0x' + Buffer.from(s).toString('hex')),
+  }
 }

--- a/backend/src/scripts/generateJWKS.ts
+++ b/backend/src/scripts/generateJWKS.ts
@@ -1,13 +1,13 @@
+import { createPublicKey } from 'crypto'
 import { readFile, writeFile } from 'fs/promises'
-import r from 'jsrsasign'
 
 import config from '../utils/config.js'
 import { getKid } from '../utils/registryUtils.js'
 
 async function script() {
   const pem = await readFile(config.app.publicKey, { encoding: 'utf-8' })
-  const key = r.KEYUTIL.getKey(pem)
-  const jwk = r.KEYUTIL.getJWKFromKey(key)
+  const key = createPublicKey(pem)
+  const jwk = key.export({ format: 'jwk' })
   jwk.kid = await getKid()
   await writeFile(config.app.jwks, JSON.stringify({ keys: [jwk] }))
 }

--- a/backend/test/clients/kms.spec.ts
+++ b/backend/test/clients/kms.spec.ts
@@ -45,6 +45,10 @@ vi.mock('../../src/utils/config.js', () => ({
 }))
 
 describe('clients > s3', () => {
+  // value from https://docs.yubico.com/yesdk/users-manual/application-piv/ecdsa-signatures.html
+  const exampleSignatureString =
+    '302c021500e91a49c5147db1a9aaf244f05a434d6486931d2d0213526db078b05edecbcd1eb4a208f3ae1617ae82'
+
   test('sign > success', async () => {
     kmsMocks.send.mockResolvedValueOnce({
       KeyMetadata: {
@@ -52,7 +56,7 @@ describe('clients > s3', () => {
       },
     })
     kmsMocks.send.mockResolvedValueOnce({
-      Signature: 'abcefgh',
+      Signature: Buffer.from(exampleSignatureString, 'hex'),
     })
 
     await sign('hash123')
@@ -63,10 +67,65 @@ describe('clients > s3', () => {
     expect(kmsMocks.send).toHaveBeenCalled()
   })
 
+  test('sign > invalid DER sequence', async () => {
+    kmsMocks.send.mockResolvedValueOnce({
+      KeyMetadata: {
+        SigningAlgorithms: ['abc'],
+      },
+    })
+    kmsMocks.send.mockResolvedValueOnce({
+      Signature: Buffer.from(exampleSignatureString.substring(1), 'hex'),
+    })
+
+    await expect(sign('hash123')).rejects.toThrowError(/^Invalid DER signature/)
+  })
+
+  test('sign > DER too short', async () => {
+    kmsMocks.send.mockResolvedValueOnce({
+      KeyMetadata: {
+        SigningAlgorithms: ['abc'],
+      },
+    })
+    kmsMocks.send.mockResolvedValueOnce({
+      Signature: Buffer.from(exampleSignatureString.substring(0, exampleSignatureString.length - 1), 'hex'),
+    })
+
+    await expect(sign('hash123')).rejects.toThrowError(/^Malformed DER sequence/)
+  })
+
+  test('sign > DER missing r integer', async () => {
+    kmsMocks.send.mockResolvedValueOnce({
+      KeyMetadata: {
+        SigningAlgorithms: ['abc'],
+      },
+    })
+    kmsMocks.send.mockResolvedValueOnce({
+      Signature: Buffer.from(exampleSignatureString.substring(0, 5) + '3' + exampleSignatureString.substring(6), 'hex'),
+    })
+
+    await expect(sign('hash123')).rejects.toThrowError(/^Invalid DER: missing r integer/)
+  })
+
+  test('sign > DER missing s integer', async () => {
+    kmsMocks.send.mockResolvedValueOnce({
+      KeyMetadata: {
+        SigningAlgorithms: ['abc'],
+      },
+    })
+    kmsMocks.send.mockResolvedValueOnce({
+      Signature: Buffer.from(
+        exampleSignatureString.substring(0, 51) + '3' + exampleSignatureString.substring(52),
+        'hex',
+      ),
+    })
+
+    await expect(sign('hash123')).rejects.toThrowError(/^Invalid DER: missing s integer/)
+  })
+
   test('sign > cannot get key information', async () => {
     kmsMocks.send.mockResolvedValueOnce({})
     kmsMocks.send.mockResolvedValueOnce({
-      Signature: 'abcefgh',
+      Signature: Buffer.from(exampleSignatureString, 'hex'),
     })
 
     const response = sign('hash123')


### PR DESCRIPTION
Remove jsrsasign package dependency ahead of upcoming deprecation.

https://github.com/kjur/jsrsasign#end-of-support-announcement-for-jsrsasign

> End of Support Announcement for jsrsasign
> -----------------------------------------
> On 14 April 2026, we announce end of support for jsrsasign. 
> 
> Effective 3 Jun 2026, support is no longer provided for jsrsasign and all version of "npm" packages of jsrsasign is deprecated. Thank you very much for using jsrsasign since the release of its first version, 1.0, on June 3, 2010.