### PR TITLE
Improved handling for entities in different case notations

### DIFF
--- a/backend/src/services/model.ts
+++ b/backend/src/services/model.ts
@@ -870,7 +870,7 @@ export async function getCurrentUserPermissionsByModel(
   }
 }
 
-export async function getModelSystemRoles(user: UserInterface, model: ModelDoc) {
+export async function getModelSystemRoles(user: UserInterface, model: ModelDoc): Promise<string[]> {
   const entities = await authentication.getEntities(user)
   const normalizedEntities = entities.map((entity) => entity.toLowerCase())
 

--- a/backend/src/services/model.ts
+++ b/backend/src/services/model.ts
@@ -872,10 +872,10 @@ export async function getCurrentUserPermissionsByModel(
 
 export async function getModelSystemRoles(user: UserInterface, model: ModelDoc): Promise<string[]> {
   const entities = await authentication.getEntities(user)
-  const normalizedEntities = entities.map((entity) => entity.toLowerCase())
+  const normalisedEntities = entities.map((entity) => entity.toLowerCase())
 
   return model.collaborators
-    .filter((collaborator) => normalizedEntities.includes(collaborator.entity.toLowerCase()))
+    .filter((collaborator) => normalisedEntities.includes(collaborator.entity.toLowerCase()))
     .map((collaborator) => collaborator.roles)
     .flat()
 }

--- a/backend/src/services/model.ts
+++ b/backend/src/services/model.ts
@@ -872,9 +872,10 @@ export async function getCurrentUserPermissionsByModel(
 
 export async function getModelSystemRoles(user: UserInterface, model: ModelDoc) {
   const entities = await authentication.getEntities(user)
+  const normalizedEntities = entities.map((entity) => entity.toLowerCase())
 
   return model.collaborators
-    .filter((collaborator) => entities.includes(collaborator.entity))
+    .filter((collaborator) => normalizedEntities.includes(collaborator.entity.toLowerCase()))
     .map((collaborator) => collaborator.roles)
     .flat()
 }

--- a/backend/test/services/model.spec.ts
+++ b/backend/test/services/model.spec.ts
@@ -12,6 +12,7 @@ import {
   getModelById,
   getModelByIdNoAuth,
   getModelCardRevision,
+  getModelSystemRoles,
   isModelCardRevisionDoc,
   popularTagsForEntries,
   removeModel,
@@ -778,5 +779,24 @@ describe('services > model', () => {
     ModelModelMock.aggregate.mockResolvedValueOnce([{ _id: 'test-tag' }])
     const tags = await popularTagsForEntries()
     expect(tags).toEqual(['test-tag'])
+  })
+
+  test('getModelSystemRoles > should handle case-insensitive entity matching', async () => {
+    const mockModel = {
+      collaborators: [
+        {
+          entity: 'Bobs_User_Group',
+          roles: ['owner'],
+        },
+      ],
+    } as any
+
+    const mockUser = { dn: 'user' } as any
+
+    authenticationMocks.getEntities.mockResolvedValueOnce(['BOBS_USER_GROUP'])
+
+    const response = await getModelSystemRoles(mockUser, mockModel)
+
+    expect(response).toContain('owner')
   })
 })


### PR DESCRIPTION
- Before there was an issue where the list of entities we get back from the `authentication.getEntities(user)` request could be all uppercase, such as `BOBS_USER_GROUP` but the `collaborator.entity` might have a mix of upper & lowercase e.g `Bobs_User_Group`.
- Fixed by ensuring both are lowercase before doing string comparison