### PR TITLE
Bump artefactscan debian version and drop ubuntu from dockerfile

### DIFF
--- a/compose.prod.yaml
+++ b/compose.prod.yaml
@@ -22,7 +22,7 @@ services:
     volumes:
       - ./backend/certs:/certs:ro
     healthcheck:
-      test: ['CMD-SHELL', 'curl --fail http://127.0.0.1:3311/info || exit 1']
+      test: ['CMD', 'python', '-c', "import urllib.request; urllib.request.urlopen('http://127.0.0.1:3311/info')"]
       interval: 30s
       timeout: 10s
       retries: 5

--- a/lib/artefactscan_api/Dockerfile
+++ b/lib/artefactscan_api/Dockerfile
@@ -1,37 +1,41 @@
 # syntax=docker/dockerfile:1
 
-ARG PYTHONPATH=/venv/lib/python3.12/site-packages
+ARG UID=65532
+ARG GID=65532
 
-FROM python:3.12.13-slim-bookworm AS build
-ARG PYTHONPATH
-ENV PYTHONDONTWRITEBYTECODE=1 \
-    PYTHONUNBUFFERED=1
+FROM python:3.12.13-slim-trixie AS build
 
-RUN --mount=type=cache,target=/root/.cache/pip \
-    python3 -m venv /venv && \
-    /venv/bin/pip install --upgrade pip setuptools wheel
-
-COPY requirements.txt /requirements.txt
-RUN --mount=type=cache,target=/root/.cache/pip /venv/bin/pip install -r /requirements.txt
-
-FROM ubuntu:24.04 AS base
-ARG PYTHONPATH
 ENV PYTHONDONTWRITEBYTECODE=1 \
     PYTHONUNBUFFERED=1 \
-    PYTHONPATH=${PYTHONPATH}
-# Cache packages with run cache, set up nonroot user
-# Update system packages, install python3
-RUN --mount=type=cache,target=/var/cache/apt,sharing=locked --mount=type=cache,target=/var/lib/apt,sharing=locked \
-    rm -f /etc/apt/apt.conf.d/docker-clean && \
-    echo 'Binary::apt::APT::Keep-Downloaded-Packages "true";' > /etc/apt/apt.conf.d/keep-cache && \
-    groupadd -g 65532 nonroot && \
-    useradd nonroot -u 65532 -g 65532 -M && \
-    apt-get update && \
-    apt-get install -y --no-install-recommends curl python3 && \
-    apt-get dist-upgrade -y
+    VIRTUAL_ENV=/venv \
+    PATH="/venv/bin:$PATH"
+
+WORKDIR /build
+
+# Create virtual environment and upgrade packaging tooling
+RUN python -m venv ${VIRTUAL_ENV} && \
+    pip install --upgrade pip setuptools wheel
+
+# Install Python dependencies with pip cache
+COPY requirements.txt .
+RUN --mount=type=cache,target=/root/.cache/pip \
+    pip install --no-compile -r requirements.txt
+
+
+FROM python:3.12.13-slim-trixie AS base
+ARG UID
+ARG GID
+
+ENV PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1 \
+    VIRTUAL_ENV=/venv \
+    PATH="/venv/bin:$PATH"
+
+# Create non-root runtime user
+RUN groupadd --gid ${GID} appuser && \
+    useradd --uid ${UID} --gid ${GID} -M --shell /usr/sbin/nologin appuser
 
 WORKDIR /app
-CMD ["python3", "/venv/bin/fastapi", "run", "bailo_artefactscan_api/main.py", "--port", "3311"]
 
 FROM aquasec/trivy:0.70.0 AS trivy
 
@@ -41,13 +45,18 @@ COPY --from=build /venv /venv
 COPY --from=trivy /usr/local/bin/trivy /usr/local/bin/trivy
 # Ensure app dir exists before mounting
 RUN mkdir -p /app/bailo_artefactscan_api
-CMD ["python3", "/venv/bin/fastapi", "dev", "bailo_artefactscan_api/main.py", "--host", "0.0.0.0", "--port", "3311"]
+
+CMD ["fastapi", "dev", "bailo_artefactscan_api/main.py", "--host", "0.0.0.0", "--port", "3311"]
 
 FROM base AS prod
+ARG UID
+ARG GID
 
-COPY --from=build --chown=65532:65532 /venv /venv
+COPY --from=build --chown=${UID}:${GID} /venv /venv
 COPY --from=trivy /usr/local/bin/trivy /usr/local/bin/trivy
 # Copy application files
-COPY --chown=65532:65532 ./bailo_artefactscan_api /app/bailo_artefactscan_api
+COPY --chown=${UID}:${GID} bailo_artefactscan_api /app/bailo_artefactscan_api
 # Run as non-root
-USER 65532
+USER ${UID}:${GID}
+
+CMD ["fastapi", "run", "bailo_artefactscan_api/main.py", "--port", "3311"]

--- a/lib/artefactscan_api/bailo_artefactscan_api/config.py
+++ b/lib/artefactscan_api/bailo_artefactscan_api/config.py
@@ -25,7 +25,7 @@ class Settings(BaseSettings):
         "\n"
         "Clients can upload files or image layers and retrieve structured scan results via a REST interface."
     )
-    app_version: str = "4.0.2"
+    app_version: str = "4.1.0"
     modelscan_settings: dict[str, Any] = DEFAULT_SETTINGS
     block_size: int = 1024
     maximum_filesize: int = 4 * 1024**3  # 4GB


### PR DESCRIPTION
Decrease artefactscan image size and modernise dockerfile. Contributes towards #3284

- Switch to [latest debian version trixie](https://www.debian.org/releases/)
- Replace `ubuntu:24.04` stage
- Remove extra `curl` dependency in favour of already installed Python `requests`
- Bump artefactscan version