### PR TITLE
Replace Debian bookworm with newer trixie

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.12-bookworm
+FROM python:3.12-trixie
 
 LABEL dev.containers.image.node.version="24" \
       dev.containers.image.python.version="3.12"

--- a/Dockerfile.standalone
+++ b/Dockerfile.standalone
@@ -14,7 +14,7 @@
 #       docker run --rm -p 4318:8080 --network dev_internal --name second-bailo second-bailo:latest
 #       Access UI at http://localhost:4318/
 
-FROM python:3.14-bookworm AS sphinx-docs
+FROM python:3.14-trixie AS sphinx-docs
 ENV PYTHONDONTWRITEBYTECODE=1 \
     PYTHONUNBUFFERED=1
 RUN --mount=type=cache,target=/var/cache/apt,sharing=locked --mount=type=cache,target=/var/lib/apt \

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1
 
-FROM python:3.14.2-bookworm AS sphinx-docs
+FROM python:3.14.2-trixie AS sphinx-docs
 
 # Prevents Python from writing pyc files, and from buffering stdout and stderr to avoid situations where the application crashes without emitting any logs due to buffering.
 ENV PYTHONDONTWRITEBYTECODE=1 \


### PR DESCRIPTION
As per #3576, switch to [latest debian version trixie](https://www.debian.org/releases/).