### PR TITLE
Fix bad file typing

### DIFF
--- a/backend/src/connectors/audit/Base.ts
+++ b/backend/src/connectors/audit/Base.ts
@@ -1,7 +1,7 @@
 import { Request } from 'express'
 
 import { AccessRequestDoc } from '../../models/AccessRequest.js'
-import { FileInterface, FileWithScanResultsInterface } from '../../models/File.js'
+import { FileInterface, FileWithScanResultsAggregate } from '../../models/File.js'
 import { InferenceDoc } from '../../models/Inference.js'
 import { ModelCardInterface, ModelDoc, ModelInterface } from '../../models/Model.js'
 import { ImageTagRef, ReleaseDoc } from '../../models/Release.js'
@@ -436,7 +436,7 @@ export abstract class BaseAuditConnector {
   abstract onViewFile(req: Request, file: FileInterface): Promise<void>
   abstract onViewFiles(req: Request, modelId: string, files: FileInterface[]): Promise<void>
   abstract onUpdateFile(req: Request, modelId: string, fileId: string): Promise<void>
-  abstract onDeleteFile(req: Request, file: FileWithScanResultsInterface): Promise<void>
+  abstract onDeleteFile(req: Request, file: FileWithScanResultsAggregate): Promise<void>
 
   abstract onCreateRelease(req: Request, release: ReleaseDoc): Promise<void>
   abstract onViewRelease(req: Request, release: ReleaseDoc): Promise<void>

--- a/backend/src/connectors/audit/silly.ts
+++ b/backend/src/connectors/audit/silly.ts
@@ -1,7 +1,7 @@
 import { Request } from 'express'
 
 import { AccessRequestDoc } from '../../models/AccessRequest.js'
-import { FileInterface, FileInterfaceDoc, FileWithScanResultsInterface } from '../../models/File.js'
+import { FileInterface, FileInterfaceDoc, FileWithScanResultsAggregate } from '../../models/File.js'
 import { InferenceDoc } from '../../models/Inference.js'
 import { ModelCardInterface, ModelDoc, ModelInterface } from '../../models/Model.js'
 import { ImageTagRef, ReleaseDoc } from '../../models/Release.js'
@@ -33,7 +33,7 @@ export class SillyAuditConnector extends BaseAuditConnector {
   async onViewFile(_req: Request, _file: FileInterfaceDoc) {}
   async onViewFiles(_req: Request, _modelId: string, _files: FileInterface[]) {}
   async onUpdateFile(_req: Request, _modelId: string, _fileId: string) {}
-  async onDeleteFile(_req: Request, _file: FileWithScanResultsInterface) {}
+  async onDeleteFile(_req: Request, _file: FileWithScanResultsAggregate) {}
   async onCreateRelease(_req: Request, _release: ReleaseDoc) {}
   async onViewRelease(_req: Request, _release: ReleaseDoc) {}
   async onViewReleases(_req: Request, _releases: ReleaseDoc[]) {}

--- a/backend/src/connectors/audit/stdout.ts
+++ b/backend/src/connectors/audit/stdout.ts
@@ -1,7 +1,7 @@
 import { Request } from 'express'
 
 import { AccessRequestDoc } from '../../models/AccessRequest.js'
-import { FileInterface, FileInterfaceDoc, FileWithScanResultsInterface } from '../../models/File.js'
+import { FileInterface, FileInterfaceDoc, FileWithScanResultsAggregate } from '../../models/File.js'
 import { InferenceDoc } from '../../models/Inference.js'
 import { ModelCardInterface, ModelDoc, ModelInterface } from '../../models/Model.js'
 import { ImageTagRef, ReleaseDoc } from '../../models/Release.js'
@@ -108,7 +108,7 @@ export class StdoutAuditConnector extends BaseAuditConnector {
     req.log.info(event, req.audit.description)
   }
 
-  async onDeleteFile(req: Request, file: FileWithScanResultsInterface) {
+  async onDeleteFile(req: Request, file: FileWithScanResultsAggregate) {
     this.checkEventType(AuditInfo.DeleteFile, req)
     const event = this.generateEvent(req, file)
     req.log.info(event, req.audit.description)

--- a/backend/src/connectors/audit/stroom.ts
+++ b/backend/src/connectors/audit/stroom.ts
@@ -4,7 +4,7 @@ import os from 'os'
 import { ParsedQs } from 'qs'
 
 import { AccessRequestDoc } from '../../models/AccessRequest.js'
-import { FileInterface, FileInterfaceDoc, FileWithScanResultsInterface } from '../../models/File.js'
+import { FileInterface, FileInterfaceDoc, FileWithScanResultsAggregate } from '../../models/File.js'
 import { InferenceDoc } from '../../models/Inference.js'
 import { ModelCardInterface, ModelDoc, ModelInterface } from '../../models/Model.js'
 import { ImageTagRef, ReleaseDoc } from '../../models/Release.js'
@@ -252,7 +252,7 @@ export class StroomAuditConnector extends BaseAuditConnector {
     this.auditGenericEvent(req, `${modelId} - ${fileId}`)
   }
 
-  async onDeleteFile(req: Request, file: FileWithScanResultsInterface) {
+  async onDeleteFile(req: Request, file: FileWithScanResultsAggregate) {
     this.auditFileEvent(req, [file])
   }
 

--- a/backend/src/models/File.ts
+++ b/backend/src/models/File.ts
@@ -1,6 +1,6 @@
 import { HydratedDocument, model, ObjectId, Schema } from 'mongoose'
 
-import { SoftDeleteDocument, softDeletionPlugin } from './plugins/softDeletePlugin.js'
+import { SoftDeleteDocument, SoftDeleteInterface, softDeletionPlugin } from './plugins/softDeletePlugin.js'
 import { ScanInterface } from './Scan.js'
 
 // This interface stores information about the properties on the base object.
@@ -29,6 +29,10 @@ export interface FileInterface {
 // object from Mongoose it should use this interface
 export type FileInterfaceDoc = HydratedDocument<FileInterface> & SoftDeleteDocument
 // `id` is used by the python API so we need to keep this to prevent a breaking change
+export type FileWithScanResultsAggregate = FileInterface & {
+  id: string
+  scanResults: ScanInterface[]
+} & SoftDeleteInterface
 export type FileWithScanResultsInterface = FileInterfaceDoc & { scanResults: ScanInterface[] }
 
 const FileSchema = new Schema<FileInterfaceDoc>(

--- a/backend/src/routes/v2/model/file/getDownloadFile.ts
+++ b/backend/src/routes/v2/model/file/getDownloadFile.ts
@@ -7,7 +7,7 @@ import { Request, Response } from 'express'
 import { AuditInfo } from '../../../../connectors/audit/Base.js'
 import audit from '../../../../connectors/audit/index.js'
 import { z } from '../../../../lib/zod.js'
-import { type FileWithScanResultsInterface } from '../../../../models/File.js'
+import { type FileWithScanResultsAggregate } from '../../../../models/File.js'
 import { downloadFile, getFileById } from '../../../../services/file.js'
 import log from '../../../../services/log.js'
 import { getFileByReleaseFileName } from '../../../../services/release.js'
@@ -116,7 +116,7 @@ export const getDownloadFile = [
   async (req: Request, res: Response): Promise<void> => {
     req.audit = AuditInfo.ViewFile
     const { params } = parse(req, getDownloadFileSchema)
-    let file: FileWithScanResultsInterface
+    let file: FileWithScanResultsAggregate
     if ('semver' in params) {
       file = await getFileByReleaseFileName(req.user, params.modelId, params.semver, params.fileName)
     } else {

--- a/backend/src/routes/v2/model/file/getFiles.ts
+++ b/backend/src/routes/v2/model/file/getFiles.ts
@@ -3,7 +3,7 @@ import { Request, Response } from 'express'
 import { AuditInfo } from '../../../../connectors/audit/Base.js'
 import audit from '../../../../connectors/audit/index.js'
 import { z } from '../../../../lib/zod.js'
-import { FileWithScanResultsInterface } from '../../../../models/File.js'
+import { FileWithScanResultsAggregate } from '../../../../models/File.js'
 import { getFilesByModel } from '../../../../services/file.js'
 import { fileWithScanInterfaceSchema, registerPath } from '../../../../services/specification.js'
 import { parse } from '../../../../utils/validate.js'
@@ -37,7 +37,7 @@ registerPath({
 })
 
 interface GetFilesResponse {
-  files: Array<FileWithScanResultsInterface>
+  files: Array<FileWithScanResultsAggregate>
 }
 
 export const getFiles = [

--- a/backend/src/routes/v2/release/getRelease.ts
+++ b/backend/src/routes/v2/release/getRelease.ts
@@ -3,7 +3,7 @@ import { Request, Response } from 'express'
 import { AuditInfo } from '../../../connectors/audit/Base.js'
 import audit from '../../../connectors/audit/index.js'
 import { z } from '../../../lib/zod.js'
-import { FileWithScanResultsInterface } from '../../../models/File.js'
+import { FileWithScanResultsAggregate } from '../../../models/File.js'
 import { ReleaseInterface } from '../../../models/Release.js'
 import { ResponseKind } from '../../../models/Response.js'
 import { getFilesByIds } from '../../../services/file.js'
@@ -39,7 +39,7 @@ registerPath({
 })
 
 interface getReleaseResponse {
-  release: ReleaseInterface & { files: FileWithScanResultsInterface[] }
+  release: ReleaseInterface & { files: FileWithScanResultsAggregate[] }
 }
 
 export const getRelease = [

--- a/backend/src/services/file.ts
+++ b/backend/src/services/file.ts
@@ -14,7 +14,7 @@ import {
 } from '../clients/s3.js'
 import { FileAction } from '../connectors/authorisation/actions.js'
 import authorisation from '../connectors/authorisation/index.js'
-import FileModel, { FileInterface, FileInterfaceDoc, FileWithScanResultsInterface } from '../models/File.js'
+import FileModel, { FileInterface, FileInterfaceDoc, FileWithScanResultsAggregate } from '../models/File.js'
 import { EntryKind, ModelDoc } from '../models/Model.js'
 import ScanModel from '../models/Scan.js'
 import { UserInterface } from '../models/User.js'
@@ -239,8 +239,8 @@ export async function getFileById(
   user: UserInterface,
   fileId: string,
   model?: ModelDoc,
-): Promise<FileWithScanResultsInterface> {
-  const files: FileWithScanResultsInterface[] = await FileModel.aggregate([
+): Promise<FileWithScanResultsAggregate> {
+  const files = await FileModel.aggregate<FileWithScanResultsAggregate>([
     { $match: { _id: new Types.ObjectId(fileId) } },
     { $limit: 1 },
     { $addFields: { id: { $toString: '$_id' } } },
@@ -257,7 +257,7 @@ export async function getFileById(
   if (!files || files.length === 0) {
     throw NotFound(`The requested file was not found.`, { fileId })
   }
-  const file: FileWithScanResultsInterface = { ...files[0], id: files[0].id }
+  const file: FileWithScanResultsAggregate = { ...files[0], id: files[0].id }
 
   if (!model) {
     model = await getModelById(user, file.modelId)
@@ -272,7 +272,7 @@ export async function getFileById(
 
 export async function getFilesByModel(user: UserInterface, modelId: string) {
   const model = await getModelById(user, modelId)
-  const files: FileWithScanResultsInterface[] = await FileModel.aggregate([
+  const files = await FileModel.aggregate<FileWithScanResultsAggregate>([
     { $match: { modelId } },
     { $addFields: { id: { $toString: '$_id' } } },
     {
@@ -293,12 +293,12 @@ export async function getFilesByIds(
   user: UserInterface,
   modelId: string,
   fileIds: string[],
-): Promise<FileWithScanResultsInterface[]> {
+): Promise<FileWithScanResultsAggregate[]> {
   const model = await getModelById(user, modelId)
   if (fileIds.length === 0) {
     return []
   }
-  const files: FileWithScanResultsInterface[] = await FileModel.aggregate([
+  const files = await FileModel.aggregate<FileWithScanResultsAggregate>([
     { $match: { _id: { $in: fileIds } } },
     { $addFields: { id: { $toString: '$_id' } } },
     {
@@ -332,7 +332,7 @@ export async function removeFiles(
   if (EntryKind.MirroredModel === model.kind && !deleteMirroredModel) {
     throw BadReq('Cannot remove file from a mirrored model.')
   }
-  const allFiles: FileWithScanResultsInterface[] = []
+  const allFiles: FileWithScanResultsAggregate[] = []
 
   for (const fileId of fileIds) {
     const file = await getFileById(user, fileId)
@@ -400,7 +400,7 @@ export async function updateFile(
   fileId: string,
   patchFileParams: Partial<Pick<FileInterface, 'tags' | 'name' | 'mime'>>,
 ) {
-  let file: FileWithScanResultsInterface
+  let file: FileWithScanResultsAggregate
   try {
     file = await getFileById(user, fileId)
   } catch {
@@ -424,7 +424,7 @@ export async function updateFile(
     throw BadReq('There was a problem updating the file', { modelId, fileId, patchFileParams })
   }
 
-  // return the full FileWithScanResultsInterface and not just the FileInterface
+  // return the full FileWithScanResultsAggregate and not just the FileInterface
   file = await getFileById(user, fileId)
 
   return file

--- a/backend/src/services/mirroredModel/entityParsers.ts
+++ b/backend/src/services/mirroredModel/entityParsers.ts
@@ -3,7 +3,8 @@ import { ModelCardRevisionDoc } from '../../models/ModelCardRevision.js'
 import { ReleaseDoc } from '../../models/Release.js'
 import { MirrorImportLogData } from '../../types/types.js'
 import { InternalError } from '../../utils/error.js'
-import { createFilePath, isFileInterfaceDoc } from '../../utils/fileUtils.js'
+import { createFilePath, isFileWithScanResultsInterface } from '../../utils/fileUtils.js'
+import log from '../log.js'
 import { isModelCardRevisionDoc } from '../model.js'
 import { isReleaseDoc } from '../release.js'
 
@@ -80,11 +81,12 @@ export async function parseFile(
   sourceModelId: string,
   logData: MirrorImportLogData,
 ) {
-  if (!isFileInterfaceDoc(file)) {
+  log.info({ file })
+  if (!isFileWithScanResultsInterface(file)) {
     throw InternalError('Data cannot be converted into a file.', { file, mirroredModelId, sourceModelId, ...logData })
   }
 
-  file.path = createFilePath(mirroredModelId, file.id)
+  file.path = createFilePath(mirroredModelId, file._id.toString())
 
   try {
     file.complete = await objectExists(file.path)

--- a/backend/src/services/mirroredModel/exporters/documents.ts
+++ b/backend/src/services/mirroredModel/exporters/documents.ts
@@ -2,7 +2,7 @@ import prettyBytes from 'pretty-bytes'
 
 import { ArtefactScanState } from '../../../connectors/artefactScanning/Base.js'
 import scanners from '../../../connectors/artefactScanning/index.js'
-import { FileWithScanResultsInterface } from '../../../models/File.js'
+import { FileWithScanResultsAggregate } from '../../../models/File.js'
 import { ModelDoc } from '../../../models/Model.js'
 import { ReleaseDoc } from '../../../models/Release.js'
 import { UserInterface } from '../../../models/User.js'
@@ -18,7 +18,7 @@ import { BaseExporter, checkAuths, requiresInit, withStreams } from './base.js'
 
 export class DocumentsExporter extends BaseExporter {
   protected readonly releases: ReleaseDoc[]
-  protected files: FileWithScanResultsInterface[] | undefined
+  protected files: FileWithScanResultsAggregate[] | undefined
 
   constructor(user: UserInterface, model: ModelDoc, releases: ReleaseDoc[], logData: MirrorExportLogData) {
     super(user, model, logData)
@@ -178,7 +178,7 @@ export class DocumentsExporter extends BaseExporter {
   @withStreams
   protected async addReleaseToTarball(release: ReleaseDoc) {
     log.debug({ semver: release.semver, ...this.logData }, 'Adding release to tarball file of releases.')
-    const files: FileWithScanResultsInterface[] = await getFilesByIds(this.user, release.modelId, release.fileIds)
+    const files: FileWithScanResultsAggregate[] = await getFilesByIds(this.user, release.modelId, release.fileIds)
 
     try {
       const releaseJson = JSON.stringify(release.toJSON())
@@ -205,7 +205,7 @@ export class DocumentsExporter extends BaseExporter {
   @requiresInit
   @checkAuths
   @withStreams
-  protected async addFilesToTarball(files: FileWithScanResultsInterface[]) {
+  protected async addFilesToTarball(files: FileWithScanResultsAggregate[]) {
     for (const file of files) {
       try {
         const fileJson = JSON.stringify(file)

--- a/backend/src/services/mirroredModel/exporters/file.ts
+++ b/backend/src/services/mirroredModel/exporters/file.ts
@@ -2,7 +2,7 @@ import { ArtefactScanState } from '../../../connectors/artefactScanning/Base.js'
 import scanners from '../../../connectors/artefactScanning/index.js'
 import { FileAction } from '../../../connectors/authorisation/actions.js'
 import authorisation from '../../../connectors/authorisation/index.js'
-import { FileWithScanResultsInterface } from '../../../models/File.js'
+import { FileWithScanResultsAggregate } from '../../../models/File.js'
 import { ModelDoc } from '../../../models/Model.js'
 import { UserInterface } from '../../../models/User.js'
 import { MirrorExportLogData, MirrorKind } from '../../../types/types.js'
@@ -13,9 +13,9 @@ import { addEntryToTarGzUpload, initialiseTarGzUpload } from '../tarball.js'
 import { BaseExporter } from './base.js'
 
 export class FileExporter extends BaseExporter {
-  protected readonly file: FileWithScanResultsInterface
+  protected readonly file: FileWithScanResultsAggregate
 
-  constructor(user: UserInterface, model: ModelDoc, file: FileWithScanResultsInterface, logData: MirrorExportLogData) {
+  constructor(user: UserInterface, model: ModelDoc, file: FileWithScanResultsAggregate, logData: MirrorExportLogData) {
     super(user, model, logData)
     this.file = file
   }

--- a/backend/src/services/release.ts
+++ b/backend/src/services/release.ts
@@ -4,7 +4,7 @@ import { Optional } from 'utility-types'
 
 import { ReleaseAction } from '../connectors/authorisation/actions.js'
 import authorisation from '../connectors/authorisation/index.js'
-import { FileWithScanResultsInterface } from '../models/File.js'
+import { FileWithScanResultsAggregate, FileWithScanResultsInterface } from '../models/File.js'
 import { EntryKind, ModelDoc, ModelInterface } from '../models/Model.js'
 import ReleaseModel, { ImageTagRef, ReleaseDoc, ReleaseInterface, SemverObject } from '../models/Release.js'
 import ResponseModel, { ResponseKind } from '../models/Response.js'
@@ -82,7 +82,7 @@ export async function validateRelease(user: UserInterface, model: ModelDoc, rele
     const fileNames: Array<string> = []
 
     for (const fileId of release.fileIds) {
-      let file: FileWithScanResultsInterface | undefined
+      let file: FileWithScanResultsAggregate | undefined
       try {
         file = await getFileById(user, fileId)
       } catch (e) {

--- a/backend/src/utils/fileUtils.ts
+++ b/backend/src/utils/fileUtils.ts
@@ -1,26 +1,32 @@
-import { FileInterfaceDoc } from '../models/File.js'
-import { isHydratedMongoDoc } from './mongo.js'
+import { isValidObjectId } from 'mongoose'
 
-export function isFileInterfaceDoc(data: unknown): data is FileInterfaceDoc {
+import { FileWithScanResultsInterface } from '../models/File.js'
+
+export function isFileWithScanResultsInterface(data: unknown): data is FileWithScanResultsInterface {
   if (typeof data !== 'object' || data === null) {
     return false
   }
 
   if (
+    !('_id' in data) ||
     !('modelId' in data) ||
     !('name' in data) ||
     !('size' in data) ||
     !('mime' in data) ||
     !('path' in data) ||
     !('complete' in data) ||
-    !('deleted' in data) ||
+    !('tags' in data) ||
     !('createdAt' in data) ||
     !('updatedAt' in data) ||
-    !('_id' in data)
+    !('id' in data) ||
+    !('scanResults' in data) ||
+    !('deleted' in data) ||
+    !('deletedAt' in data) ||
+    !('deletedBy' in data)
   ) {
     return false
   }
-  return isHydratedMongoDoc(data)
+  return isValidObjectId(data._id)
 }
 
 export const createFilePath = (modelId: string, fileId: string) => {

--- a/backend/src/utils/mongo.ts
+++ b/backend/src/utils/mongo.ts
@@ -1,5 +1,4 @@
 import { MongoServerError } from 'mongodb'
-import { HydratedDocument, isValidObjectId } from 'mongoose'
 
 import { BadReq } from './error.js'
 
@@ -13,21 +12,6 @@ export function isMongoServerError(err: unknown): err is MongoServerError {
   }
 
   return false
-}
-
-export function isHydratedMongoDoc<T>(value: unknown): value is HydratedDocument<T> {
-  if (typeof value !== 'object' || value === null) {
-    return false
-  }
-
-  const doc = value as any
-
-  return (
-    typeof doc.$isNew === 'boolean' &&
-    typeof doc.$get === 'function' &&
-    typeof doc.toObject === 'function' &&
-    isValidObjectId(doc._id)
-  )
 }
 
 export function handleDuplicateKeys(error: unknown) {

--- a/backend/test/services/mirroredModel/entityParsers.spec.ts
+++ b/backend/test/services/mirroredModel/entityParsers.spec.ts
@@ -8,7 +8,7 @@ const s3Mocks = vi.hoisted(() => ({
 vi.mock('../../../src/clients/s3.js', () => s3Mocks)
 
 const fileUtilsMocks = vi.hoisted(() => ({
-  isFileInterfaceDoc: vi.fn(() => true),
+  isFileWithScanResultsInterface: vi.fn(() => true),
   createFilePath: vi.fn(() => 'beta/model/modelId/files/fileId'),
 }))
 vi.mock('../../../src/utils/fileUtils.js', () => fileUtilsMocks)
@@ -135,7 +135,7 @@ describe('services > parsers > modelParser', () => {
   })
 
   test('parseFile > data not a file', async () => {
-    fileUtilsMocks.isFileInterfaceDoc.mockReturnValueOnce(false)
+    fileUtilsMocks.isFileWithScanResultsInterface.mockReturnValueOnce(false)
     await expect(() => parseFile({}, '', '', mockLogData)).rejects.toThrow('Data cannot be converted into a file.')
   })
 

--- a/backend/test/utils/fileUtils.spec.ts
+++ b/backend/test/utils/fileUtils.spec.ts
@@ -1,10 +1,11 @@
 import { describe, expect, test, vi } from 'vitest'
 
-import { createFilePath, isFileInterfaceDoc } from '../../src/utils/fileUtils.js'
+import { createFilePath, isFileWithScanResultsInterface } from '../../src/utils/fileUtils.js'
 
-vi.mock('../../src/utils/mongo.js', () => ({
-  isHydratedMongoDoc: vi.fn(() => true),
+const mongooseMocks = vi.hoisted(() => ({
+  isValidObjectId: vi.fn(() => true),
 }))
+vi.mock('mongoose', () => mongooseMocks)
 
 describe('utils > array', () => {
   test('createFilePath', () => {
@@ -12,8 +13,9 @@ describe('utils > array', () => {
     expect(createFilePath('', '')).toStrictEqual(`beta/model//files/`)
   })
 
-  test('isFileInterfaceDoc > success', async () => {
-    const result = isFileInterfaceDoc({
+  test('isFileWithScanResultsInterface > success', async () => {
+    const result = isFileWithScanResultsInterface({
+      _id: '',
       modelId: '',
       name: '',
       size: 1,
@@ -21,17 +23,21 @@ describe('utils > array', () => {
       bucket: '',
       path: '',
       complete: true,
-      deleted: false,
+      tags: [],
       createdAt: '',
       updatedAt: '',
-      _id: '',
+      id: '',
+      scanResults: [],
+      deleted: false,
+      deletedAt: '',
+      deletedBy: '',
     })
 
     expect(result).toBe(true)
   })
 
-  test('isFileInterfaceDoc > missing property', async () => {
-    const result = isFileInterfaceDoc({
+  test('isFileWithScanResultsInterface > missing property', async () => {
+    const result = isFileWithScanResultsInterface({
       modelId: '',
       name: '',
       mime: '',
@@ -46,8 +52,8 @@ describe('utils > array', () => {
     expect(result).toBe(false)
   })
 
-  test('isFileInterfaceDoc > wrong type', async () => {
-    const result = isFileInterfaceDoc(null)
+  test('isFileWithScanResultsInterface > wrong type', async () => {
+    const result = isFileWithScanResultsInterface(null)
 
     expect(result).toBe(false)
   })

--- a/backend/test/utils/mongo.spec.ts
+++ b/backend/test/utils/mongo.spec.ts
@@ -1,7 +1,7 @@
 import { MongoServerError } from 'mongodb'
 import { describe, expect, test, vi } from 'vitest'
 
-import { isHydratedMongoDoc, isMongoServerError } from '../../src/utils/mongo.js'
+import { isMongoServerError } from '../../src/utils/mongo.js'
 
 const mongooseMocks = vi.hoisted(() => ({
   isValidObjectId: vi.fn(() => true),
@@ -28,39 +28,6 @@ describe('utils > mongo', () => {
     test('returns false for an error that is not an object', async () => {
       const result = isMongoServerError(null)
       expect(result).toBe(false)
-    })
-  })
-
-  describe('isHydratedMongoDoc', () => {
-    test('success', () => {
-      expect(
-        isHydratedMongoDoc({
-          $isNew: true,
-          $get: vi.fn(),
-          toObject: vi.fn(),
-          _id: '_id',
-        }),
-      ).toBe(true)
-    })
-
-    test('fail > missing properties', () => {
-      expect(isHydratedMongoDoc({})).toBe(false)
-    })
-
-    test('fail > not an object', () => {
-      expect(isHydratedMongoDoc('true')).toBe(false)
-    })
-
-    test('fail > not isValidObjectId', () => {
-      mongooseMocks.isValidObjectId.mockReturnValueOnce(false)
-      expect(
-        isHydratedMongoDoc({
-          $isNew: true,
-          $get: vi.fn(),
-          toObject: vi.fn(),
-          _id: '_id',
-        }),
-      ).toBe(false)
     })
   })
 })


### PR DESCRIPTION
Replace mongoose aggregates to correctly return a new type `FileWithScanResultsAggregate` rather than `FileWithScanResultsInterface`. Removes no-longer-used `isHydratedMongoDoc` function.