### PR TITLE
Hotfix/remove/content length header

### DIFF
--- a/backend/src/clients/registry.ts
+++ b/backend/src/clients/registry.ts
@@ -422,7 +422,6 @@ export async function uploadLayerMonolithic(
   uploadURL: string,
   digest: string,
   blob: Readable | ReadableStream,
-  size: string,
 ) {
   const result = await registryRequest(token, `${uploadURL}&digest=${digest}`.replace(/^(\/v2\/)/, ''), {
     headersSchema: BlobUploadResponseHeadersSchema,
@@ -435,7 +434,6 @@ export async function uploadLayerMonolithic(
       redirect: 'error',
     },
     extraHeaders: {
-      'content-length': size,
       'content-type': 'application/octet-stream',
     },
   })
@@ -457,7 +455,6 @@ export async function mountBlob(
       extraFetchOptions: {
         method: 'POST',
       },
-      extraHeaders: { 'Content-Length': '0' },
     },
   )
 

--- a/backend/src/services/mirroredModel/importers/image.ts
+++ b/backend/src/services/mirroredModel/importers/image.ts
@@ -131,7 +131,7 @@ export class ImageImporter extends BaseImporter {
               },
               'Putting image blob.',
             )
-            await uploadLayerMonolithic(repositoryPushPullToken, res.location!, layerDigest, stream, String(entry.size))
+            await uploadLayerMonolithic(repositoryPushPullToken, res.location!, layerDigest, stream)
             await finished(stream)
           }
         } catch (err) {

--- a/backend/test/clients/__snapshots__/registry.spec.ts.snap
+++ b/backend/test/clients/__snapshots__/registry.spec.ts.snap
@@ -379,7 +379,6 @@ exports[`clients > registry > mountBlob > success 1`] = `
       "dispatcher": "mock agent",
       "headers": {
         "Authorization": "Bearer token",
-        "Content-Length": "0",
       },
       "method": "POST",
       "signal": {
@@ -450,7 +449,6 @@ exports[`clients > registry > uploadLayerMonolithic > success 1`] = `
       "duplex": "half",
       "headers": {
         "Authorization": "Bearer token",
-        "content-length": "size",
         "content-type": "application/octet-stream",
       },
       "method": "PUT",

--- a/backend/test/services/mirroredModel/importers/image.spec.ts
+++ b/backend/test/services/mirroredModel/importers/image.spec.ts
@@ -134,7 +134,6 @@ describe('connectors > mirroredModel > importers > ImageImporter', () => {
     const entry: Headers = {
       name: 'content-dir/blobs/sha256/' + 'b'.repeat(64),
       type: 'file',
-      size: 20,
     } as Headers
     const stream = new PassThrough()
 
@@ -144,9 +143,8 @@ describe('connectors > mirroredModel > importers > ImageImporter', () => {
     expect(registryClientMocks.uploadLayerMonolithic).toHaveBeenCalledWith(
       undefined,
       'upload-location',
-      expect.stringContaining('sha256:'),
+      'sha256:' + 'b'.repeat(64),
       stream,
-      String(entry.size),
     )
   })
 


### PR DESCRIPTION
Undici 7 has enforced this rule https://developer.mozilla.org/en-US/docs/Glossary/Forbidden_request_header causing registry cross blob mounting to fail