### PR TITLE
Fix bad `renameMultiManifest` logic

### DIFF
--- a/backend/src/services/registry.ts
+++ b/backend/src/services/registry.ts
@@ -330,9 +330,9 @@ async function getTagDigestReferenceMap(
         refs.add(rootDigest)
       }
       if (body && 'manifests' in body) {
-        for (const m of body.manifests) {
-          if (m.digest) {
-            refs.add(m.digest)
+        for (const manifest of body.manifests) {
+          if (manifest.digest) {
+            refs.add(manifest.digest)
           }
         }
       }
@@ -429,8 +429,8 @@ async function renameMultiManifest(
   allRefsMap.delete(source.tag)
   const otherRefs = new Set<string>()
   for (const refs of allRefsMap.values()) {
-    for (const d of refs) {
-      otherRefs.add(d)
+    for (const digest of refs) {
+      otherRefs.add(digest)
     }
   }
   const listIsOrphaned = !otherRefs.has(sourceDigest)

--- a/backend/src/services/registry.ts
+++ b/backend/src/services/registry.ts
@@ -304,8 +304,12 @@ export async function getImageBlob(user: UserInterface, repoRef: ImageNameRef, d
   return await getRegistryLayerStream(repositoryToken, repoRef, digest)
 }
 
-async function getTagDigestMap(token: string, repository: string, name: string): Promise<Map<string, string>> {
-  const map = new Map<string, string>()
+async function getTagDigestReferenceMap(
+  token: string,
+  repository: string,
+  name: string,
+): Promise<Map<string, Set<string>>> {
+  const map = new Map<string, Set<string>>()
 
   let tags: string[]
   try {
@@ -317,18 +321,24 @@ async function getTagDigestMap(token: string, repository: string, name: string):
     return map
   }
 
-  const results = await Promise.all(
+  await Promise.all(
     tags.map(async (tag) => {
-      const { headers } = await getImageTagManifests(token, { repository, name, tag })
-      return { tag, digest: headers['docker-content-digest'] }
+      const refs = new Set<string>()
+      const { body, headers } = await getImageTagManifests(token, { repository, name, tag })
+      const rootDigest = headers['docker-content-digest']
+      if (rootDigest) {
+        refs.add(rootDigest)
+      }
+      if (body && 'manifests' in body) {
+        for (const m of body.manifests) {
+          if (m.digest) {
+            refs.add(m.digest)
+          }
+        }
+      }
+      map.set(tag, refs)
     }),
   )
-
-  for (const { tag, digest } of results) {
-    if (digest) {
-      map.set(tag, digest)
-    }
-  }
 
   return map
 }
@@ -415,9 +425,15 @@ async function renameMultiManifest(
   multiRepositoryToken: string,
   sourceDigest: string,
 ) {
-  const sourceTagDigestMap = await getTagDigestMap(multiRepositoryToken, source.repository, source.name)
-  const sourceDigestSet = new Set(sourceTagDigestMap.values())
-  const listIsOrphaned = !sourceDigestSet.has(sourceDigest)
+  const allRefsMap = await getTagDigestReferenceMap(multiRepositoryToken, source.repository, source.name)
+  allRefsMap.delete(source.tag)
+  const otherRefs = new Set<string>()
+  for (const refs of allRefsMap.values()) {
+    for (const d of refs) {
+      otherRefs.add(d)
+    }
+  }
+  const listIsOrphaned = !otherRefs.has(sourceDigest)
 
   const tmpTags: string[] = []
   const updatedManifestBody = structuredClone(manifestBody)
@@ -467,14 +483,25 @@ async function renameMultiManifest(
         throw InternalError('Child manifest digest missing after PUT', { tmpTag })
       }
 
-      const platformIsOrphaned = !Array.from(sourceTagDigestMap.values()).some((digest) => digest === manifest.digest)
+      // Only delete the child platform manifest if no other tag references it
+      // (either as a root digest or as a child platform digest)
+      const platformIsOrphaned = !otherRefs.has(manifest.digest)
 
       if (platformIsOrphaned) {
+        log.trace(
+          { source, childDigest: manifest.digest },
+          'Child platform manifest is orphaned; deleting from source repository.',
+        )
         await deleteManifest(multiRepositoryToken, {
           repository: source.repository,
           name: source.name,
           digest: manifest.digest,
         })
+      } else {
+        log.trace(
+          { source, childDigest: manifest.digest },
+          'Child platform manifest is still referenced by another tag; preserving.',
+        )
       }
 
       // overwrite digest to point to new child manifest

--- a/backend/test/services/registry.spec.ts
+++ b/backend/test/services/registry.spec.ts
@@ -609,6 +609,320 @@ describe('services > registry', () => {
       await expect(renameImage({} as any, source, dest)).rejects.toThrow('Child manifest digest missing after PUT')
     })
 
+    test('renameImage > multi manifest shared child digests preserved when another tag references them', async () => {
+      const manifestList = {
+        mediaType: 'application/vnd.docker.distribution.manifest.list.v2+json',
+        manifests: [
+          { digest: 'sha256:childAmd64', platform: { architecture: 'amd64', os: 'linux' } },
+          { digest: 'sha256:childArm64', platform: { architecture: 'arm64', os: 'linux' } },
+        ],
+      }
+      const childManifest = {
+        config: { digest: 'sha256:config' },
+        layers: [{ digest: 'sha256:layer1' }],
+        mediaType: 'mediaType',
+      }
+      registryClientMocks.getImageTagManifests
+        // initial GET of source fat manifest
+        .mockResolvedValueOnce({ body: manifestList, headers: { 'docker-content-digest': 'sha256:rootDigest' } })
+        // getTagDigestReferenceMap GET for sibling tag "latest-2" (same fat manifest, same root digest)
+        .mockResolvedValueOnce({ body: manifestList, headers: { 'docker-content-digest': 'sha256:rootDigest' } })
+        // GET child amd64 platform manifest
+        .mockResolvedValueOnce({ body: childManifest, headers: {} })
+        // GET child arm64 platform manifest
+        .mockResolvedValueOnce({ body: childManifest, headers: {} })
+      // sibling tag still present in source repo
+      registryClientMocks.listImageTags.mockResolvedValueOnce(['latest-2'])
+      registryClientMocks.putManifest
+        .mockResolvedValueOnce({ 'docker-content-digest': 'sha256:newChildAmd64' })
+        .mockResolvedValueOnce({ 'docker-content-digest': 'sha256:newChildArm64' })
+        .mockResolvedValueOnce({ 'docker-content-digest': 'sha256:newRootDigest' })
+      const source = { repository: 'modelid-123', name: 'alpine', tag: 'latest' }
+      const destination = { repository: 'soft_deleted/modelid-123', name: 'alpine', tag: 'latest' }
+
+      await renameImage({} as any, source, destination)
+
+      // Only the source tag should be deleted, never the shared child digests nor the shared root digest
+      // Also deletes the 2 temporary tags
+      expect(registryClientMocks.deleteManifest).toHaveBeenCalledTimes(3)
+      expect(registryClientMocks.deleteManifest).toHaveBeenCalledWith('token', source)
+      expect(registryClientMocks.deleteManifest).toHaveBeenCalledWith('token', {
+        repository: destination.repository,
+        name: destination.name,
+        tag: expect.stringMatching(/^__bailo_tmp_[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}__$/),
+      })
+      // Specifically assert the extra deletes did not happen
+      expect(registryClientMocks.deleteManifest).not.toHaveBeenCalledWith('token', {
+        repository: source.repository,
+        name: source.name,
+        digest: 'sha256:childAmd64',
+      })
+      expect(registryClientMocks.deleteManifest).not.toHaveBeenCalledWith('token', {
+        repository: source.repository,
+        name: source.name,
+        digest: 'sha256:childArm64',
+      })
+      expect(registryClientMocks.deleteManifest).not.toHaveBeenCalledWith('token', {
+        repository: source.repository,
+        name: source.name,
+        digest: 'sha256:rootDigest',
+      })
+    })
+
+    test('renameImage > multi manifest orphaned child and root digests are deleted when no other tag references them', async () => {
+      const manifestList = {
+        mediaType: 'application/vnd.docker.distribution.manifest.list.v2+json',
+        manifests: [
+          { digest: 'sha256:childAmd64', platform: { architecture: 'amd64', os: 'linux' } },
+          { digest: 'sha256:childArm64', platform: { architecture: 'arm64', os: 'linux' } },
+        ],
+      }
+      const childManifest = {
+        config: { digest: 'sha256:config' },
+        layers: [{ digest: 'sha256:layer1' }],
+        mediaType: 'mediaType',
+      }
+      registryClientMocks.getImageTagManifests
+        .mockResolvedValueOnce({ body: manifestList, headers: { 'docker-content-digest': 'sha256:rootDigest' } })
+        .mockResolvedValueOnce({ body: childManifest, headers: {} })
+        .mockResolvedValueOnce({ body: childManifest, headers: {} })
+      // no other tags reference the fat manifest
+      registryClientMocks.listImageTags.mockResolvedValueOnce([])
+      registryClientMocks.putManifest
+        .mockResolvedValueOnce({ 'docker-content-digest': 'sha256:newChildAmd64' })
+        .mockResolvedValueOnce({ 'docker-content-digest': 'sha256:newChildArm64' })
+        .mockResolvedValueOnce({ 'docker-content-digest': 'sha256:newRootDigest' })
+
+      const source = { repository: 'modelid-123', name: 'alpine', tag: 'latest' }
+      const destination = { repository: 'soft_deleted/modelid-123', name: 'alpine', tag: 'latest' }
+
+      await renameImage({} as any, source, destination)
+
+      expect(registryClientMocks.deleteManifest).toHaveBeenCalledWith('token', {
+        repository: source.repository,
+        name: source.name,
+        digest: 'sha256:childAmd64',
+      })
+      expect(registryClientMocks.deleteManifest).toHaveBeenCalledWith('token', {
+        repository: source.repository,
+        name: source.name,
+        digest: 'sha256:childArm64',
+      })
+      expect(registryClientMocks.deleteManifest).toHaveBeenCalledWith('token', source)
+      expect(registryClientMocks.deleteManifest).toHaveBeenCalledWith('token', {
+        repository: source.repository,
+        name: source.name,
+        digest: 'sha256:rootDigest',
+      })
+    })
+
+    test('renameImage > multi manifest only deletes child digests not referenced by other tags', async () => {
+      const sourceManifestList = {
+        mediaType: 'application/vnd.docker.distribution.manifest.list.v2+json',
+        manifests: [
+          { digest: 'sha256:sharedAmd64', platform: { architecture: 'amd64', os: 'linux' } },
+          { digest: 'sha256:uniqueArm64', platform: { architecture: 'arm64', os: 'linux' } },
+        ],
+      }
+      const siblingManifestList = {
+        mediaType: 'application/vnd.docker.distribution.manifest.list.v2+json',
+        manifests: [
+          { digest: 'sha256:sharedAmd64', platform: { architecture: 'amd64', os: 'linux' } },
+          { digest: 'sha256:otherArm64', platform: { architecture: 'arm64', os: 'linux' } },
+        ],
+      }
+      const childManifest = {
+        config: { digest: 'sha256:config' },
+        layers: [{ digest: 'sha256:layer1' }],
+        mediaType: 'mediaType',
+      }
+      registryClientMocks.getImageTagManifests
+        // initial fetch of source fat manifest
+        .mockResolvedValueOnce({ body: sourceManifestList, headers: { 'docker-content-digest': 'sha256:sourceRoot' } })
+        // getTagDigestReferenceMap fetch for sibling tag
+        .mockResolvedValueOnce({
+          body: siblingManifestList,
+          headers: { 'docker-content-digest': 'sha256:siblingRoot' },
+        })
+        // GET shared amd64 child manifest
+        .mockResolvedValueOnce({ body: childManifest, headers: {} })
+        // GET unique arm64 child manifest
+        .mockResolvedValueOnce({ body: childManifest, headers: {} })
+      registryClientMocks.listImageTags.mockResolvedValueOnce(['sibling-tag'])
+      registryClientMocks.putManifest
+        .mockResolvedValueOnce({ 'docker-content-digest': 'sha256:newAmd64' })
+        .mockResolvedValueOnce({ 'docker-content-digest': 'sha256:newArm64' })
+        .mockResolvedValueOnce({ 'docker-content-digest': 'sha256:newRoot' })
+      const source = { repository: 'modelid-123', name: 'alpine', tag: 'latest' }
+      const destination = { repository: 'soft_deleted/modelid-123', name: 'alpine', tag: 'latest' }
+
+      await renameImage({} as any, source, destination)
+
+      // shared amd64 must not be deleted
+      expect(registryClientMocks.deleteManifest).not.toHaveBeenCalledWith('token', {
+        repository: source.repository,
+        name: source.name,
+        digest: 'sha256:sharedAmd64',
+      })
+      // unique arm64 must be deleted
+      expect(registryClientMocks.deleteManifest).toHaveBeenCalledWith('token', {
+        repository: source.repository,
+        name: source.name,
+        digest: 'sha256:uniqueArm64',
+      })
+      // sourceRoot is not referenced by sibling tag, so it is orphaned and deleted
+      expect(registryClientMocks.deleteManifest).toHaveBeenCalledWith('token', {
+        repository: source.repository,
+        name: source.name,
+        digest: 'sha256:sourceRoot',
+      })
+      // source tag itself deleted
+      expect(registryClientMocks.deleteManifest).toHaveBeenCalledWith('token', source)
+    })
+
+    test('renameImage > multi manifest excludes source tag from its own reference set', async () => {
+      const manifestList = {
+        mediaType: 'application/vnd.docker.distribution.manifest.list.v2+json',
+        manifests: [{ digest: 'sha256:child1', platform: { architecture: 'amd64', os: 'linux' } }],
+      }
+      const childManifest = {
+        config: { digest: 'sha256:config' },
+        layers: [{ digest: 'sha256:layer' }],
+        mediaType: 'mediaType',
+      }
+      registryClientMocks.getImageTagManifests
+        .mockResolvedValueOnce({ body: manifestList, headers: { 'docker-content-digest': 'sha256:root' } })
+        // getTagDigestReferenceMap fetch for the source tag itself (should be excluded from refs)
+        .mockResolvedValueOnce({ body: manifestList, headers: { 'docker-content-digest': 'sha256:root' } })
+        .mockResolvedValueOnce({ body: childManifest, headers: {} })
+      // listImageTags returns only the source tag (so after exclusion, the reference set is empty)
+      registryClientMocks.listImageTags.mockResolvedValueOnce(['latest'])
+      registryClientMocks.putManifest
+        .mockResolvedValueOnce({ 'docker-content-digest': 'sha256:newChild' })
+        .mockResolvedValueOnce({ 'docker-content-digest': 'sha256:newRoot' })
+      const source = { repository: 'modelid-123', name: 'alpine', tag: 'latest' }
+      const destination = { repository: 'soft_deleted/modelid-123', name: 'alpine', tag: 'latest' }
+
+      await renameImage({} as any, source, destination)
+
+      // because the source tag is excluded from its own ref set, both child and root are treated as orphaned
+      expect(registryClientMocks.deleteManifest).toHaveBeenCalledWith('token', {
+        repository: source.repository,
+        name: source.name,
+        digest: 'sha256:child1',
+      })
+      expect(registryClientMocks.deleteManifest).toHaveBeenCalledWith('token', {
+        repository: source.repository,
+        name: source.name,
+        digest: 'sha256:root',
+      })
+      expect(registryClientMocks.deleteManifest).toHaveBeenCalledWith('token', source)
+    })
+
+    test('softDeleteImage > multi manifest does not delete digests still referenced by sibling tag', async () => {
+      const manifestList = {
+        mediaType: 'application/vnd.docker.distribution.manifest.list.v2+json',
+        manifests: [
+          { digest: 'sha256:childAmd64', platform: { architecture: 'amd64', os: 'linux' } },
+          { digest: 'sha256:childArm64', platform: { architecture: 'arm64', os: 'linux' } },
+        ],
+      }
+      const childManifest = {
+        config: { digest: 'sha256:config' },
+        layers: [{ digest: 'sha256:layer1' }],
+        mediaType: 'mediaType',
+      }
+      registryClientMocks.getImageTagManifests
+        .mockResolvedValueOnce({ body: manifestList, headers: { 'docker-content-digest': 'sha256:rootDigest' } })
+        .mockResolvedValueOnce({ body: manifestList, headers: { 'docker-content-digest': 'sha256:rootDigest' } })
+        .mockResolvedValueOnce({ body: childManifest, headers: {} })
+        .mockResolvedValueOnce({ body: childManifest, headers: {} })
+      registryClientMocks.listImageTags.mockResolvedValueOnce(['latest-2'])
+      registryClientMocks.putManifest
+        .mockResolvedValueOnce({ 'docker-content-digest': 'sha256:newChildAmd64' })
+        .mockResolvedValueOnce({ 'docker-content-digest': 'sha256:newChildArm64' })
+        .mockResolvedValueOnce({ 'docker-content-digest': 'sha256:newRootDigest' })
+      const source = { name: 'alpine', repository: 'modelid-123', tag: 'latest' }
+
+      await softDeleteImage({} as any, source)
+
+      // tag deleted, but nothing else in the source repo. Also delete temp tags
+      expect(registryClientMocks.deleteManifest).toHaveBeenCalledTimes(3)
+      expect(registryClientMocks.deleteManifest).toHaveBeenCalledWith('token', source)
+      expect(registryClientMocks.deleteManifest).not.toHaveBeenCalledWith('token', {
+        repository: source.repository,
+        name: source.name,
+        digest: 'sha256:childAmd64',
+      })
+      expect(registryClientMocks.deleteManifest).not.toHaveBeenCalledWith('token', {
+        repository: source.repository,
+        name: source.name,
+        digest: 'sha256:childArm64',
+      })
+      expect(registryClientMocks.deleteManifest).not.toHaveBeenCalledWith('token', {
+        repository: source.repository,
+        name: source.name,
+        digest: 'sha256:rootDigest',
+      })
+      expect(releaseMocks.findAndDeleteImageFromReleases).toHaveBeenCalledWith({}, 'modelid-123', source, undefined)
+    })
+
+    test('renameImage > multi manifest handles 404 when listing source tags during reference map build', async () => {
+      const manifestList = {
+        mediaType: 'application/vnd.docker.distribution.manifest.list.v2+json',
+        manifests: [{ digest: 'sha256:child1', platform: { architecture: 'amd64', os: 'linux' } }],
+      }
+      const childManifest = {
+        config: { digest: 'sha256:config' },
+        layers: [{ digest: 'sha256:layer' }],
+        mediaType: 'mediaType',
+      }
+      registryClientMocks.getImageTagManifests
+        .mockResolvedValueOnce({ body: manifestList, headers: { 'docker-content-digest': 'sha256:root' } })
+        .mockResolvedValueOnce({ body: childManifest, headers: {} })
+      registryClientMocks.listImageTags.mockRejectedValueOnce(InternalError('Not found', { status: 404 }))
+      registryClientMocks.putManifest
+        .mockResolvedValueOnce({ 'docker-content-digest': 'sha256:newChild' })
+        .mockResolvedValueOnce({ 'docker-content-digest': 'sha256:newRoot' })
+      const source = { repository: 'modelid-123', name: 'alpine', tag: 'latest' }
+      const destination = { repository: 'soft_deleted/modelid-123', name: 'alpine', tag: 'latest' }
+
+      await renameImage({} as any, source, destination)
+
+      // empty ref map -> child and root are both orphaned
+      expect(registryClientMocks.deleteManifest).toHaveBeenCalledWith('token', {
+        repository: source.repository,
+        name: source.name,
+        digest: 'sha256:child1',
+      })
+      expect(registryClientMocks.deleteManifest).toHaveBeenCalledWith('token', {
+        repository: source.repository,
+        name: source.name,
+        digest: 'sha256:root',
+      })
+      expect(registryClientMocks.deleteManifest).toHaveBeenCalledWith('token', source)
+    })
+
+    test('renameImage > multi manifest rethrows non-404 errors when building reference map', async () => {
+      const manifestList = {
+        mediaType: 'application/vnd.docker.distribution.manifest.list.v2+json',
+        manifests: [{ digest: 'sha256:child1', platform: { architecture: 'amd64', os: 'linux' } }],
+      }
+      registryClientMocks.getImageTagManifests.mockResolvedValueOnce({
+        body: manifestList,
+        headers: { 'docker-content-digest': 'sha256:root' },
+      })
+      registryClientMocks.listImageTags.mockRejectedValueOnce(InternalError('Registry unavailable'))
+      const source = { repository: 'modelid-123', name: 'alpine', tag: 'latest' }
+      const destination = { repository: 'soft_deleted/modelid-123', name: 'alpine', tag: 'latest' }
+
+      await expect(renameImage({} as any, source, destination)).rejects.toThrow('Registry unavailable')
+
+      // we should not have proceeded to delete anything
+      expect(registryClientMocks.deleteManifest).not.toHaveBeenCalled()
+      expect(registryClientMocks.putManifest).not.toHaveBeenCalled()
+    })
+
     test('softDeleteImage > success', async () => {
       const mockBody = { config: { digest: 'digest' }, layers: [{ digest: 'digest' }], mediaType: 'mediaType' }
       registryClientMocks.getImageTagManifests.mockResolvedValue({

--- a/infrastructure/helm/bailo/values.yaml
+++ b/infrastructure/helm/bailo/values.yaml
@@ -200,7 +200,7 @@ minio:
 # Registry Dependencies
 registry:
   repository: registry
-  tag: 3.0.0
+  tag: 3.1.1
   enabled: true
   protocol: "https"
   #host: "bailo-registry" # service name


### PR DESCRIPTION
Fixes a bug in the `listIsOrphaned` logic which can result in `_catalog` commands being broken in the registry.

-------

Steps to reproduce bug:

1. Push two identical multi-platform images:
```console
$ DOCKER_IMAGE="alpine:3.23.3"; docker buildx imagetools create --tag "localhost:8080/modelid-123/${DOCKER_IMAGE}" "${DOCKER_IMAGE}"
[+] Building x.xs (1/1) FINISHED
 => [internal] pushing localhost:8080/modelid-123/alpine                                                                                                                            11.1s
$ DOCKER_IMAGE="alpine:3.23.3"; docker buildx imagetools create --tag "localhost:8080/modelid-123/${DOCKER_IMAGE}-2" "${DOCKER_IMAGE}"
[+] Building x.xs (1/1) FINISHED
 => [internal] pushing localhost:8080/modelid-123/alpine
```
2.  Soft delete image `localhost:8080/modelid-123/alpine`. This should break listing the registry (refresh with cache cleared to check).

You can then re-push `localhost:8080/modelid-123/alpine-2` to fix it. Repushing `localhost:8080/modelid-123/alpine` will also fix this as it looks like the shared manifest gets soft deleted when it should actually be kept, so this re-adds it.