### PR TITLE
Bump nginx image version

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -47,7 +47,7 @@ services:
       - minioVolume:/bitnami/minio
 
   nginx:
-    image: nginxinc/nginx-unprivileged:1.28.0-alpine3.21-slim
+    image: nginxinc/nginx-unprivileged:1.31.1-alpine3.23-slim
     networks:
       default:
       internal:

--- a/infrastructure/helm/bailo/values.yaml
+++ b/infrastructure/helm/bailo/values.yaml
@@ -228,7 +228,7 @@ federation:
 # Nginx Dependencies
 nginxAuth:
   repository: nginxinc/nginx-unprivileged # runs Nginx as non-root unprivileged user.
-  tag: 1.28.0-alpine3.21-slim
+  tag: 1.31.1-alpine3.23-slim
   #host: "bailo-nginx" # service name
   port: 8080
   #certDir: "/certs"


### PR DESCRIPTION
Not sure why dependabot didn't pick up on this one. It's worth keeping an eye on this and potentially finding a solution in the future if this continues to not be handled by dependabot.