### PR TITLE
Remove NodeCache maxKeys

### DIFF
--- a/backend/src/connectors/metrics/base.ts
+++ b/backend/src/connectors/metrics/base.ts
@@ -36,7 +36,6 @@ const metricsCache = new NodeCache({
   stdTTL: METRICS_CACHE_TTL,
   checkperiod: METRICS_CACHE_TTL,
   useClones: false,
-  maxKeys: 5000,
 })
 
 type CachedMetrics<MetricsCache> = {


### PR DESCRIPTION
Prevents errors being thrown.
From https://www.npmjs.com/package/@cacheable/node-cache
> | Option | Default Setting | Description |
> |--------|--------|--------|
> | `maxKeys` | `-1` | If set to a positive number, it will limit the number of keys in the cache. If the number of keys exceeds this limit, it will throw an error when trying to set more keys than the maximum. If set to -1, it means unlimited keys are allowed. |

