### PR TITLE
Add lifecycle emails

### DIFF
--- a/backend/config/default.cjs
+++ b/backend/config/default.cjs
@@ -69,7 +69,7 @@ module.exports = {
 
   smtp: {
     // Enable / disable all email sending
-    enabled: true,
+    enabled: false,
     transporter: 'smtp',
 
     // Connection information for an SMTP server.  Settings are passed directly to 'node-mailer', see reference for options:

--- a/backend/config/default.cjs
+++ b/backend/config/default.cjs
@@ -69,7 +69,7 @@ module.exports = {
 
   smtp: {
     // Enable / disable all email sending
-    enabled: false,
+    enabled: true,
     transporter: 'smtp',
 
     // Connection information for an SMTP server.  Settings are passed directly to 'node-mailer', see reference for options:

--- a/backend/config/default.cjs
+++ b/backend/config/default.cjs
@@ -86,7 +86,7 @@ module.exports = {
 
     // Refer to: https://github.com/agenda/human-interval#uses
     lifecycle: {
-      preReminderIntervals: ['1 hour', '2 weeks', '10 weeks'],
+      preReminderIntervals: ['1 day', '2 weeks', '10 weeks'],
       postReminderInterval: '1 day',
     },
 

--- a/backend/config/default.cjs
+++ b/backend/config/default.cjs
@@ -84,6 +84,12 @@ module.exports = {
       },
     },
 
+    // Refer to: https://github.com/agenda/human-interval#uses
+    lifecycle: {
+      preReminderIntervals: ['1 hour', '2 weeks', '10 weeks'],
+      postReminderInterval: '1 day',
+    },
+
     // Set the email address that Bailo should use, can be different from the SMTP server details.
     from: '"Bailo 📝" <bailo@example.org>',
   },

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -5,7 +5,7 @@ import shelljs from 'shelljs'
 import { ensureBucketExists } from './clients/s3.js'
 import log from './services/log.js'
 import { addDefaultReviewRoles } from './services/review.js'
-import { startScheduler } from './services/schedule/scheduler.js'
+import { registerLifecycleReviewJob, startScheduler } from './services/schedule/scheduler.js'
 import { addDefaultSchemas } from './services/schema.js'
 import config from './utils/config.js'
 import { connectToMongoose, runMigrations } from './utils/database.js'
@@ -32,7 +32,7 @@ await addDefaultReviewRoles()
 await addDefaultSchemas()
 
 // Start the scheduler
-await startScheduler([])
+await startScheduler([registerLifecycleReviewJob])
 
 const { server } = await import('./routes.js')
 const httpServer = server.listen(config.api.port, () => {

--- a/backend/src/services/schedule/scheduler.ts
+++ b/backend/src/services/schedule/scheduler.ts
@@ -71,8 +71,8 @@ export async function scheduleLifeCycleReviewEmails(modelId: string, reviewId: s
     .filter((interval) => interval !== undefined)
 
   const now = new Date()
-  const dueTimeStamp = new Date(dueDate)
   for (const dueIn of preReminderIntervals) {
+    const dueTimeStamp = new Date(dueDate)
     dueTimeStamp.setDate(dueTimeStamp.getDate() - dueIn)
     if (dueTimeStamp > now) {
       await scheduler.schedule(dueTimeStamp, LIFECYCLE_REVIEW_EMAIL_JOB, { modelId, reviewId, dueIn })
@@ -85,7 +85,7 @@ export async function scheduleLifeCycleReviewEmails(modelId: string, reviewId: s
       postReminderInterval,
       LIFECYCLE_REVIEW_EMAIL_JOB,
       { modelId, reviewId },
-      { startDate: dueTimeStamp },
+      { startDate: new Date(dueDate) },
     )
   }
 }
@@ -94,5 +94,6 @@ export function getScheduler(): Agenda {
   if (!started) {
     throw new Error('Scheduler has not been started')
   }
+  registerLifecycleReviewJob(agenda)
   return agenda
 }

--- a/backend/src/services/schedule/scheduler.ts
+++ b/backend/src/services/schedule/scheduler.ts
@@ -72,8 +72,7 @@ export async function scheduleLifeCycleReviewEmails(modelId: string, reviewId: s
 
   const now = new Date()
   for (const dueIn of preReminderIntervals) {
-    const dueTimeStamp = new Date(dueDate)
-    dueTimeStamp.setDate(dueTimeStamp.getDate() - dueIn)
+    const dueTimeStamp = new Date(dueDate.getTime() - dueIn)
     if (dueTimeStamp > now) {
       await scheduler.schedule(dueTimeStamp, LIFECYCLE_REVIEW_EMAIL_JOB, { modelId, reviewId, dueIn })
     }

--- a/backend/src/services/schedule/scheduler.ts
+++ b/backend/src/services/schedule/scheduler.ts
@@ -1,10 +1,21 @@
 import { MongoBackend } from '@agendajs/mongo-backend'
 import { Agenda } from 'agenda'
+import humanInterval from 'human-interval'
 
+import config from '../../utils/config.js'
 import { getConnectionURI } from '../../utils/database.js'
 import log from '../log.js'
+import { notifyLifeCycleReview } from '../smtp/smtp.js'
 
 export type JobRegistrar = (agenda: Agenda) => Promise<void> | void
+
+export type LifecycleReviewJobData = {
+  modelId: string
+  reviewId: string
+  dueIn?: string
+}
+
+const LIFECYCLE_REVIEW_EMAIL_JOB = 'sendLifeCycleReviewEmail'
 
 log.info('Scheduler initialising...')
 const agenda = new Agenda({
@@ -39,6 +50,44 @@ export async function startScheduler(jobRegistrars: JobRegistrar[] = []) {
   await Promise.all(jobRegistrars.map((registerJob) => registerJob(agenda)))
 
   return agenda
+}
+
+export function registerLifecycleReviewJob(agenda: Agenda) {
+  agenda.define<LifecycleReviewJobData>(LIFECYCLE_REVIEW_EMAIL_JOB, async (job) => {
+    const { modelId, reviewId, dueIn } = job.attrs.data
+    await notifyLifeCycleReview(modelId, reviewId, dueIn)
+  })
+}
+
+export async function cancelLifecycleReviewJobs(modelId: string, reviewId: string) {
+  const scheduler = getScheduler()
+  await scheduler.cancel({ name: LIFECYCLE_REVIEW_EMAIL_JOB, data: { modelId, reviewId } })
+}
+
+export async function scheduleLifeCycleReviewEmails(modelId: string, reviewId: string, dueDate: Date) {
+  const scheduler = getScheduler()
+  const preReminderIntervals = config.smtp.lifecycle.preReminderIntervals
+    .map(humanInterval)
+    .filter((interval) => interval !== undefined)
+
+  const now = new Date()
+  const dueTimeStamp = new Date(dueDate)
+  for (const dueIn of preReminderIntervals) {
+    dueTimeStamp.setDate(dueTimeStamp.getDate() - dueIn)
+    if (dueTimeStamp > now) {
+      await scheduler.schedule(dueTimeStamp, LIFECYCLE_REVIEW_EMAIL_JOB, { modelId, reviewId, dueIn })
+    }
+  }
+
+  const postReminderInterval = humanInterval(config.smtp.lifecycle.postReminderInterval)
+  if (postReminderInterval) {
+    await scheduler.every(
+      postReminderInterval,
+      LIFECYCLE_REVIEW_EMAIL_JOB,
+      { modelId, reviewId },
+      { startDate: dueTimeStamp },
+    )
+  }
 }
 
 export function getScheduler(): Agenda {

--- a/backend/src/services/schedule/scheduler.ts
+++ b/backend/src/services/schedule/scheduler.ts
@@ -15,7 +15,7 @@ export type LifecycleReviewJobData = {
   dueIn?: string
 }
 
-const LIFECYCLE_REVIEW_EMAIL_JOB = 'sendLifeCycleReviewEmail'
+export const LIFECYCLE_REVIEW_EMAIL_JOB = 'sendLifeCycleReviewEmail'
 
 log.info('Scheduler initialising...')
 const agenda = new Agenda({

--- a/backend/src/services/schedule/scheduler.ts
+++ b/backend/src/services/schedule/scheduler.ts
@@ -101,6 +101,5 @@ export function getScheduler(): Agenda {
   if (!started) {
     throw new Error('Scheduler has not been started')
   }
-  registerLifecycleReviewJob(agenda)
   return agenda
 }

--- a/backend/src/services/schedule/scheduler.ts
+++ b/backend/src/services/schedule/scheduler.ts
@@ -67,24 +67,32 @@ export async function cancelLifecycleReviewJobs(modelId: string, reviewId: strin
 export async function scheduleLifeCycleReviewEmails(modelId: string, reviewId: string, dueDate: Date) {
   const scheduler = getScheduler()
   const preReminderIntervals = config.smtp.lifecycle.preReminderIntervals
-    .map(humanInterval)
-    .filter((interval) => interval !== undefined)
 
   const now = new Date()
   for (const dueIn of preReminderIntervals) {
-    const dueTimeStamp = new Date(dueDate.getTime() - dueIn)
+    const interval = humanInterval(dueIn)
+    if (!interval) {
+      log.warn({ dueIn }, 'The time interval provided could not be converted to a numerical value.')
+      continue
+    }
+    const dueTimeStamp = new Date(dueDate.getTime() - interval)
     if (dueTimeStamp > now) {
       await scheduler.schedule(dueTimeStamp, LIFECYCLE_REVIEW_EMAIL_JOB, { modelId, reviewId, dueIn })
     }
   }
 
-  const postReminderInterval = humanInterval(config.smtp.lifecycle.postReminderInterval)
-  if (postReminderInterval) {
+  const interval = humanInterval(config.smtp.lifecycle.postReminderInterval)
+  if (interval) {
     await scheduler.every(
-      postReminderInterval,
+      config.smtp.lifecycle.postReminderInterval,
       LIFECYCLE_REVIEW_EMAIL_JOB,
       { modelId, reviewId },
       { startDate: new Date(dueDate) },
+    )
+  } else {
+    log.warn(
+      { reminderInterval: config.smtp.lifecycle.postReminderInterval },
+      'The time interval provided could not be converted to a numerical value.',
     )
   }
 }

--- a/backend/src/services/smtp/smtp.ts
+++ b/backend/src/services/smtp/smtp.ts
@@ -183,7 +183,7 @@ export async function notifyLifeCycleReview(modelId: string, reviewId: string, d
 
   const model = await getModelByIdNoAuth(modelId)
   const emailContent = buildEmail(
-    dueIn ? `A lifecycle review is due in ${dueIn}` : `A lifecycle review past it's due date`,
+    dueIn ? `A lifecycle review is due in ${dueIn}` : `A lifecycle review has past it's due date`,
     [],
     [
       { name: `See ${toTitleCase(model.kind, '-')}`, url: `${appBaseUrl}/${model.kind}/${modelId}` },

--- a/backend/src/services/smtp/smtp.ts
+++ b/backend/src/services/smtp/smtp.ts
@@ -183,7 +183,7 @@ export async function notifyLifeCycleReview(modelId: string, reviewId: string, d
 
   const model = await getModelByIdNoAuth(modelId)
   const emailContent = buildEmail(
-    dueIn ? `A lifecycle review is due in ${dueIn}` : `A lifecycle review has expired`,
+    dueIn ? `A lifecycle review is due in ${dueIn}` : `A lifecycle review past it's due date`,
     [],
     [
       { name: `See ${toTitleCase(model.kind, '-')}`, url: `${appBaseUrl}/${model.kind}/${modelId}` },

--- a/backend/src/services/smtp/smtp.ts
+++ b/backend/src/services/smtp/smtp.ts
@@ -10,7 +10,7 @@ import { ReviewDoc } from '../../models/Review.js'
 import config, { TransportOption } from '../../utils/config.js'
 import { toEntity } from '../../utils/entity.js'
 import { sanitiseEmail } from '../../utils/smtp.js'
-import { toTitleCase } from '../../utils/string.js'
+import { resolveKindToUrl, toTitleCase } from '../../utils/string.js'
 import log from '../log.js'
 import { getModelByIdNoAuth } from '../model.js'
 import { buildEmail, EmailContent, Info } from './emailBuilder.js'
@@ -188,7 +188,7 @@ export async function notifyLifeCycleReview(modelId: string, reviewId: string, d
       : `A lifecycle review for ${model.name} has past it's due date`,
     [],
     [
-      { name: `See ${toTitleCase(model.kind, '-')}`, url: `${appBaseUrl}/${model.kind}/${modelId}` },
+      { name: `See ${toTitleCase(model.kind, '-')}`, url: `${appBaseUrl}/${resolveKindToUrl(model.kind)}/${modelId}` },
       {
         name: 'Review Lifecycle',
         url: `${appBaseUrl}/${model.kind}/${modelId}/lifecycle/${reviewId}/review?role=owner`,

--- a/backend/src/services/smtp/smtp.ts
+++ b/backend/src/services/smtp/smtp.ts
@@ -183,11 +183,16 @@ export async function notifyLifeCycleReview(modelId: string, reviewId: string, d
 
   const model = await getModelByIdNoAuth(modelId)
   const emailContent = buildEmail(
-    dueIn ? `A lifecycle review is due in ${dueIn}` : `A lifecycle review has past it's due date`,
+    dueIn
+      ? `A lifecycle review for ${model.name} is due in ${dueIn}`
+      : `A lifecycle review for ${model.name} has past it's due date`,
     [],
     [
       { name: `See ${toTitleCase(model.kind, '-')}`, url: `${appBaseUrl}/${model.kind}/${modelId}` },
-      { name: 'Review Lifecycle', url: `${appBaseUrl}/${modelId}/lifecycle/${reviewId}/review?role=owner` },
+      {
+        name: 'Review Lifecycle',
+        url: `${appBaseUrl}/${model.kind}/${modelId}/lifecycle/${reviewId}/review?role=owner`,
+      },
     ],
   )
 

--- a/backend/src/services/smtp/smtp.ts
+++ b/backend/src/services/smtp/smtp.ts
@@ -10,6 +10,7 @@ import { ReviewDoc } from '../../models/Review.js'
 import config, { TransportOption } from '../../utils/config.js'
 import { toEntity } from '../../utils/entity.js'
 import { sanitiseEmail } from '../../utils/smtp.js'
+import { toTitleCase } from '../../utils/string.js'
 import log from '../log.js'
 import { getModelByIdNoAuth } from '../model.js'
 import { buildEmail, EmailContent, Info } from './emailBuilder.js'
@@ -172,6 +173,25 @@ export async function notifyReviewResponseForRelease(reviewResponse: ResponseInt
     ],
   )
   await dispatchEmail(toEntity('user', release.createdBy), await emailContent)
+}
+
+export async function notifyLifeCycleReview(modelId: string, reviewId: string, dueIn?: string) {
+  if (!config.smtp.enabled) {
+    log.info('Not sending email due to SMTP disabled')
+    return
+  }
+
+  const model = await getModelByIdNoAuth(modelId)
+  const emailContent = buildEmail(
+    dueIn ? `A lifecycle review is due in ${dueIn}` : `A lifecycle review has expired`,
+    [],
+    [
+      { name: `See ${toTitleCase(model.kind, '-')}`, url: `${appBaseUrl}/${model.kind}/${modelId}` },
+      { name: 'Review Lifecycle', url: `${appBaseUrl}/${modelId}/lifecycle/${reviewId}/review?role=owner` },
+    ],
+  )
+
+  await dispatchEmailToModelRole(modelId, 'owner', await emailContent)
 }
 
 export async function notifyReviewResponseForAccess(

--- a/backend/src/services/v3/response.ts
+++ b/backend/src/services/v3/response.ts
@@ -7,6 +7,7 @@ import { ReviewKind } from '../../types/enums.js'
 import { toEntity } from '../../utils/entity.js'
 import { BadReq } from '../../utils/error.js'
 import { ReviewResponseParams } from '../response.js'
+import { cancelLifecycleReviewJobs } from '../schedule/scheduler.js'
 import { createLifecycleReview, findReviewById } from '../v3/review.js'
 import { sendWebhooks } from '../webhook.js'
 
@@ -42,6 +43,7 @@ export async function respondToReview(
   })
 
   await reviewResponse.save()
+  await cancelLifecycleReviewJobs(review.modelId, reviewId)
   await sendReviewResponseNotification(review, reviewResponse, user)
 
   sendWebhooks(

--- a/backend/src/services/v3/review.ts
+++ b/backend/src/services/v3/review.ts
@@ -9,6 +9,7 @@ import { UserInterface } from '../../models/User.js'
 import { ReviewKind } from '../../types/enums.js'
 import { BadReq, Forbidden, NotFound } from '../../utils/error.js'
 import { getModelById } from '../model.js'
+import { scheduleLifeCycleReviewEmails } from '../schedule/scheduler.js'
 
 type ReviewWithModel = ReviewDoc & {
   model: ModelInterface
@@ -157,5 +158,8 @@ export async function createLifecycleReview(
     dueDate,
   })
   await newReview.save()
+
+  await scheduleLifeCycleReviewEmails(modelId, newReview._id.toString(), dueDate)
+
   return newReview
 }

--- a/backend/src/utils/config.ts
+++ b/backend/src/utils/config.ts
@@ -87,6 +87,11 @@ export interface Config {
       }
     }
 
+    lifecycle: {
+      preReminderIntervals: string[]
+      postReminderInterval: string
+    }
+
     from: string
   }
 

--- a/backend/src/utils/string.ts
+++ b/backend/src/utils/string.ts
@@ -1,3 +1,5 @@
+import { EntryKind, EntryKindKeys } from '../models/Model.js'
+
 /**
  * Naive utility to pluralise a word. Only covers +s and +es grammar rules.
  *
@@ -16,3 +18,6 @@ export const toTitleCase = (value: string, delimiter: string = ' '): string => {
     .map((word) => `${word.charAt(0).toUpperCase()}${word.slice(1).toLowerCase()}`)
     .join(' ')
 }
+
+export const resolveKindToUrl = (kind: EntryKindKeys): string =>
+  kind === EntryKind.DataCard ? EntryKind.DataCard : EntryKind.Model

--- a/backend/src/utils/string.ts
+++ b/backend/src/utils/string.ts
@@ -8,3 +8,11 @@
 export const plural = (value: number, phrase: string) => {
   return `${value} ${phrase}${value === 1 ? '' : phrase.endsWith('s') ? 'es' : 's'}`
 }
+
+export const toTitleCase = (value: string, delimiter: string = ' '): string => {
+  return value
+    .replace(/[-_]/g, ' ')
+    .split(delimiter)
+    .map((word) => `${word.charAt(0).toUpperCase()}${word.slice(1).toLowerCase()}`)
+    .join(' ')
+}

--- a/backend/test/services/scheduler.spec.ts
+++ b/backend/test/services/scheduler.spec.ts
@@ -57,7 +57,7 @@ vi.mock('../../src/services/smtp/smtp.js', () => ({
 const configMock = vi.hoisted(() => ({
   smtp: {
     lifecycle: {
-      preReminderIntervals: ['1 hour', '2 weeks', '10 weeks'],
+      preReminderIntervals: ['1 day', '2 weeks', '10 weeks'],
       postReminderInterval: '1 day',
     },
   },

--- a/backend/test/services/scheduler.spec.ts
+++ b/backend/test/services/scheduler.spec.ts
@@ -1,12 +1,32 @@
-import { describe, expect, test, vi } from 'vitest'
+import { beforeAll, describe, expect, test, vi } from 'vitest'
 
-import { getScheduler, startScheduler } from '../../src/services/schedule/scheduler.js'
+import {
+  cancelLifecycleReviewJobs,
+  getScheduler,
+  LIFECYCLE_REVIEW_EMAIL_JOB,
+  registerLifecycleReviewJob,
+  scheduleLifeCycleReviewEmails,
+  startScheduler,
+} from '../../src/services/schedule/scheduler.js'
+
+const agendaMethods = vi.hoisted(() => ({
+  start: vi.fn(),
+  on: vi.fn(),
+  define: vi.fn(),
+  schedule: vi.fn(),
+  every: vi.fn(),
+  cancel: vi.fn(),
+}))
 
 vi.mock('agenda', () => {
   return {
     Agenda: class {
-      start = vi.fn().mockResolvedValue(undefined)
-      on = vi.fn()
+      start = agendaMethods.start
+      on = agendaMethods.on
+      define = agendaMethods.define
+      schedule = agendaMethods.schedule
+      every = agendaMethods.every
+      cancel = agendaMethods.cancel
     },
   }
 })
@@ -19,12 +39,32 @@ vi.mock('../../src/utils/database.js', () => ({
   getConnectionURI: () => 'mongodb://test',
 }))
 
+const logMock = vi.hoisted(() => ({
+  debug: vi.fn(),
+  info: vi.fn(),
+  error: vi.fn(),
+  fatal: vi.fn(),
+  warn: vi.fn(),
+}))
 vi.mock('../../src/services/log.js', () => ({
-  default: {
-    info: vi.fn(),
-    error: vi.fn(),
-    fatal: vi.fn(),
+  default: logMock,
+}))
+
+vi.mock('../../src/services/smtp/smtp.js', () => ({
+  notifyLifeCycleReview: vi.fn(),
+}))
+
+const configMock = vi.hoisted(() => ({
+  smtp: {
+    lifecycle: {
+      preReminderIntervals: ['1 hour', '2 weeks', '10 weeks'],
+      postReminderInterval: '1 day',
+    },
   },
+}))
+vi.mock('../../src/utils/config.js', () => ({
+  __esModule: true,
+  default: configMock,
 }))
 
 describe('scheduler', () => {
@@ -37,5 +77,70 @@ describe('scheduler', () => {
     expect(agenda).toBeDefined()
     expect(agenda.start).toHaveBeenCalledOnce()
     expect(getScheduler()).toBe(agenda)
+  })
+})
+
+const ELEVEN_WEEKS = 6_652_800_000
+
+describe('scheduler > lifecycle jobs', () => {
+  beforeAll(async () => {
+    await startScheduler()
+  })
+
+  const dueDate = new Date(Date.now() + ELEVEN_WEEKS)
+
+  test('registerLifecycleReviewJob defines the lifecycle email job on the agenda', () => {
+    const fakeAgenda = { define: vi.fn() } as any
+    registerLifecycleReviewJob(fakeAgenda)
+    expect(fakeAgenda.define).toHaveBeenCalledWith('sendLifeCycleReviewEmail', expect.anything())
+  })
+
+  test('cancelLifecycleReviewJobs cancels jobs matching the given model and review ids', async () => {
+    await cancelLifecycleReviewJobs('model-1', 'review-1')
+    expect(agendaMethods.cancel).toHaveBeenCalledWith({
+      name: 'sendLifeCycleReviewEmail',
+      data: { modelId: 'model-1', reviewId: 'review-1' },
+    })
+  })
+
+  test('scheduleLifeCycleReviewEmails schedules pre-reminder emails for future reminder dates', async () => {
+    await scheduleLifeCycleReviewEmails('model-1', 'review-1', dueDate)
+
+    expect(agendaMethods.schedule).toHaveBeenCalledTimes(3)
+    expect(agendaMethods.every).toHaveBeenCalledOnce()
+    expect(agendaMethods.every).toHaveBeenCalledWith(
+      '1 day',
+      'sendLifeCycleReviewEmail',
+      { modelId: 'model-1', reviewId: 'review-1' },
+      { startDate: dueDate },
+    )
+  })
+
+  test('scheduleLifeCycleReviewEmails skips pre-reminders whose scheduled time is already in the past', async () => {
+    await scheduleLifeCycleReviewEmails('model-1', 'review-1', new Date())
+
+    expect(agendaMethods.schedule).not.toHaveBeenCalled()
+    expect(agendaMethods.every).toHaveBeenCalledOnce()
+  })
+
+  test('scheduleLifeCycleReviewEmails logs a warning for an unrecognised pre-reminder interval', async () => {
+    vi.spyOn(configMock.smtp.lifecycle, 'preReminderIntervals', 'get').mockReturnValue(['1 lustrum', '1 nundine'])
+    await scheduleLifeCycleReviewEmails('model-1', 'review-1', dueDate)
+
+    expect(agendaMethods.schedule).not.toHaveBeenCalled()
+    expect(logMock.warn).toHaveBeenCalled()
+  })
+
+  test('scheduleLifeCycleReviewEmails logs a warning for an unrecognised post-reminder interval', async () => {
+    vi.spyOn(configMock.smtp.lifecycle, 'postReminderInterval', 'get').mockReturnValue('10 ghurries')
+    await scheduleLifeCycleReviewEmails('model-1', 'review-1', dueDate)
+
+    expect(agendaMethods.every).not.toHaveBeenCalled()
+    expect(logMock.warn).toHaveBeenCalled()
+  })
+
+  test('getScheduler registers the lifecycle review job on every call', () => {
+    getScheduler()
+    expect(agendaMethods.define).toHaveBeenCalledWith(LIFECYCLE_REVIEW_EMAIL_JOB, expect.anything())
   })
 })

--- a/backend/test/services/scheduler.spec.ts
+++ b/backend/test/services/scheduler.spec.ts
@@ -73,10 +73,11 @@ describe('scheduler', () => {
   })
 
   test('startScheduler initialises and starts agenda', async () => {
-    const agenda = await startScheduler()
+    const agenda = await startScheduler([registerLifecycleReviewJob])
     expect(agenda).toBeDefined()
     expect(agenda.start).toHaveBeenCalledOnce()
     expect(getScheduler()).toBe(agenda)
+    expect(agendaMethods.define).toHaveBeenCalledWith(LIFECYCLE_REVIEW_EMAIL_JOB, expect.anything())
   })
 })
 
@@ -84,7 +85,7 @@ const ELEVEN_WEEKS = 6_652_800_000
 
 describe('scheduler > lifecycle jobs', () => {
   beforeAll(async () => {
-    await startScheduler()
+    await startScheduler([registerLifecycleReviewJob])
   })
 
   const dueDate = new Date(Date.now() + ELEVEN_WEEKS)
@@ -137,10 +138,5 @@ describe('scheduler > lifecycle jobs', () => {
 
     expect(agendaMethods.every).not.toHaveBeenCalled()
     expect(logMock.warn).toHaveBeenCalled()
-  })
-
-  test('getScheduler registers the lifecycle review job on every call', () => {
-    getScheduler()
-    expect(agendaMethods.define).toHaveBeenCalledWith(LIFECYCLE_REVIEW_EMAIL_JOB, expect.anything())
   })
 })

--- a/backend/test/services/smtp/smtp.spec.ts
+++ b/backend/test/services/smtp/smtp.spec.ts
@@ -2,6 +2,7 @@ import { describe, expect, test, vi } from 'vitest'
 
 import {
   dispatchEmailToModelRole,
+  notifyLifeCycleReview,
   notifyReviewResponseForAccess,
   notifyReviewResponseForRelease,
   requestReviewForAccessRequest,
@@ -259,5 +260,43 @@ describe('services > smtp > smtp', () => {
 
     const result: Promise<void> = requestReviewForRelease('user:user', review, release)
     await expect(result).rejects.toThrow(`Unable to send email`)
+  })
+
+  test('that a lifecycle review email is not sent when smtp is disabled', async () => {
+    vi.spyOn(configMock.smtp, 'enabled', 'get').mockReturnValueOnce(false)
+    await notifyLifeCycleReview('modelId', 'review-1', '1 hour')
+    expect(transporterMock.sendMail).not.toHaveBeenCalled()
+  })
+
+  test('that a lifecycle review email includes a due-in message when dueIn is provided', async () => {
+    getModelByIdMock.mockReturnValue({
+      id: 'modelId',
+      name: 'Test Model',
+      kind: 'model',
+      collaborators: [{ entity: 'user:user', roles: ['owner'] }],
+    } as any)
+    await notifyLifeCycleReview('modelId', 'review-1', '1 hour')
+    expect(emailBuilderMock.buildEmail).toHaveBeenCalledWith(
+      'A lifecycle review for Test Model is due in 1 hour',
+      expect.anything(),
+      expect.anything(),
+    )
+    expect(transporterMock.sendMail).toHaveBeenCalled()
+  })
+
+  test('that a lifecycle review email includes a past-due message when dueIn is not provided', async () => {
+    getModelByIdMock.mockReturnValue({
+      id: 'modelId',
+      name: 'Test Model',
+      kind: 'model',
+      collaborators: [{ entity: 'user:user', roles: ['owner'] }],
+    } as any)
+    await notifyLifeCycleReview('modelId', 'review-1')
+    expect(emailBuilderMock.buildEmail).toHaveBeenCalledWith(
+      "A lifecycle review for Test Model has past it's due date",
+      expect.anything(),
+      expect.anything(),
+    )
+    expect(transporterMock.sendMail).toHaveBeenCalled()
   })
 })

--- a/backend/test/services/v3/response.spec.ts
+++ b/backend/test/services/v3/response.spec.ts
@@ -21,6 +21,7 @@ const reviewV3Mock = vi.hoisted(() => ({
   findReviewById: vi.fn(function () {
     return [testReleaseReview]
   }),
+  createLifecycleReview: vi.fn(),
 }))
 vi.mock('../../../src/services/v3/review.js', () => reviewV3Mock)
 
@@ -33,6 +34,11 @@ const mockWebhookService = vi.hoisted(() => ({
   sendWebhooks: vi.fn(),
 }))
 vi.mock('../../../src/services/webhook.js', () => mockWebhookService)
+
+const mockSchedulerService = vi.hoisted(() => ({
+  cancelLifecycleReviewJobs: vi.fn(),
+}))
+vi.mock('../../../src/services/schedule/scheduler.js', () => mockSchedulerService)
 
 describe('services > v3 > response', () => {
   const user: any = { dn: 'test' }
@@ -53,5 +59,20 @@ describe('services > v3 > response', () => {
     expect(ResponseModelMock.save).toHaveBeenCalledOnce()
     expect(responseV2Mock.sendReviewResponseNotification).toHaveBeenCalledOnce()
     expect(mockWebhookService.sendWebhooks).toHaveBeenCalledOnce()
+  })
+
+  test('respondToReview > cancels lifecycle review jobs after saving response', async () => {
+    reviewV3Mock.findReviewById.mockReturnValue(testReleaseReview as any)
+    ReviewModel.aggregate.mockResolvedValue([{ modelId: testReleaseReview.modelId, role: 'owner' }])
+
+    await respondToReview(user, '6a058ab4db7a3be341fb3cca', {
+      decision: Decision.RequestChanges,
+      comment: 'Do better!',
+    })
+
+    expect(mockSchedulerService.cancelLifecycleReviewJobs).toHaveBeenCalledWith(
+      testReleaseReview.modelId,
+      '6a058ab4db7a3be341fb3cca',
+    )
   })
 })

--- a/backend/test/services/v3/review.spec.ts
+++ b/backend/test/services/v3/review.spec.ts
@@ -24,6 +24,11 @@ const modelMock = vi.hoisted(() => ({
 }))
 vi.mock('../../../src/services/model.js', () => modelMock)
 
+const mockSchedulerService = vi.hoisted(() => ({
+  scheduleLifeCycleReviewEmails: vi.fn(),
+}))
+vi.mock('../../../src/services/schedule/scheduler.js', () => mockSchedulerService)
+
 describe('services > review', () => {
   const user: any = { dn: 'test' }
 
@@ -59,6 +64,31 @@ describe('services > review', () => {
       dueDate: new Date('2026-05-28T12:54:03.780Z'),
     })
     expect(newReview).toMatchSnapshot()
+  })
+
+  test('createReview > schedules lifecycle review emails after creating a lifecycle review', async () => {
+    const dueDate = new Date('2026-05-28T12:54:03.780Z')
+    modelMock.getModelById.mockResolvedValueOnce({
+      id: 'test-1234',
+      collaborators: [{ entity: 'user:user', roles: ['owner'] }],
+      save: vi.fn(),
+    })
+    modelMock.getModelSystemRoles.mockReturnValue(['owner'])
+    ReviewModel.aggregate.mockResolvedValue([])
+    ReviewModel.findOne.mockResolvedValueOnce(undefined)
+    authMocks.default.models.mockResolvedValueOnce([{ success: true } as any])
+    authMocks.default.model.mockResolvedValueOnce({ success: true } as any)
+
+    await createReview({} as any, 'test-1234', {
+      kind: ReviewKind.Lifecycle,
+      dueDate,
+    })
+
+    expect(mockSchedulerService.scheduleLifeCycleReviewEmails).toHaveBeenCalledWith(
+      'test-1234',
+      expect.any(String),
+      dueDate,
+    )
   })
 
   test('createReview > cannot create lifecycle review if existing review is open', async () => {

--- a/backend/test/utils/string.spec.ts
+++ b/backend/test/utils/string.spec.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from 'vitest'
 
-import { plural } from '../../src/utils/string.js'
+import { plural, toTitleCase } from '../../src/utils/string.js'
 
 describe('utils > string', () => {
   test('plural', () => {
@@ -8,5 +8,15 @@ describe('utils > string', () => {
     expect(plural(2, 'thing')).toEqual('2 things')
     expect(plural(1, 'bus')).toEqual('1 bus')
     expect(plural(2, 'bus')).toEqual('2 buses')
+  })
+
+  test('toTitleCase', () => {
+    expect(toTitleCase('hello world')).toEqual('Hello World')
+    expect(toTitleCase('HELLO WORLD')).toEqual('Hello World')
+    expect(toTitleCase('single')).toEqual('Single')
+    expect(toTitleCase('hello-world')).toEqual('Hello World')
+    expect(toTitleCase('hello_world')).toEqual('Hello World')
+    expect(toTitleCase('model', '-')).toEqual('Model')
+    expect(toTitleCase('data-card', '-')).toEqual('Data card')
   })
 })

--- a/infrastructure/helm/bailo/templates/bailo/bailo.configmap.yaml
+++ b/infrastructure/helm/bailo/templates/bailo/bailo.configmap.yaml
@@ -121,6 +121,10 @@ data:
             rejectUnauthorized: {{ .Values.config.smtp.rejectUnauthorized }},
           },
         },
+        lifecycle: {
+          preReminderIntervals: {{ toJson .Values.config.smtp.preReminderIntervals }},
+          postReminderInterval: '{{ .Values.config.smtp.postReminderInterval }}',
+        },
 
         // Set the email address that Bailo should use, can be different from the SMTP server details.
         from: '{{ .Values.config.smtp.from }}',

--- a/infrastructure/helm/bailo/values.yaml
+++ b/infrastructure/helm/bailo/values.yaml
@@ -287,6 +287,8 @@ config:
     pass: "mailpass"
     from: "bailo@example.com"
     transporter: "smtp"
+    preReminderIntervals: ['1 day', '2 weeks', '10 weeks']
+    postReminderInterval: '1 day'
 
   app:
     protocol: "https"


### PR DESCRIPTION
Emails are sent per entry to each model owner:
- Sends an email for specific time periods before a lifecycle review.
- Sends reminder emails every period of time after a lifecycle review has expired.