### PR TITLE
Update assorted deprecated function calls

### DIFF
--- a/backend/src/routes/v1/registryAuth.ts
+++ b/backend/src/routes/v1/registryAuth.ts
@@ -37,7 +37,7 @@ export async function getAdminToken(): Promise<string> {
   }
 
   const key = await getPrivateKey()
-  const hash = createHash('sha256').update(key).digest().slice(0, 16)
+  const hash = createHash('sha256').update(key).digest().subarray(0, 16)
   hash[6] = (hash[6] & 0x0f) | 0x40
   hash[8] = (hash[8] & 0x3f) | 0x80
 

--- a/backend/src/utils/registryUtils.ts
+++ b/backend/src/utils/registryUtils.ts
@@ -9,7 +9,7 @@ export async function getKid(cert?: X509Certificate) {
     cert = new X509Certificate(await getPublicKey())
   }
   const der = cert.publicKey.export({ format: 'der', type: 'spki' })
-  const hash = createHash('sha256').update(der).digest().slice(0, 30)
+  const hash = createHash('sha256').update(der).digest().subarray(0, 30)
 
   return formatKid(hash)
 }

--- a/backend/test/connectors/metrics/base.spec.ts
+++ b/backend/test/connectors/metrics/base.spec.ts
@@ -512,7 +512,7 @@ await describe('connectors > metrics > simple > calculateEntryVolume', async () 
 
     await expect(
       connector.calculateEntryVolume(mockUser, 'week', '2026-01-01', '2026-02-01', 'notARealTimeZone'),
-    ).rejects.toThrowError(BadReq('Invalid timezone. Must be a valid IANA timezone or UTC offset.'))
+    ).rejects.toThrow(BadReq('Invalid timezone. Must be a valid IANA timezone or UTC offset.'))
   })
 
   test('calculateEntryVolume > day interval stepping', async () => {

--- a/backend/test/routes/v3/model/images/getImage.spec.ts
+++ b/backend/test/routes/v3/model/images/getImage.spec.ts
@@ -28,7 +28,7 @@ describe('routes > images > getImageByDigest', () => {
     )
 
     expect(res.statusCode).toBe(200)
-    expect(audit.onViewModelImage).toBeCalled()
+    expect(audit.onViewModelImage).toHaveBeenCalled()
     expect(audit.onViewModelImage.mock.calls.at(0)?.at(1)).toMatchSnapshot()
     expect(audit.onViewModelImage.mock.calls.at(0)?.at(2)).toMatchSnapshot()
   })

--- a/backend/test/services/accessRequest.spec.ts
+++ b/backend/test/services/accessRequest.spec.ts
@@ -102,7 +102,7 @@ describe('services > accessRequest', () => {
     modelMocks.getModelById.mockResolvedValue({ kind: EntryKind.UntrustedModel } as any)
     schemaMocks.getSchemaById.mockResolvedValue({ jsonSchema: {} })
 
-    await expect(() => createAccessRequest({} as any, 'example-model', accessRequest)).rejects.toThrowError(
+    await expect(() => createAccessRequest({} as any, 'example-model', accessRequest)).rejects.toThrow(
       'Cannot create an access request for an untrusted model.',
     )
   })

--- a/backend/test/services/file.spec.ts
+++ b/backend/test/services/file.spec.ts
@@ -312,9 +312,9 @@ describe('services > file', () => {
 
     await expect(() =>
       uploadMultipartFilePart({} as any, modelId, testFileId, 'testUploadId', 1, new Readable() as any, 1024),
-    ).rejects.toThrowError(/^You do not have permission to upload a file to this model./)
+    ).rejects.toThrow(/^You do not have permission to upload a file to this model./)
 
-    expect(s3Mocks.putObjectPartStream).not.toBeCalled()
+    expect(s3Mocks.putObjectPartStream).not.toHaveBeenCalled()
   })
 
   test('uploadMultipartFilePart > no file', async () => {
@@ -322,9 +322,9 @@ describe('services > file', () => {
 
     await expect(() =>
       uploadMultipartFilePart({} as any, 'testModelId', testFileId, 'testUploadId', 1, new Readable() as any, 1024),
-    ).rejects.toThrowError(/^The requested file was not found./)
+    ).rejects.toThrow(/^The requested file was not found./)
 
-    expect(s3Mocks.putObjectPartStream).not.toBeCalled()
+    expect(s3Mocks.putObjectPartStream).not.toHaveBeenCalled()
   })
 
   test('finishUploadMultipartFile > success', async () => {

--- a/backend/test/services/model.spec.ts
+++ b/backend/test/services/model.spec.ts
@@ -151,10 +151,8 @@ describe('services > model', () => {
       settings: { mirror: {}, ungovernedAccess: false, allowTemplating: false },
     }
 
-    await expect(() => createModel({} as any, testModel)).rejects.toThrowError(
-      /^Untrusted models cannot be made public./,
-    )
-    expect(ModelModelMock.save).not.toBeCalled()
+    await expect(() => createModel({} as any, testModel)).rejects.toThrow(/^Untrusted models cannot be made public./)
+    expect(ModelModelMock.save).not.toHaveBeenCalled()
   })
 
   test('getModelByIdNoAuth > good', async () => {
@@ -610,7 +608,7 @@ describe('services > model', () => {
     }
     ModelModelMock.findOne.mockResolvedValueOnce(testModel)
 
-    await expect(() => updateModel({} as any, 'test123', { visibility: EntryVisibility.Public })).rejects.toThrowError(
+    await expect(() => updateModel({} as any, 'test123', { visibility: EntryVisibility.Public })).rejects.toThrow(
       /^Untrusted models cannot be made public./,
     )
   })


### PR DESCRIPTION
Buffer.slice() is functionally identical to Buffer.subarray() - see https://github.com/danielleadams/node/commit/84752a495f93d766c7f7c08b812ea6c2e53df09d
