### PR TITLE
Fix possible frontend turbopack error

### DIFF
--- a/compose.override.yaml
+++ b/compose.override.yaml
@@ -12,6 +12,7 @@ services:
   frontend:
     volumes:
       - ./frontend:/app
+      - /app/node_modules/@next # use container-built @next SWC binaries (musl), not the host's (e.g. glibc)
     build:
       target: dev
 


### PR DESCRIPTION
Fixes possible frontend runtime error with `docker compose` e.g.
```
> dev
> next dev

▲ Next.js 16.2.6 (Turbopack)
- Local: http://localhost:3000
- Network: http://<ip>:3000
✓ Ready in 1234ms
⚠ Attempted to load @next/swc-linux-x64-gnu, but an error occurred: Error relocating /app/node_modules/@next/swc-linux-x64-gnu/next-swc.linux-x64-gnu.node: __register_atfork: symbol not found
⚠ Attempted to load @next/swc-linux-x64-musl, but it was not installed
  Skipping creating a lockfile at /app/.next/dev/lock because we're using WASM bindings
Error: Turbopack is not supported on this platform (linux/x64) because native bindings are not available. Only WebAssembly (WASM) bindings were loaded, and Turbopack required native bindings.
```
by keeping the source bind-mount for hot-reload, but use an anonymous volume to preserve the container's own `node_modules/@next` directory.