### PR TITLE
Add announcement printout to python package

### DIFF
--- a/lib/python/CHANGELOG.md
+++ b/lib/python/CHANGELOG.md
@@ -2,10 +2,19 @@
 
 All dates are formatted dd/mm/yyyy.
 
-## 3.7.2 - dd/mm/2026
+## 3.8.0 - dd/mm/2026
+
+### Changes
+
+- Display Bailo announcements in log, similar to tools like git. These will only be displayed once every 24 hours. This can be disabled with `Client(announcements=False)`.
+- Update package dependencies.
+
+## 3.7.2 - 11/05/2026
+
+### Changes
 
 - Fix boolean to string conversion for API requests.
-- Extend unit & integration test coverage
+- Extend unit & integration test coverage.
 
 ## 3.7.1 - 27/04/2026
 

--- a/lib/python/CHANGELOG.md
+++ b/lib/python/CHANGELOG.md
@@ -6,7 +6,7 @@ All dates are formatted dd/mm/yyyy.
 
 ### Changes
 
-- Display Bailo announcements in log, similar to tools like git. These will only be displayed once every 24 hours. This can be disabled with `Client(announcements=False)`.
+- Display Bailo announcements in logger `bailo.announcements`. These will only be displayed once every 24 hours per `Client`. This can be disabled with `Client(announcements=False)`.
 - Update package dependencies.
 
 ## 3.7.2 - 11/05/2026

--- a/lib/python/pyproject.toml
+++ b/lib/python/pyproject.toml
@@ -22,6 +22,7 @@ classifiers = [
 requires-python = ">=3.10"
 dynamic = ["version"]
 dependencies = [
+    "backports-datetime-fromisoformat==2.0.3; python_version < '3.11'",
     "requests==2.34.2",
     "semantic-version==2.10.0",
     "tqdm==4.68.1"

--- a/lib/python/src/bailo/__init__.py
+++ b/lib/python/src/bailo/__init__.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 import logging
 
 # Package Version
-__version__ = "3.7.2"
+__version__ = "3.8.0"
 
 
 from bailo.core.agent import Agent, PkiAgent, TokenAgent

--- a/lib/python/src/bailo/core/client.py
+++ b/lib/python/src/bailo/core/client.py
@@ -7,9 +7,18 @@ import time
 from io import BytesIO
 from typing import Any
 
+try:
+    from backports.datetime_fromisoformat import MonkeyPatch  # pyright: ignore[reportMissingImports]
+except ImportError:
+    MonkeyPatch = None
+
 from bailo.core.agent import Agent, TokenAgent
 from bailo.core.enums import CollaboratorEntry, EntryKind, ModelVisibility, SchemaKind
 from bailo.core.utils import filter_none, normalise_query_params
+
+if MonkeyPatch is not None:
+    # backport `datetime.fromisoformat` 3.11 changes https://pypi.org/project/backports-datetime-fromisoformat/
+    MonkeyPatch.patch_fromisoformat()
 
 logger = logging.getLogger(__name__)
 # Give users a clean way to suppress/reformat announcements without affecting debug/error logs
@@ -74,14 +83,12 @@ class Client:
                     return
 
                 start_timestamp = announcement.get("startTimestamp", "")
-                # Python 3.10 support - see https://docs.python.org/3/library/datetime.html#datetime.datetime.fromisoformat for origin
-                start_timestamp = start_timestamp.replace("Z", "+00:00")
                 now = datetime.datetime.now(datetime.timezone.utc)
                 if not start_timestamp == "" and now < datetime.datetime.fromisoformat(start_timestamp):
                     return
 
                 for line in text.splitlines():
-                    announcement_logger.info("remote: %s", line)
+                    announcement_logger.warning("remote: %s", line)
             except Exception:  # pylint: disable=broad-exception-caught
                 logger.debug("Failed to check for server announcements", exc_info=True)
 

--- a/lib/python/src/bailo/core/client.py
+++ b/lib/python/src/bailo/core/client.py
@@ -72,6 +72,8 @@ class Client:
                 return
 
             start_timestamp = announcement.get("startTimestamp", "")
+            # Python 3.10 support - see https://docs.python.org/3/library/datetime.html#datetime.datetime.fromisoformat for origin
+            start_timestamp = start_timestamp.replace("Z", "+00:00")
             now = datetime.datetime.now(datetime.timezone.utc)
             if not start_timestamp == "" and now < datetime.datetime.fromisoformat(start_timestamp):
                 return

--- a/lib/python/src/bailo/core/client.py
+++ b/lib/python/src/bailo/core/client.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import datetime
 import logging
-import sys
+import threading
 import time
 from io import BytesIO
 from typing import Any
@@ -12,6 +12,8 @@ from bailo.core.enums import CollaboratorEntry, EntryKind, ModelVisibility, Sche
 from bailo.core.utils import filter_none, normalise_query_params
 
 logger = logging.getLogger(__name__)
+# Give users a clean way to suppress/reformat announcements without affecting debug/error logs
+announcement_logger = logging.getLogger("bailo.announcements")
 
 
 class Client:
@@ -34,12 +36,12 @@ class Client:
         self._agent = agent or Agent()
         self._announcements_enabled = announcements
         self._last_announcement_check: float | None = None
-        self._checking_announcement = False
+        self._announcement_lock = threading.Lock()
 
     @property
     def agent(self) -> Agent:
         """Return the HTTP agent, checking for announcements periodically."""
-        if self._announcements_enabled and not self._checking_announcement:
+        if self._announcements_enabled:
             self._maybe_check_announcement()
         return self._agent
 
@@ -59,31 +61,29 @@ class Client:
 
     def _check_announcement(self) -> None:
         """Fetch the server announcement and print it to stderr if enabled and current."""
-        self._checking_announcement = True
-        try:
-            response = self._agent.get(f"{self.url}/v2/config/ui").json()
-            announcement = response.get("uiConfig", {}).get("announcement", {})
+        with self._announcement_lock:
+            try:
+                response = self._agent.get(f"{self.url}/v2/config/ui").json()
+                announcement = response.get("uiConfig", {}).get("announcement", {})
 
-            if not announcement.get("enabled", False):
-                return
+                if not announcement.get("enabled", False):
+                    return
 
-            text = announcement.get("text", "")
-            if not text:
-                return
+                text = announcement.get("text", "")
+                if not text:
+                    return
 
-            start_timestamp = announcement.get("startTimestamp", "")
-            # Python 3.10 support - see https://docs.python.org/3/library/datetime.html#datetime.datetime.fromisoformat for origin
-            start_timestamp = start_timestamp.replace("Z", "+00:00")
-            now = datetime.datetime.now(datetime.timezone.utc)
-            if not start_timestamp == "" and now < datetime.datetime.fromisoformat(start_timestamp):
-                return
+                start_timestamp = announcement.get("startTimestamp", "")
+                # Python 3.10 support - see https://docs.python.org/3/library/datetime.html#datetime.datetime.fromisoformat for origin
+                start_timestamp = start_timestamp.replace("Z", "+00:00")
+                now = datetime.datetime.now(datetime.timezone.utc)
+                if not start_timestamp == "" and now < datetime.datetime.fromisoformat(start_timestamp):
+                    return
 
-            for line in text.splitlines():
-                print(f"remote: {line}", file=sys.stderr)
-        except Exception:  # pylint: disable=broad-exception-caught
-            logger.debug("Failed to check for server announcements", exc_info=True)
-        finally:
-            self._checking_announcement = False
+                for line in text.splitlines():
+                    announcement_logger.info("remote: %s", line)
+            except Exception:  # pylint: disable=broad-exception-caught
+                logger.debug("Failed to check for server announcements", exc_info=True)
 
     def get_ui_config(self):
         """Retrieve the UI configuration from the server.

--- a/lib/python/src/bailo/core/client.py
+++ b/lib/python/src/bailo/core/client.py
@@ -1,11 +1,17 @@
 from __future__ import annotations
 
+import datetime
+import logging
+import sys
+import time
 from io import BytesIO
 from typing import Any
 
 from bailo.core.agent import Agent, TokenAgent
 from bailo.core.enums import CollaboratorEntry, EntryKind, ModelVisibility, SchemaKind
 from bailo.core.utils import filter_none, normalise_query_params
+
+logger = logging.getLogger(__name__)
 
 
 class Client:
@@ -15,14 +21,76 @@ class Client:
     :param agent: An agent object to handle requests
     """
 
-    def __init__(self, url: str, agent: Agent | None = None):
+    _ANNOUNCEMENT_CHECK_INTERVAL = 60 * 60 * 24  # 24 hours
+
+    def __init__(self, url: str, agent: Agent | None = None, *, announcements: bool = True):
         """Initialise a Client.
 
         :param url: URL of the Bailo instance website.
         :param agent: An agent object to handle requests, defaults to Agent().
+        :param announcements: Whether to check and display server announcements, defaults to True.
         """
         self.url = url.rstrip("/") + "/api"
-        self.agent = agent or Agent()
+        self._agent = agent or Agent()
+        self._announcements_enabled = announcements
+        self._last_announcement_check: float | None = None
+        self._checking_announcement = False
+
+    @property
+    def agent(self) -> Agent:
+        """Return the HTTP agent, checking for announcements periodically."""
+        if self._announcements_enabled and not self._checking_announcement:
+            self._maybe_check_announcement()
+        return self._agent
+
+    @agent.setter
+    def agent(self, value: Agent) -> None:
+        self._agent = value
+
+    def _maybe_check_announcement(self) -> None:
+        """Check for announcements if enough time has elapsed since the last check."""
+        now = time.monotonic()
+        if (
+            self._last_announcement_check is None
+            or (now - self._last_announcement_check) >= self._ANNOUNCEMENT_CHECK_INTERVAL
+        ):
+            self._check_announcement()
+            self._last_announcement_check = now
+
+    def _check_announcement(self) -> None:
+        """Fetch the server announcement and print it to stderr if enabled and current."""
+        self._checking_announcement = True
+        try:
+            response = self._agent.get(f"{self.url}/v2/config/ui").json()
+            announcement = response.get("uiConfig", {}).get("announcement", {})
+
+            if not announcement.get("enabled", False):
+                return
+
+            text = announcement.get("text", "")
+            if not text:
+                return
+
+            start_timestamp = announcement.get("startTimestamp", "")
+            now = datetime.datetime.now(datetime.timezone.utc)
+            if not start_timestamp == "" and now < datetime.datetime.fromisoformat(start_timestamp):
+                return
+
+            for line in text.splitlines():
+                print(f"remote: {line}", file=sys.stderr)
+        except Exception:  # pylint: disable=broad-exception-caught
+            logger.debug("Failed to check for server announcements", exc_info=True)
+        finally:
+            self._checking_announcement = False
+
+    def get_ui_config(self):
+        """Retrieve the UI configuration from the server.
+
+        :return: JSON response object containing the UI configuration.
+        """
+        return self._agent.get(
+            f"{self.url}/v2/config/ui",
+        ).json()
 
     def post_model(
         self,

--- a/lib/python/src/bailo/core/client.py
+++ b/lib/python/src/bailo/core/client.py
@@ -49,7 +49,7 @@ class Client:
 
     def _maybe_check_announcement(self) -> None:
         """Check for announcements if enough time has elapsed since the last check."""
-        now = time.monotonic()
+        now = time.time()
         if (
             self._last_announcement_check is None
             or (now - self._last_announcement_check) >= self._ANNOUNCEMENT_CHECK_INTERVAL

--- a/lib/python/tests/test_client.py
+++ b/lib/python/tests/test_client.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import logging
 import random
 
 import pytest
@@ -496,18 +497,18 @@ def test_get_ui_config(requests_mock):
     assert result["uiConfig"]["announcement"]["text"] == "Maintenance Saturday"
 
 
-def test_announcement_displayed_on_first_use(requests_mock, capsys):
+def test_announcement_displayed_on_first_use(requests_mock, caplog):
     requests_mock.get("https://example.com/api/v2/config/ui", json=MOCK_UI_CONFIG)
     requests_mock.get("https://example.com/api/v2/model/test_id", json=mock_result)
 
     client = Client("https://example.com")
-    client.get_model(model_id="test_id")
+    with caplog.at_level(logging.INFO, logger="bailo.announcements"):
+        client.get_model(model_id="test_id")
 
-    captured = capsys.readouterr()
-    assert "remote: Maintenance Saturday" in captured.err
+    assert "remote: Maintenance Saturday" in caplog.text
 
 
-def test_announcement_not_displayed_when_disabled(requests_mock, capsys):
+def test_announcement_not_displayed_when_disabled(requests_mock, caplog):
     config = {
         "uiConfig": {"announcement": {"enabled": False, "text": "Hidden", "startTimestamp": "1970-01-01T00:00:00Z"}}
     }
@@ -515,69 +516,67 @@ def test_announcement_not_displayed_when_disabled(requests_mock, capsys):
     requests_mock.get("https://example.com/api/v2/model/test_id", json=mock_result)
 
     client = Client("https://example.com")
-    client.get_model(model_id="test_id")
+    with caplog.at_level(logging.INFO, logger="bailo.announcements"):
+        client.get_model(model_id="test_id")
 
-    captured = capsys.readouterr()
-    assert "remote:" not in captured.err
+    assert "remote:" not in caplog.text
 
 
-def test_announcement_not_displayed_when_empty_text(requests_mock, capsys):
+def test_announcement_not_displayed_when_empty_text(requests_mock, caplog):
     config = {"uiConfig": {"announcement": {"enabled": True, "text": "", "startTimestamp": "1970-01-01T00:00:00Z"}}}
     requests_mock.get("https://example.com/api/v2/config/ui", json=config)
     requests_mock.get("https://example.com/api/v2/model/test_id", json=mock_result)
 
     client = Client("https://example.com")
-    client.get_model(model_id="test_id")
+    with caplog.at_level(logging.INFO, logger="bailo.announcements"):
+        client.get_model(model_id="test_id")
 
-    captured = capsys.readouterr()
-    assert "remote:" not in captured.err
+    assert "remote:" not in caplog.text
 
 
-def test_announcement_not_future_timestamp(requests_mock, capsys):
-    config = {"uiConfig": {"announcement": {"enabled": True, "text": "", "startTimestamp": "2099-01-01T00:00:00Z"}}}
+def test_announcement_not_future_timestamp(requests_mock, caplog):
+    config = {"uiConfig": {"announcement": {"enabled": True, "text": "text", "startTimestamp": "2099-01-01T00:00:00Z"}}}
     requests_mock.get("https://example.com/api/v2/config/ui", json=config)
     requests_mock.get("https://example.com/api/v2/model/test_id", json=mock_result)
 
     client = Client("https://example.com")
-    client.get_model(model_id="test_id")
-    capsys.readouterr()
+    with caplog.at_level(logging.INFO, logger="bailo.announcements"):
+        client.get_model(model_id="test_id")
 
-    client._last_announcement_check = None
-    client.get_model(model_id="test_id")
+        client._last_announcement_check = None
+        client.get_model(model_id="test_id")
 
-    captured = capsys.readouterr()
-    assert "remote:" not in captured.err
+    assert "remote:" not in caplog.text
 
 
-def test_announcement_redisplayed_on_new_timestamp(requests_mock, capsys):
+def test_announcement_redisplayed_on_new_timestamp(requests_mock, caplog):
     requests_mock.get("https://example.com/api/v2/config/ui", json=MOCK_UI_CONFIG)
     requests_mock.get("https://example.com/api/v2/model/test_id", json=mock_result)
 
     client = Client("https://example.com")
     client.get_model(model_id="test_id")
-    capsys.readouterr()
 
     updated_config = {
         "uiConfig": {"announcement": {"enabled": True, "text": "V2 notice", "startTimestamp": "1970-06-01T00:00:00Z"}}
     }
     requests_mock.get("https://example.com/api/v2/config/ui", json=updated_config)
     client._last_announcement_check = None
-    client.get_model(model_id="test_id")
+    with caplog.at_level(logging.INFO, logger="bailo.announcements"):
+        client.get_model(model_id="test_id")
 
-    captured = capsys.readouterr()
-    assert "remote: V2 notice" in captured.err
+    assert "remote: V2 notice" in caplog.text
 
 
-def test_announcement_failure_silent(requests_mock, capsys):
+def test_announcement_failure_silent(requests_mock, caplog):
     requests_mock.get("https://example.com/api/v2/config/ui", status_code=500)
     requests_mock.get("https://example.com/api/v2/model/test_id", json=mock_result)
 
     client = Client("https://example.com")
-    result = client.get_model(model_id="test_id")
+    with caplog.at_level(logging.INFO, logger="bailo.announcements"):
+        result = client.get_model(model_id="test_id")
 
     assert result == mock_result
-    captured = capsys.readouterr()
-    assert "remote:" not in captured.err
+    assert "remote:" not in caplog.text
 
 
 def test_announcement_opt_out(requests_mock):
@@ -590,7 +589,7 @@ def test_announcement_opt_out(requests_mock):
     assert not any("config/ui" in h.url for h in requests_mock.request_history)
 
 
-def test_announcement_multiline(requests_mock, capsys):
+def test_announcement_multiline(requests_mock, caplog):
     config = {
         "uiConfig": {
             "announcement": {
@@ -604,10 +603,12 @@ def test_announcement_multiline(requests_mock, capsys):
     requests_mock.get("https://example.com/api/v2/model/test_id", json=mock_result)
 
     client = Client("https://example.com")
-    client.get_model(model_id="test_id")
+    with caplog.at_level(logging.INFO, logger="bailo.announcements"):
+        client.get_model(model_id="test_id")
 
-    captured = capsys.readouterr()
-    assert "remote: Line 1\nremote: Line 2\nremote: Line 3\n" in captured.err
+    assert "remote: Line 1\n" in caplog.text
+    assert "remote: Line 2\n" in caplog.text
+    assert "remote: Line 3\n" in caplog.text
 
 
 def test_announcement_no_recheck_within_24h(requests_mock):

--- a/lib/python/tests/test_client.py
+++ b/lib/python/tests/test_client.py
@@ -15,6 +15,16 @@ from example_schemas import METRICS_JSON_SCHEMA
 
 mock_result = {"success": True}
 
+MOCK_UI_CONFIG = {
+    "uiConfig": {
+        "announcement": {
+            "enabled": True,
+            "text": "Maintenance Saturday",
+            "startTimestamp": "1970-01-01T00:00:00Z",
+        }
+    }
+}
+
 
 def test_bailo_exception(requests_mock):
     requests_mock.get(
@@ -475,6 +485,145 @@ def test_put_image_scan(requests_mock):
     result = client.put_image_scan(model_id="test_model_id", image_name="test_image_name", image_tag="test_image_tag")
 
     assert result == {"status": "Scan started"}
+
+
+def test_get_ui_config(requests_mock):
+    requests_mock.get("https://example.com/api/v2/config/ui", json=MOCK_UI_CONFIG)
+
+    client = Client("https://example.com", announcements=False)
+    result = client.get_ui_config()
+
+    assert result["uiConfig"]["announcement"]["text"] == "Maintenance Saturday"
+
+
+def test_announcement_displayed_on_first_use(requests_mock, capsys):
+    requests_mock.get("https://example.com/api/v2/config/ui", json=MOCK_UI_CONFIG)
+    requests_mock.get("https://example.com/api/v2/model/test_id", json=mock_result)
+
+    client = Client("https://example.com")
+    client.get_model(model_id="test_id")
+
+    captured = capsys.readouterr()
+    assert "remote: Maintenance Saturday" in captured.err
+
+
+def test_announcement_not_displayed_when_disabled(requests_mock, capsys):
+    config = {
+        "uiConfig": {"announcement": {"enabled": False, "text": "Hidden", "startTimestamp": "1970-01-01T00:00:00Z"}}
+    }
+    requests_mock.get("https://example.com/api/v2/config/ui", json=config)
+    requests_mock.get("https://example.com/api/v2/model/test_id", json=mock_result)
+
+    client = Client("https://example.com")
+    client.get_model(model_id="test_id")
+
+    captured = capsys.readouterr()
+    assert "remote:" not in captured.err
+
+
+def test_announcement_not_displayed_when_empty_text(requests_mock, capsys):
+    config = {"uiConfig": {"announcement": {"enabled": True, "text": "", "startTimestamp": "1970-01-01T00:00:00Z"}}}
+    requests_mock.get("https://example.com/api/v2/config/ui", json=config)
+    requests_mock.get("https://example.com/api/v2/model/test_id", json=mock_result)
+
+    client = Client("https://example.com")
+    client.get_model(model_id="test_id")
+
+    captured = capsys.readouterr()
+    assert "remote:" not in captured.err
+
+
+def test_announcement_not_future_timestamp(requests_mock, capsys):
+    config = {"uiConfig": {"announcement": {"enabled": True, "text": "", "startTimestamp": "2099-01-01T00:00:00Z"}}}
+    requests_mock.get("https://example.com/api/v2/config/ui", json=config)
+    requests_mock.get("https://example.com/api/v2/model/test_id", json=mock_result)
+
+    client = Client("https://example.com")
+    client.get_model(model_id="test_id")
+    capsys.readouterr()
+
+    client._last_announcement_check = None
+    client.get_model(model_id="test_id")
+
+    captured = capsys.readouterr()
+    assert "remote:" not in captured.err
+
+
+def test_announcement_redisplayed_on_new_timestamp(requests_mock, capsys):
+    requests_mock.get("https://example.com/api/v2/config/ui", json=MOCK_UI_CONFIG)
+    requests_mock.get("https://example.com/api/v2/model/test_id", json=mock_result)
+
+    client = Client("https://example.com")
+    client.get_model(model_id="test_id")
+    capsys.readouterr()
+
+    updated_config = {
+        "uiConfig": {"announcement": {"enabled": True, "text": "V2 notice", "startTimestamp": "1970-06-01T00:00:00Z"}}
+    }
+    requests_mock.get("https://example.com/api/v2/config/ui", json=updated_config)
+    client._last_announcement_check = None
+    client.get_model(model_id="test_id")
+
+    captured = capsys.readouterr()
+    assert "remote: V2 notice" in captured.err
+
+
+def test_announcement_failure_silent(requests_mock, capsys):
+    requests_mock.get("https://example.com/api/v2/config/ui", status_code=500)
+    requests_mock.get("https://example.com/api/v2/model/test_id", json=mock_result)
+
+    client = Client("https://example.com")
+    result = client.get_model(model_id="test_id")
+
+    assert result == mock_result
+    captured = capsys.readouterr()
+    assert "remote:" not in captured.err
+
+
+def test_announcement_opt_out(requests_mock):
+    requests_mock.get("https://example.com/api/v2/model/test_id", json=mock_result)
+
+    client = Client("https://example.com", announcements=False)
+    result = client.get_model(model_id="test_id")
+
+    assert result == mock_result
+    assert not any("config/ui" in h.url for h in requests_mock.request_history)
+
+
+def test_announcement_multiline(requests_mock, capsys):
+    config = {
+        "uiConfig": {
+            "announcement": {
+                "enabled": True,
+                "text": "Line 1\nLine 2\nLine 3",
+                "startTimestamp": "1970-01-01T00:00:00Z",
+            }
+        }
+    }
+    requests_mock.get("https://example.com/api/v2/config/ui", json=config)
+    requests_mock.get("https://example.com/api/v2/model/test_id", json=mock_result)
+
+    client = Client("https://example.com")
+    client.get_model(model_id="test_id")
+
+    captured = capsys.readouterr()
+    assert "remote: Line 1\nremote: Line 2\nremote: Line 3\n" in captured.err
+
+
+def test_announcement_no_recheck_within_24h(requests_mock):
+    requests_mock.get("https://example.com/api/v2/config/ui", json=MOCK_UI_CONFIG)
+    requests_mock.get("https://example.com/api/v2/model/test_id", json=mock_result)
+
+    client = Client("https://example.com")
+    client.get_model(model_id="test_id")
+
+    config_calls = sum(1 for h in requests_mock.request_history if "config/ui" in h.url)
+    assert config_calls == 1
+
+    client.get_model(model_id="test_id")
+
+    config_calls = sum(1 for h in requests_mock.request_history if "config/ui" in h.url)
+    assert config_calls == 1
 
 
 @pytest.mark.integration


### PR DESCRIPTION
Re-use the existing `announcements` config from `GET /api/v2/config/ui` in the Python client to allow displaying important messages to non-UI users.

Announcements follow the frontend logic and are only shown when all of the following is met:
- `enabled` is `true`
- `text` is set
- `startTimestamp` is either unset or is a past date

Announcements are only shown on the first connection to the specific Bailo `Client`, and may then be redisplayed once every 24 hours. Announcements are printed to stdout via its own logger `bailo.announcements`, which allows for individual logger configuration/suppression. Announcements may be completely disabled using the `Client(announcements=False)` kwarg for headless Python clients.