### PR TITLE
Fix bad semver lookup type breaking file exports

### DIFF
--- a/backend/src/services/model.ts
+++ b/backend/src/services/model.ts
@@ -755,11 +755,20 @@ export async function createModelCardFromTemplate(
 }
 
 export async function saveImportedModelCard(modelCardRevision: Omit<ModelCardRevisionDoc, '_id'>) {
-  const { valid, errors } = await validateContentAgainstSchema(modelCardRevision.schemaId, modelCardRevision.metadata)
-  if (!valid) {
-    throw BadReq('Model metadata could not be validated against the schema.', {
-      validationErrors: errors,
-    })
+  if (modelCardRevision.version === 1) {
+    // Special case for the first when a schema is set but `metadata` is still `undefined`
+    if (modelCardRevision.metadata !== undefined) {
+      throw BadReq('Model card metadata must not be set for the first version.', {
+        metadata: modelCardRevision.metadata,
+      })
+    }
+  } else {
+    const { valid, errors } = await validateContentAgainstSchema(modelCardRevision.schemaId, modelCardRevision.metadata)
+    if (!valid) {
+      throw BadReq('Model metadata could not be validated against the schema.', {
+        validationErrors: errors,
+      })
+    }
   }
 
   const foundModelCardRevision = await ModelCardRevisionModel.findOne({

--- a/backend/src/services/release.ts
+++ b/backend/src/services/release.ts
@@ -611,8 +611,9 @@ export async function getFileByReleaseFileName(user: UserInterface, modelId: str
 }
 
 export async function getAllFileIds(modelId: string, semvers: string[]): Promise<string[]> {
+  const semverObjects = semvers.flatMap((semverString) => semverStringToObject(semverString))
   const result = await ReleaseModel.aggregate()
-    .match({ modelId, semver: { $in: semvers } })
+    .match({ modelId, semver: { $in: semverObjects } })
     .unwind({ path: '$fileIds' })
     .group({
       _id: null,


### PR DESCRIPTION
- Correct lookup to user semver objects rather than strings.
- Fix regression of validation logic for the model card `metadata` being unset for the first version of the model card