### PR TITLE
Re-add attachments to smtp after refactor

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -29,7 +29,7 @@
         "chalk": "^5.6.2",
         "clamscan": "^2.4.0",
         "config": "^4.4.0",
-        "connect-mongo": "6.0.0",
+        "connect-mongo": "^6.0.0",
         "content-disposition": "^2.0.1",
         "dedent-js": "^1.0.1",
         "dev-null": "^0.1.1",
@@ -85,6 +85,7 @@
         "@types/jsonwebtoken": "^9.0.10",
         "@types/lodash-es": "^4.17.12",
         "@types/mjml": "^5.0.0",
+        "@types/mjml-core": "^5.0.0",
         "@types/morgan": "^1.9.10",
         "@types/node": "^26.0.0",
         "@types/node-fetch": "^2.6.13",
@@ -4117,9 +4118,9 @@
       }
     },
     "node_modules/@types/mjml-core": {
-      "version": "4.15.2",
-      "resolved": "https://registry.npmjs.org/@types/mjml-core/-/mjml-core-4.15.2.tgz",
-      "integrity": "sha512-Q7SxFXgoX979HP57DEVsRI50TV8x1V4lfCA4Up9AvfINDM5oD/X9ARgfoyX1qS987JCnDLv85JjkqAjt3hZSiQ==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@types/mjml-core/-/mjml-core-5.0.0.tgz",
+      "integrity": "sha512-E1Rho2ZfVEqZekQoESDuPAw7C3MrzdUvS6YAiEPGdhQQqAchMXfdChXlSi6ly9YhZgUP026ujrRlEGJn9o/zAg==",
       "dev": true,
       "license": "MIT"
     },

--- a/backend/package.json
+++ b/backend/package.json
@@ -96,6 +96,7 @@
     "@types/jsonwebtoken": "^9.0.10",
     "@types/lodash-es": "^4.17.12",
     "@types/mjml": "^5.0.0",
+    "@types/mjml-core": "^5.0.0",
     "@types/morgan": "^1.9.10",
     "@types/node": "^26.0.0",
     "@types/node-fetch": "^2.6.13",

--- a/backend/src/services/smtp/emailBuilder.ts
+++ b/backend/src/services/smtp/emailBuilder.ts
@@ -1,12 +1,9 @@
 import dedent from 'dedent-js'
 import mjml2html from 'mjml'
+import Mail from 'nodemailer/lib/mailer/index.js'
 import sanitizeHtml from 'sanitize-html'
 
-export type EmailContent = {
-  subject: string
-  text: string
-  html: string
-}
+export type EmailContent = Pick<Mail.Options, 'subject' | 'text' | 'html' | 'attachments'>
 
 export type Info = {
   title: string
@@ -58,7 +55,7 @@ export async function buildEmail(
   }
 }
 
-function emailText(title, reviewMetadata: Info[], reviewActions: actions[]) {
+function emailText(title: string, reviewMetadata: Info[], reviewActions: actions[]) {
   return dedent(`
     ${title}
 
@@ -76,7 +73,7 @@ function textActions(actionsList: actions[]) {
   return `${actionsList.map((action) => `${action.name}: '${action.url}'\n`).join('')}`
 }
 
-async function emailHtml(title, reviewMetadata, reviewActions) {
+async function emailHtml(title: string, reviewMetadata: Info[], reviewActions: actions[]) {
   const email = await mjml2html(
     wrapper(`
     <mj-section padding-bottom="5px" css-class='gradient-bg' padding-bottom="5px">


### PR DESCRIPTION
Update `EmailContent` to allow for attachments, update a few types, and fix stale `@types/mjml-core` package version which was (erroneously) reporting `mjml2html` as not being `async`.