### PR TITLE
Create simple markdown style checker for docs pages

### DIFF
--- a/.github/workflows/docs-style.yml
+++ b/.github/workflows/docs-style.yml
@@ -1,0 +1,17 @@
+name: Docs style check
+
+on:
+  pull_request:
+    paths:
+      - 'frontend/pages/docs/**/*.mdx'
+      - 'frontend/scripts/check-docs-style.sh'
+      - '.github/workflows/docs-style.yml'
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v7
+      - name: Check docs style guide compliance
+        run: bash frontend/scripts/check-docs-style.sh

--- a/frontend/pages/docs/administration/llm/llm-import.mdx
+++ b/frontend/pages/docs/administration/llm/llm-import.mdx
@@ -39,7 +39,7 @@ your configuration override (for example `production.cjs` or `local.js`):
 ```
 
 For Helm deployments, these values are set in `values.yaml` under `llm` and `config.ui.llmImport`. See
-[App Configuration](../app-configuration) for details on how configuration inheritance works.
+[App Configuration](../getting-started/app-configuration) for details on how configuration inheritance works.
 
 ## Configuration options
 

--- a/frontend/pages/docs/administration/migrations/bailo-0.4.mdx
+++ b/frontend/pages/docs/administration/migrations/bailo-0.4.mdx
@@ -25,7 +25,7 @@ service.
 
 The code originally in `server` is now stored in the `backend` folder.
 
-### Turbo
+## Turbo
 
 Bailo v0.4 uses `turborepo` to manage the monorepo structure with separate frontend and backend apps. It provides us
 with high performance and reproducible builds, only compiling what has changed since the last compilation. The monorepo
@@ -59,7 +59,7 @@ Workspaces is a standard NPM function, read more about it on the
 [Workspaces page](https://docs.npmjs.com/cli/v7/using-npm/workspaces). In addition, the `turbopack` docs can be found
 [here](https://turbo.build/repo/docs).
 
-### ESM
+## ESM
 
 The 'backend' application now runs entirely as ESM. This requires a modern NodeJS version, at least v14+. Some changes
 are also made to how tests are written. Specifically, to mock dependencies there is now a need to mock the dependency
@@ -82,7 +82,7 @@ be read on how Jest works with ESM [here](https://jestjs.io/docs/ecmascript-modu
 within the application, beyond imports requiring a `.js` ending. We have `esModuleInterop` enabled, which should mean we
 remain compatible with both old and new packages.
 
-#### What is ESM?
+### What is ESM?
 
 ESM, or ECMAScript Modules, is the latest standard for packaging / modularising JS code, as opposed to CJS (CommonJS),
 or Common JavaScript. ESM has a number of benefits that include nicer import/export syntax, better code reusability, and
@@ -93,7 +93,7 @@ For more information about ESM, we recommend visiting:
 - [nodejs.org](https://nodejs.org/api/esm.html)
 - [webpack.js.org](https://webpack.js.org/guides/ecma-script-modules/)
 
-### Helm
+## Helm
 
 {/* Helm charts were updated to support the new two-container architecture. */}
 
@@ -109,7 +109,7 @@ minimal setup.
 The helm folder has changed, it is now stored in `infrastructure/helm`, this change was made to allow other deploy
 methods.
 
-### Config
+## Config
 
 Configuration options were reorganised and standardised in v0.4.
 

--- a/frontend/pages/docs/style-guide.mdx
+++ b/frontend/pages/docs/style-guide.mdx
@@ -50,7 +50,7 @@ Every page must include a blockquote immediately after the H1 that lists two to 
 
 Use bold for the label:
 
-> Common questions this page answers:
+> **Common questions this page answers:**
 >
 > - What does this feature do?
 > - How do I configure it?

--- a/frontend/pages/docs/users/programmatically-using-bailo/open-api.mdx
+++ b/frontend/pages/docs/users/programmatically-using-bailo/open-api.mdx
@@ -6,6 +6,12 @@ import bailoSwaggerDocs from 'public/docs/bailo_swagger_docs.png'
 
 # OpenAPI Documentation
 
+> **Common questions this page answers:**
+>
+> - How do I view the Bailo API specification?
+> - What tools can I use with the OpenAPI specification?
+> - Where do I find the Swagger UI?
+
 Bailo provides an OpenAPI specification for all Bailo endpoints viewable [here](../../../api/docs) on a running Bailo
 instance.
 

--- a/frontend/scripts/check-docs-style.sh
+++ b/frontend/scripts/check-docs-style.sh
@@ -1,0 +1,153 @@
+#!/usr/bin/env bash
+# This script intentionally performs a lightweight set of heuristic checks to catch common style-guide violations in CI.
+# It is not a full MDX or Markdown parser and does not attempt to validate every possible document structure or edge case.
+#
+# The checks are designed to provide fast feedback with a low maintenance cost.
+# False positives and false negatives are possible, particularly for complex MDX content, unusual formatting, or constructs that span multiple lines.
+#
+# If additional validation requirements arise, prefer keeping the rules simple where possible and consider using a dedicated Markdown/MDX parser rather
+# than continually increasing the complexity of this shell script.
+set -euo pipefail
+
+DOCS_DIR="frontend/pages/docs"
+ERRORS=0
+REPO_ROOT="$(pwd)"
+DOCS_ABS="$REPO_ROOT/$DOCS_DIR"
+
+EXCLUDE_FILES=(
+  "$DOCS_DIR/markdown-examples.mdx"
+  "$DOCS_DIR/style-guide.mdx"
+)
+
+is_excluded() {
+  local file="$1"
+  for excl in "${EXCLUDE_FILES[@]}"; do
+    [[ "$file" == "$excl" ]] && return 0
+  done
+  return 1
+}
+
+error() {
+  echo "ERROR: $1"
+  ERRORS=$((ERRORS + 1))
+}
+
+mapfile -t MDX_FILES < <(find "$DOCS_DIR" -name '*.mdx' -type f | sort)
+
+for file in "${MDX_FILES[@]}"; do
+  is_excluded "$file" && continue
+
+  file_dir="$(dirname "$file")"
+  line_num=0
+  h1_count=0
+  has_common_questions=false
+  has_docs_wrapper=false
+  in_code_block=false
+
+  while IFS= read -r line || [[ -n "$line" ]]; do
+    line_num=$((line_num + 1))
+
+    # Track fenced code blocks to avoid false positives
+    if [[ "$line" =~ ^\`\`\` ]]; then
+      if $in_code_block; then
+        in_code_block=false
+      else
+        in_code_block=true
+      fi
+      continue
+    fi
+    $in_code_block && continue
+
+    # Check H1 count
+    if [[ "$line" =~ ^#[[:space:]][^#] ]]; then
+      h1_count=$((h1_count + 1))
+    fi
+
+    # Check H4+ headings
+    if [[ "$line" =~ ^#{4,}[[:space:]] ]]; then
+      error "$file:$line_num: H4 or deeper heading found (style guide says no H4+)"
+    fi
+
+    # Check common questions callout
+    if [[ "$line" =~ ^\> ]] && [[ "$line" =~ \*\*[Cc]ommon\ questions ]]; then
+      has_common_questions=true
+    fi
+
+    # Check DocsWrapper export
+    if [[ "$line" =~ export[[:space:]]+default ]] && [[ "$line" =~ DocsWrapper ]]; then
+      has_docs_wrapper=true
+    fi
+
+    # Check links (only outside code blocks)
+    check_line="$line"
+    link_re='\[([^]]+)\]\(([^)]+)\)'
+    while [[ "$check_line" =~ $link_re ]]; do
+      link_text="${BASH_REMATCH[1]}"
+      link_target="${BASH_REMATCH[2]}"
+      check_line="${check_line#*"${BASH_REMATCH[0]}"}"
+
+      # Skip external links, anchors, autolinks, and non-MDX targets (.html, etc.)
+      if [[ "$link_target" =~ ^https?:// ]] || [[ "$link_target" =~ ^# ]] \
+        || [[ "$link_target" =~ ^\< ]] || [[ "$link_target" =~ \.[a-zA-Z]+$ ]]; then
+        continue
+      fi
+
+      # Strip anchor from target
+      link_target="${link_target%%#*}"
+      # Strip query params
+      link_target="${link_target%%\?*}"
+
+      # Allow docs index page links such as "docs/getting-started/quick-start"
+      if [[ "$file" == "$DOCS_DIR/index.mdx" ]] && [[ "$link_target" == docs/* ]]; then
+        link_target="${link_target#docs/}"
+      fi
+
+      # Check for root-relative links
+      if [[ "$link_target" =~ ^/ ]]; then
+        error "$file:$line_num: Root-relative link '${link_target}' - use relative paths instead"
+        continue
+      fi
+
+      # Check for "click here" link text
+      if [[ "${link_text,,}" == "click here" ]]; then
+        error "$file:$line_num: Link text 'click here' - use descriptive link text"
+        continue
+      fi
+
+      # Resolve to absolute path and skip links outside the docs directory
+      resolved_abs="$(realpath -m "$file_dir/$link_target" 2>/dev/null)"
+      case "$resolved_abs" in
+        "$DOCS_ABS"/*) ;;
+        *) continue ;;
+      esac
+
+      if [[ ! -f "${resolved_abs}.mdx" ]] && [[ ! -f "${resolved_abs}/index.mdx" ]] && [[ ! -f "$resolved_abs" ]]; then
+        error "$file:$line_num: Broken internal link '${link_target}' - no matching .mdx file found"
+      fi
+    done
+  done < "$file"
+
+  # Per-file checks
+  if [[ $h1_count -eq 0 ]]; then
+    error "$file: Missing H1 heading"
+  elif [[ $h1_count -gt 1 ]]; then
+    error "$file: Multiple H1 headings found ($h1_count)"
+  fi
+
+  if ! $has_common_questions; then
+    error "$file: Missing common questions callout (expected '> Common questions...' block)"
+  fi
+
+  if ! $has_docs_wrapper; then
+    error "$file: Missing DocsWrapper export"
+  fi
+done
+
+if [[ $ERRORS -gt 0 ]]; then
+  echo ""
+  echo "Found $ERRORS style violation(s). See the style guide: $DOCS_DIR/style-guide.mdx"
+  exit 1
+else
+  echo "All docs style checks passed."
+  exit 0
+fi


### PR DESCRIPTION
Add a lightweight CI check to enforce key documentation style-guide rules, including heading structure, required page metadata, and internal link validation.
This also updates existing documentation pages to comply with the new checks.