### PR TITLE
Prevent useUnsavedChanges on edit model card page change

### DIFF
--- a/frontend/src/hooks/useUnsavedChanges.ts
+++ b/frontend/src/hooks/useUnsavedChanges.ts
@@ -7,6 +7,22 @@ export type UnsavedChangesHook = {
   sendWarning: () => boolean
 }
 
+/**
+ * Returns a deterministically ordered array of query parameter entries.
+ *
+ * Parameters are sorted first by key and then by value, producing a stable
+ * representation that can be safely compared regardless of the original
+ * query string ordering.
+ *
+ * @param params The URL search parameters to normalise.
+ * @returns An array of `[key, value]` tuples sorted by key and value.
+ */
+function normaliseParams(params: URLSearchParams): [string, string][] {
+  return [...params.entries()].sort(([keyA, valueA], [keyB, valueB]) =>
+    keyA === keyB ? valueA.localeCompare(valueB) : keyA.localeCompare(keyB),
+  )
+}
+
 export default function useUnsavedChanges(): UnsavedChangesHook {
   const [unsavedChanges, setUnsavedChanges] = useState(false)
 
@@ -20,9 +36,22 @@ export default function useUnsavedChanges(): UnsavedChangesHook {
       e.preventDefault()
       return (e.returnValue = warningText)
     }
-    const handleBrowseAway = () => {
+    const handleBrowseAway = (url: string) => {
       if (!unsavedChanges) {
         return
+      }
+      // Suppress edge case for switching page in JsonSchemaForm
+      const currentUrl = new URL(router.asPath, window.location.origin)
+      const destinationUrl = new URL(url, window.location.origin)
+      if (currentUrl.pathname === destinationUrl.pathname) {
+        const currentParams = new URLSearchParams(currentUrl.search)
+        const destinationParams = new URLSearchParams(destinationUrl.search)
+        currentParams.delete('page')
+        destinationParams.delete('page')
+        // stable comparison
+        if (JSON.stringify(normaliseParams(currentParams)) === JSON.stringify(normaliseParams(destinationParams))) {
+          return
+        }
       }
       const res = window.confirm(warningText)
       if (res) {

--- a/frontend/test/hooks/useUnsavedChanges.spec.ts
+++ b/frontend/test/hooks/useUnsavedChanges.spec.ts
@@ -1,0 +1,165 @@
+import { act, renderHook } from '@testing-library/react'
+import mockRouter from 'next-router-mock'
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
+
+import useUnsavedChanges from '../../src/hooks/useUnsavedChanges'
+
+describe('useUnsavedChanges', () => {
+  beforeEach(() => {
+    mockRouter.setCurrentUrl('/model/test-id?tab=overview&page=0')
+    vi.spyOn(window, 'confirm').mockReturnValue(true)
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  describe('no warning', () => {
+    test('unsavedChanges is false', async () => {
+      renderHook(() => useUnsavedChanges())
+
+      await act(async () => {
+        await mockRouter.replace('/different-page')
+      })
+
+      expect(window.confirm).not.toHaveBeenCalled()
+    })
+
+    test('only the page query param changes', async () => {
+      const { result } = renderHook(() => useUnsavedChanges())
+
+      act(() => {
+        result.current.setUnsavedChanges(true)
+      })
+
+      await act(async () => {
+        await mockRouter.replace('/model/test-id?tab=overview&page=1')
+      })
+
+      expect(window.confirm).not.toHaveBeenCalled()
+    })
+
+    test('page param is added to a URL that had none', async () => {
+      mockRouter.setCurrentUrl('/model/test-id?tab=overview')
+      const { result } = renderHook(() => useUnsavedChanges())
+
+      act(() => {
+        result.current.setUnsavedChanges(true)
+      })
+
+      await act(async () => {
+        await mockRouter.replace('/model/test-id?tab=overview&page=1')
+      })
+
+      expect(window.confirm).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('warning', () => {
+    test('navigating to a different page', async () => {
+      const { result } = renderHook(() => useUnsavedChanges())
+
+      act(() => {
+        result.current.setUnsavedChanges(true)
+      })
+
+      await act(async () => {
+        await mockRouter.replace('/different-page')
+      })
+
+      expect(window.confirm).toHaveBeenCalled()
+    })
+
+    test('the tab query param changes', async () => {
+      const { result } = renderHook(() => useUnsavedChanges())
+
+      act(() => {
+        result.current.setUnsavedChanges(true)
+      })
+
+      await act(async () => {
+        await mockRouter.replace('/model/test-id?tab=settings')
+      })
+
+      expect(window.confirm).toHaveBeenCalled()
+    })
+
+    test('both tab and page query params change', async () => {
+      const { result } = renderHook(() => useUnsavedChanges())
+
+      act(() => {
+        result.current.setUnsavedChanges(true)
+      })
+
+      await act(async () => {
+        await mockRouter.replace('/model/test-id?tab=settings&page=0')
+      })
+
+      expect(window.confirm).toHaveBeenCalled()
+    })
+  })
+
+  test('set unsavedChanges to false when user confirms the warning', async () => {
+    const { result } = renderHook(() => useUnsavedChanges())
+
+    act(() => {
+      result.current.setUnsavedChanges(true)
+    })
+
+    await act(async () => {
+      await mockRouter.replace('/different-page')
+    })
+
+    expect(result.current.unsavedChanges).toBe(false)
+  })
+
+  test('abort navigation when user cancels the warning', async () => {
+    vi.spyOn(window, 'confirm').mockReturnValue(false)
+    const { result } = renderHook(() => useUnsavedChanges())
+
+    act(() => {
+      result.current.setUnsavedChanges(true)
+    })
+
+    await expect(
+      act(async () => {
+        await mockRouter.replace('/different-page')
+      }),
+    ).rejects.toThrow('routeChange aborted.')
+
+    expect(result.current.unsavedChanges).toBe(true)
+  })
+
+  test('sendWarning returns true and resets state when user confirms', () => {
+    const { result } = renderHook(() => useUnsavedChanges())
+
+    act(() => {
+      result.current.setUnsavedChanges(true)
+    })
+
+    let returnValue: boolean
+    act(() => {
+      returnValue = result.current.sendWarning()
+    })
+
+    expect(returnValue!).toBe(true)
+    expect(result.current.unsavedChanges).toBe(false)
+  })
+
+  test('sendWarning returns false and keeps state when user cancels', () => {
+    vi.spyOn(window, 'confirm').mockReturnValue(false)
+    const { result } = renderHook(() => useUnsavedChanges())
+
+    act(() => {
+      result.current.setUnsavedChanges(true)
+    })
+
+    let returnValue: boolean
+    act(() => {
+      returnValue = result.current.sendWarning()
+    })
+
+    expect(returnValue!).toBe(false)
+    expect(result.current.unsavedChanges).toBe(true)
+  })
+})


### PR DESCRIPTION
Fix behaviour where "Any unsaved changes will be lost..." alert is shown when switching page while editing a model card, and subsequently not triggering when changing tab after dismissing the alert. The alert now ignores the `page` URL param but all others are considered. The check ignores query order (`?a=1&b=9` == `?b=9&a=1`).

Edit: planning to close this off in favour of #3740 once that adds some tests.