### PR TITLE
Optimise GitHub workflow on conditions

### DIFF
--- a/.github/workflows/artefactscan.yml
+++ b/.github/workflows/artefactscan.yml
@@ -5,6 +5,9 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
+    paths:
+      - 'lib/artefactscan_api/**'
+      - '.github/workflows/artefactscan.yml'
 
 jobs:
   artefactscan_build:

--- a/.github/workflows/artefactscan.yml
+++ b/.github/workflows/artefactscan.yml
@@ -5,6 +5,7 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
+    # Restrict PR execution to files that affect this workflow to reduce CI runtime and GitHub Actions consumption
     paths:
       - 'lib/artefactscan_api/**'
       - '.github/workflows/artefactscan.yml'

--- a/.github/workflows/build.js.yml
+++ b/.github/workflows/build.js.yml
@@ -5,6 +5,13 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
+    paths:
+      - 'backend/**'
+      - 'frontend/**'
+      - 'lib/artefactscan_api/**'
+      - 'lib/python/**'
+      - 'infrastructure/helm/bailo/**'
+      - '.github/workflows/build.js.yml'
   release:
     types: [published]
 

--- a/.github/workflows/build.js.yml
+++ b/.github/workflows/build.js.yml
@@ -5,13 +5,6 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
-    paths:
-      - 'backend/**'
-      - 'frontend/**'
-      - 'lib/artefactscan_api/**'
-      - 'lib/python/**'
-      - 'infrastructure/helm/bailo/**'
-      - '.github/workflows/build.js.yml'
   release:
     types: [published]
 

--- a/.github/workflows/codeql.js.yml
+++ b/.github/workflows/codeql.js.yml
@@ -35,7 +35,7 @@ jobs:
         uses: github/codeql-action/init@v4
         # Override language selection by uncommenting this and choosing your languages
         with:
-          languages: javascript, python
+          languages: javascript-typescript, python, actions
 
       # Autobuild attempts to build any compiled languages (C/C++, C#, Go, or Java).
       # If this step fails, then you should remove it and run the build manually (see below).

--- a/.github/workflows/docs-style.yml
+++ b/.github/workflows/docs-style.yml
@@ -5,6 +5,7 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
+    # Restrict PR execution to files that affect this workflow to reduce CI runtime and GitHub Actions consumption
     paths:
       - 'frontend/pages/docs/**/*.mdx'
       - 'frontend/scripts/check-docs-style.sh'

--- a/.github/workflows/docs-style.yml
+++ b/.github/workflows/docs-style.yml
@@ -1,14 +1,17 @@
 name: Docs style check
 
 on:
+  push:
+    branches: [main]
   pull_request:
+    branches: [main]
     paths:
       - 'frontend/pages/docs/**/*.mdx'
       - 'frontend/scripts/check-docs-style.sh'
       - '.github/workflows/docs-style.yml'
 
 jobs:
-  check:
+  docs_style_check:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -5,6 +5,7 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
+    # Restrict PR execution to files that affect this workflow to reduce CI runtime and GitHub Actions consumption
     paths:
       - 'lib/python/**'
       - '.github/workflows/python.yml'

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -5,6 +5,9 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
+    paths:
+      - 'lib/python/**'
+      - '.github/workflows/python.yml'
 
 jobs:
   python_static_checks:

--- a/.github/workflows/web.yml
+++ b/.github/workflows/web.yml
@@ -10,6 +10,11 @@ on:
     branches: ["main"]
   pull_request:
     branches: [main]
+    paths:
+      - 'backend/**'
+      - 'frontend/pages/docs/**'
+      - 'lib/landing/**'
+      - '.github/workflows/web.yml'
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:

--- a/.github/workflows/web.yml
+++ b/.github/workflows/web.yml
@@ -10,6 +10,7 @@ on:
     branches: ["main"]
   pull_request:
     branches: [main]
+    # Restrict PR execution to files that affect this workflow to reduce CI runtime and GitHub Actions consumption
     paths:
       - 'backend/**'
       - 'frontend/pages/docs/**'


### PR DESCRIPTION
Only run GitHub Workflows on a PR when relevant files change. All Workflows are still run on `main`.