### PR TITLE
Correct GitHub workflow skip logic for required

### DIFF
--- a/.github/workflows/artefactscan.yml
+++ b/.github/workflows/artefactscan.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [main]
 
+permissions:
+  contents: read
+
 jobs:
   changes:
     runs-on: ubuntu-latest

--- a/.github/workflows/artefactscan.yml
+++ b/.github/workflows/artefactscan.yml
@@ -5,13 +5,26 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
-    # Restrict PR execution to files that affect this workflow to reduce CI runtime and GitHub Actions consumption
-    paths:
-      - 'lib/artefactscan_api/**'
-      - '.github/workflows/artefactscan.yml'
 
 jobs:
+  changes:
+    runs-on: ubuntu-latest
+    outputs:
+      relevant: ${{ steps.filter.outputs.relevant }}
+    steps:
+      - uses: actions/checkout@v7
+      # Restrict PR execution to files that affect this workflow to reduce CI runtime and GitHub Actions consumption
+      - uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            relevant:
+              - 'lib/artefactscan_api/**'
+              - '.github/workflows/artefactscan.yml'
+
   artefactscan_build:
+    needs: changes
+    if: github.ref == 'refs/heads/main' || needs.changes.outputs.relevant == 'true'
     runs-on: ubuntu-latest
     strategy:
       matrix:

--- a/.github/workflows/build.js.yml
+++ b/.github/workflows/build.js.yml
@@ -11,6 +11,9 @@ on:
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 
+# jobs define their own required permissions
+permissions: {}
+
 jobs:
   build_images:
     runs-on: ubuntu-latest

--- a/.github/workflows/codeql.js.yml
+++ b/.github/workflows/codeql.js.yml
@@ -17,6 +17,9 @@ on:
     #        *  * * * *
     - cron: '30 10 * * 0'
 
+# jobs define their own required permissions
+permissions: {}
+
 jobs:
   CodeQL-Build:
     # CodeQL runs on ubuntu-latest, windows-latest, and macos-latest
@@ -24,6 +27,7 @@ jobs:
 
     permissions:
       # required for all workflows
+      contents: read
       security-events: write
 
     steps:

--- a/.github/workflows/docs-style.yml
+++ b/.github/workflows/docs-style.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [main]
 
+permissions:
+  contents: read
+
 jobs:
   changes:
     runs-on: ubuntu-latest

--- a/.github/workflows/docs-style.yml
+++ b/.github/workflows/docs-style.yml
@@ -5,14 +5,27 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
-    # Restrict PR execution to files that affect this workflow to reduce CI runtime and GitHub Actions consumption
-    paths:
-      - 'frontend/pages/docs/**/*.mdx'
-      - 'frontend/scripts/check-docs-style.sh'
-      - '.github/workflows/docs-style.yml'
 
 jobs:
+  changes:
+    runs-on: ubuntu-latest
+    outputs:
+      relevant: ${{ steps.filter.outputs.relevant }}
+    steps:
+      - uses: actions/checkout@v7
+      # Restrict PR execution to files that affect this workflow to reduce CI runtime and GitHub Actions consumption
+      - uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            relevant:
+              - 'frontend/pages/docs/**/*.mdx'
+              - 'frontend/scripts/check-docs-style.sh'
+              - '.github/workflows/docs-style.yml'
+
   docs_style_check:
+    needs: changes
+    if: github.ref == 'refs/heads/main' || needs.changes.outputs.relevant == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:

--- a/.github/workflows/python-publish-test.yml
+++ b/.github/workflows/python-publish-test.yml
@@ -6,6 +6,9 @@ on:
       tags:
         description: 'Publish to TestPyPI.'
 
+permissions:
+  contents: read
+
 jobs:
   build:
     name: Build distribution

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -4,6 +4,9 @@ on:
   push:
     branches: [main]
 
+permissions:
+  contents: read
+
 jobs:
   build:
     name: Build distribution

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [main]
 
+permissions:
+  contents: read
+
 jobs:
   changes:
     runs-on: ubuntu-latest

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -5,13 +5,26 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
-    # Restrict PR execution to files that affect this workflow to reduce CI runtime and GitHub Actions consumption
-    paths:
-      - 'lib/python/**'
-      - '.github/workflows/python.yml'
 
 jobs:
+  changes:
+    runs-on: ubuntu-latest
+    outputs:
+      relevant: ${{ steps.filter.outputs.relevant }}
+    steps:
+      - uses: actions/checkout@v7
+      # Restrict PR execution to files that affect this workflow to reduce CI runtime and GitHub Actions consumption
+      - uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            relevant:
+              - 'lib/python/**'
+              - '.github/workflows/python.yml'
+
   python_static_checks:
+    needs: changes
+    if: github.ref == 'refs/heads/main' || needs.changes.outputs.relevant == 'true'
     runs-on: ubuntu-latest
     outputs:
       black: ${{ steps.black.outputs.status }}
@@ -55,7 +68,8 @@ jobs:
 
 
   python_test:
-    needs: python_static_checks
+    needs: [changes, python_static_checks]
+    if: github.ref == 'refs/heads/main' || needs.changes.outputs.relevant == 'true'
     runs-on: ubuntu-latest
     strategy:
       matrix:

--- a/.github/workflows/web.yml
+++ b/.github/workflows/web.yml
@@ -10,12 +10,6 @@ on:
     branches: ["main"]
   pull_request:
     branches: [main]
-    # Restrict PR execution to files that affect this workflow to reduce CI runtime and GitHub Actions consumption
-    paths:
-      - 'backend/**'
-      - 'frontend/pages/docs/**'
-      - 'lib/landing/**'
-      - '.github/workflows/web.yml'
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
@@ -27,7 +21,26 @@ permissions:
   id-token: write
 
 jobs:
+  changes:
+    runs-on: ubuntu-latest
+    outputs:
+      relevant: ${{ steps.filter.outputs.relevant }}
+    steps:
+      - uses: actions/checkout@v7
+      # Restrict PR execution to files that affect this workflow to reduce CI runtime and GitHub Actions consumption
+      - uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            relevant:
+              - 'backend/**'
+              - 'frontend/pages/docs/**'
+              - 'lib/landing/**'
+              - '.github/workflows/web.yml'
+
   sphinx:
+    needs: changes
+    if: github.ref == 'refs/heads/main' || needs.changes.outputs.relevant == 'true'
     runs-on: ubuntu-latest
     defaults:
       run:
@@ -60,7 +73,8 @@ jobs:
 
   # Build job
   build:
-    needs: sphinx
+    needs: [changes, sphinx]
+    if: github.ref == 'refs/heads/main' || needs.changes.outputs.relevant == 'true'
     runs-on: ubuntu-latest
     defaults:
       run:
@@ -137,8 +151,8 @@ jobs:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
     runs-on: ubuntu-latest
-    needs: build
-    if: github.ref == 'refs/heads/main'
+    needs: [changes, build]
+    if: needs.changes.outputs.relevant == 'true' && github.ref == 'refs/heads/main'
     steps:
       - name: Deploy to GitHub Pages
         id: deployment


### PR DESCRIPTION
- Fix for workflows being skipped due to path filtering blocking merges as checks associated with that workflow remain in a "Pending" state (see [GitHub docs](https://docs.github.com/en/enterprise-cloud@latest/pull-requests/collaborating-with-pull-requests/collaborating-on-repositories-with-code-quality-features/troubleshooting-required-status-checks#handling-skipped-but-required-checks)).
- Add top level `permissions` to all workflows as per [actions/missing-workflow-permissions](https://codeql.github.com/codeql-query-help/actions/actions-missing-workflow-permissions/)