### PR TITLE
Add new job for GitHub matrix jobs required success check

### DIFF
--- a/.github/workflows/artefactscan.yml
+++ b/.github/workflows/artefactscan.yml
@@ -66,3 +66,14 @@ jobs:
           python -m pytest -m integration
         env:
           PYTEST_RUN_PATH: "lib/artefactscan_api"
+
+  # Gate job for branch protection: always runs so the required check is never left pending when the matrix is skipped
+  artefactscan_build_result:
+    if: always()
+    needs: [changes, artefactscan_build]
+    runs-on: ubuntu-latest
+    steps:
+      - run: exit 1
+        if: >-
+          needs.artefactscan_build.result == 'failure'
+          || (needs.changes.outputs.relevant == 'true' && needs.artefactscan_build.result != 'success')

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -107,3 +107,14 @@ jobs:
           python -m pytest
         env:
           PYTEST_RUN_PATH: "lib/python"
+
+  # Gate job for branch protection: always runs so the required check is never left pending when the matrix is skipped
+  python_test_result:
+    if: always()
+    needs: [changes, python_test]
+    runs-on: ubuntu-latest
+    steps:
+      - run: exit 1
+        if: >-
+          needs.python_test.result == 'failure'
+          || (needs.changes.outputs.relevant == 'true' && needs.python_test.result != 'success')


### PR DESCRIPTION
Previously, if a job was skipped then only `python_test` (or `artefactscan_build`) job was created, but if not skipped then `python_test (3.10)` etc. were created for each matrix entry. This PR adds a new gate job which depends on full completion of the prior job(s) so covers both skipped and run jobs, so we can make the gate job required which has a stable name, rather than having issues with differing names.