### PR TITLE
Fix mirrored model card import from templated model

### DIFF
--- a/backend/src/services/model.ts
+++ b/backend/src/services/model.ts
@@ -753,14 +753,9 @@ export async function createModelCardFromTemplate(
 }
 
 export async function saveImportedModelCard(modelCardRevision: Omit<ModelCardRevisionDoc, '_id'>) {
-  if (modelCardRevision.version === 1) {
-    // Special case for the first when a schema is set but `metadata` is still `undefined`
-    if (modelCardRevision.metadata !== undefined) {
-      throw BadReq('Model card metadata must not be set for the first version.', {
-        metadata: modelCardRevision.metadata,
-      })
-    }
-  } else {
+  // Special case for the first model card revision when a schema is set but `metadata` is still `undefined`
+  // This only happens when created from a schema, but when created from a template the first revision will not be undefined
+  if (modelCardRevision.version !== 1 || modelCardRevision.metadata !== undefined) {
     const { valid, errors } = await validateContentAgainstSchema(modelCardRevision.schemaId, modelCardRevision.metadata)
     if (!valid) {
       throw BadReq('Model metadata could not be validated against the schema.', {
@@ -775,9 +770,9 @@ export async function saveImportedModelCard(modelCardRevision: Omit<ModelCardRev
     mirrored: true,
   })
 
-  if (!foundModelCardRevision && modelCardRevision.version !== 1) {
+  if (!foundModelCardRevision && !(modelCardRevision.version === 1 && modelCardRevision.metadata === undefined)) {
     // This model card did not already exist in Mongo, so it is a new model card. Return it to be audited.
-    // Ignore model cards with a version number of 1 as these will always be blank.
+    // Conditionally ignore model cards with a version number of 1 as these will be blank if created from schema.
     const newModelCardRevision = new ModelCardRevisionModel({ ...modelCardRevision, mirrored: true })
     await newModelCardRevision.save()
     return modelCardRevision

--- a/backend/test/services/model.spec.ts
+++ b/backend/test/services/model.spec.ts
@@ -18,6 +18,7 @@ import {
   isModelCardRevisionDoc,
   popularTagsForEntries,
   removeModel,
+  saveImportedModelCard,
   searchModels,
   setLatestImportedModelCard,
   updateModel,
@@ -69,7 +70,7 @@ vi.mock('../../src/services/review.js', async () => reviewMock)
 
 const schemaMock = vi.hoisted(() => ({
   getSchemaById: vi.fn(() => ({ jsonschema: {}, reviewRoles: [] as string[] })),
-  validateContentAgainstSchema: vi.fn(() => ({ valid: true, errors: [] })),
+  validateContentAgainstSchema: vi.fn(() => ({ valid: true, errors: [] as string[] })),
 }))
 vi.mock('../../src/services/schema.js', async () => schemaMock)
 
@@ -647,6 +648,79 @@ describe('services > model', () => {
       /^Cannot alter a mirrored model./,
     )
     expect(ModelModelMock.save).not.toHaveBeenCalled()
+  })
+
+  describe('saveImportedModelCard', () => {
+    const modelCardRevision = {
+      modelId: 'test-model',
+      schemaId: 'test-schema',
+      version: 2,
+      metadata: { key: 'value' },
+      createdBy: 'user',
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    }
+
+    test('validate metadata against schema and save a new model card revision', async () => {
+      ModelCardRevisionModelMock.findOne.mockResolvedValueOnce(undefined)
+
+      const result = await saveImportedModelCard(modelCardRevision as any)
+
+      expect(schemaMock.validateContentAgainstSchema).toHaveBeenCalledWith('test-schema', { key: 'value' })
+      expect(ModelCardRevisionModelMock.save).toHaveBeenCalled()
+      expect(result).toEqual(modelCardRevision)
+    })
+
+    test('throw BadReq when metadata fails schema validation', async () => {
+      schemaMock.validateContentAgainstSchema.mockResolvedValueOnce({ valid: false, errors: ['invalid field'] })
+
+      await expect(() => saveImportedModelCard(modelCardRevision as any)).rejects.toThrow(
+        /^Model metadata could not be validated against the schema./,
+      )
+      expect(ModelCardRevisionModelMock.save).not.toHaveBeenCalled()
+    })
+
+    test('skip validation for version 1 with undefined metadata', async () => {
+      // create from schema has v1 be undefined
+      const revisionV1 = { ...modelCardRevision, version: 1, metadata: undefined }
+      ModelCardRevisionModelMock.findOne.mockResolvedValueOnce(undefined)
+
+      await saveImportedModelCard(revisionV1 as any)
+
+      expect(schemaMock.validateContentAgainstSchema).not.toHaveBeenCalled()
+    })
+
+    test('not save when a mirrored revision already exists', async () => {
+      ModelCardRevisionModelMock.findOne.mockResolvedValueOnce({ modelId: 'test-model', version: 2 })
+
+      const result = await saveImportedModelCard(modelCardRevision as any)
+
+      expect(result).toBeUndefined()
+      expect(ModelCardRevisionModelMock.save).not.toHaveBeenCalled()
+    })
+
+    test('not save version 1 with undefined metadata even when no existing revision', async () => {
+      // create from schema has v1 be undefined
+      const revisionV1 = { ...modelCardRevision, version: 1, metadata: undefined }
+      ModelCardRevisionModelMock.findOne.mockResolvedValueOnce(undefined)
+
+      const result = await saveImportedModelCard(revisionV1 as any)
+
+      expect(result).toBeUndefined()
+      expect(ModelCardRevisionModelMock.save).not.toHaveBeenCalled()
+    })
+
+    test('should validate version 1 with defined metadata', async () => {
+      // create from template has v1 be populated
+      const revisionV1WithMeta = { ...modelCardRevision, version: 1 }
+      ModelCardRevisionModelMock.findOne.mockResolvedValueOnce(undefined)
+
+      const result = await saveImportedModelCard(revisionV1WithMeta as any)
+
+      expect(schemaMock.validateContentAgainstSchema).toHaveBeenCalledWith('test-schema', { key: 'value' })
+      expect(ModelCardRevisionModelMock.save).toHaveBeenCalled()
+      expect(result).toEqual(revisionV1WithMeta)
+    })
   })
 
   test('setLatestImportedModelCard > success', async () => {


### PR DESCRIPTION
This fix allows the importing of models from a template. Previously, some logic assumed that `modelCardRevision.metadata` was always `undefined` when `modelCardRevision.version === 1` but this is _not_ the case when a model is created from a template.