### PR TITLE
Rework backend scripts approach

### DIFF
--- a/.github/workflows/web.yml
+++ b/.github/workflows/web.yml
@@ -125,7 +125,7 @@ jobs:
 
       - name: Generate OpenAPI specs
         working-directory: backend
-        run: npm run script generateOpenApiSpecs
+        run: npx tsx src/scripts/generateOpenApiSpecs.ts
 
       - name: Install dependencies
         run: npm i

--- a/backend/src/scripts/README.md
+++ b/backend/src/scripts/README.md
@@ -1,0 +1,95 @@
+# Backend Scripts
+
+Administrative helper scripts for Bailo.
+
+## Running Scripts
+
+Scripts using `defineScript()` should be run directly with `npx tsx`, not via `npm run script` (the legacy runner strips
+named flags).
+
+When running from the host, `defineScript()` automatically detects it is outside Docker and reads the MongoDB connection
+details from the Docker Compose config file (`backend/config/dev_docker_compose.cjs`), replacing the container hostname
+with `localhost`.
+
+```bash
+npx tsx src/scripts/exampleScript.ts --modelId abc-123 --dryRun
+```
+
+Every script supports `--help`:
+
+```bash
+npx tsx src/scripts/exampleScript.ts --help
+```
+
+### Legacy Scripts
+
+Older scripts that do not use `defineScript()` rely on `npm run script` and must be run inside the `backend` container
+or pod, where the correct `NODE_CONFIG_ENV` and MongoDB hostname are already set.
+
+```bash
+# Docker Compose
+docker compose exec backend npm run script -- getTopModelCollaborators
+
+# Kubernetes
+kubectl exec -it deploy/backend -- npm run script -- getTopModelCollaborators
+```
+
+Legacy scripts accept positional arguments only (named flags like `--modelId` are not forwarded):
+
+```bash
+docker compose exec backend npm run script -- modelSoftDelete my-model-id
+```
+
+New scripts should use `defineScript()` instead - see [Creating a New Script](#creating-a-new-script).
+
+## Creating a New Script
+
+Use `defineScript()` from `scriptHelper.ts`. It handles argument parsing, MongoDB connection, error handling, and
+cleanup automatically.
+
+```ts
+import log from '../services/log.js'
+import { defineScript } from './scriptHelper.js'
+
+defineScript({
+  name: 'myScript',
+  description: 'What the script does',
+  args: (yargs) =>
+    yargs
+      .option('someFlag', { type: 'string', demandOption: true, describe: 'A required flag' })
+      .option('dryRun', { type: 'boolean', default: false, describe: 'Preview without changes' })
+      .option('status', {
+        choices: ['active', 'disabled'] as const,
+      })
+      .option('ids', {
+        type: 'array',
+      }),
+  run: async (args) => {
+    log.info({ someFlag: args.someFlag }, 'Running')
+    // Your logic here - MongoDB is already connected
+  },
+})
+```
+
+### Options
+
+| Option           | Type             | Default | Description                                        |
+| ---------------- | ---------------- | ------- | -------------------------------------------------- |
+| `name`           | `string`         | -       | Script name (shown in `--help`)                    |
+| `description`    | `string`         | -       | One-line description (shown in `--help`)           |
+| `args`           | `function`       | -       | Configures [yargs](https://yargs.js.org/) options  |
+| `run`            | `async function` | -       | Script logic, receives parsed args                 |
+| `connectToMongo` | `boolean`        | `true`  | Set to `false` for scripts that don't need MongoDB |
+
+### Argument Definition
+
+Arguments use [yargs options](https://yargs.js.org/docs/#api-reference-optionkey-opt):
+
+- `type`: `'string'`, `'number'`, `'boolean'`, `'array'`
+- `demandOption: true`: makes the flag required
+- `default`: default value
+- `describe`: help text
+- `choices`: restrict to specific values
+- `alias`: short flag (e.g., `alias: 'n'` for `-n`)
+
+See `exampleScript.ts` for a working reference.

--- a/backend/src/scripts/README.md
+++ b/backend/src/scripts/README.md
@@ -4,27 +4,28 @@ Administrative helper scripts for Bailo.
 
 ## Running Scripts
 
+All scripts must be run inside the `backend` container/pod.
+
 Scripts using `defineScript()` should be run directly with `npx tsx`, not via `npm run script` (the legacy runner strips
 named flags).
 
-When running from the host, `defineScript()` automatically detects it is outside Docker and reads the MongoDB connection
-details from the Docker Compose config file (`backend/config/dev_docker_compose.cjs`), replacing the container hostname
-with `localhost`.
-
 ```bash
-npx tsx src/scripts/exampleScript.ts --modelId abc-123 --dryRun
+# Docker Compose
+docker compose exec backend npx tsx src/scripts/exampleScript.ts --modelId abc-123 --dryRun
+
+# Kubernetes
+kubectl exec -it deploy/backend npx tsx src/scripts/exampleScript.ts --modelId abc-123 --dryRun
 ```
 
 Every script supports `--help`:
 
 ```bash
-npx tsx src/scripts/exampleScript.ts --help
+docker compose exec backend npx tsx src/scripts/exampleScript.ts --help
 ```
 
 ### Legacy Scripts
 
-Older scripts that do not use `defineScript()` rely on `npm run script` and must be run inside the `backend` container
-or pod, where the correct `NODE_CONFIG_ENV` and MongoDB hostname are already set.
+Older scripts that do not use `defineScript()` rely on `npm run script`.
 
 ```bash
 # Docker Compose

--- a/backend/src/scripts/README.md
+++ b/backend/src/scripts/README.md
@@ -4,23 +4,24 @@ Administrative helper scripts for Bailo.
 
 ## Running Scripts
 
-All scripts must be run inside the `backend` container/pod.
+All scripts must be executed inside the `backend` container/pod using `npx tsx`. Each script supports `--help` which
+shows its options and example invocations for Docker Compose and Kubernetes.
 
-Scripts using `defineScript()` should be run directly with `npx tsx`, not via `npm run script` (the legacy runner strips
-named flags).
+```console
+$ npx tsx src/scripts/exampleScript.ts --help
+Example script demonstrating the defineScript pattern
 
-```bash
-# Docker Compose
-docker compose exec backend npx tsx src/scripts/exampleScript.ts --modelId abc-123 --dryRun
+Usage: exampleScript [options]
 
-# Kubernetes
-kubectl exec -it deploy/backend npx tsx src/scripts/exampleScript.ts --modelId abc-123 --dryRun
-```
+Options:
+  --version  Show version number                                       [boolean]
+  --modelId  The model ID to look up                         [string] [required]
+  --dryRun   Preview without making changes           [boolean] [default: false]
+  --help     Show help                                                 [boolean]
 
-Every script supports `--help`:
-
-```bash
-docker compose exec backend npx tsx src/scripts/exampleScript.ts --help
+Run inside the backend container/pod:
+  docker compose exec backend npx tsx src/scripts/exampleScript.ts [options]
+  kubectl exec -it deploy/backend -- npx tsx src/scripts/exampleScript.ts [options]
 ```
 
 ### Legacy Scripts

--- a/backend/src/scripts/exampleScript.ts
+++ b/backend/src/scripts/exampleScript.ts
@@ -1,0 +1,22 @@
+import ModelModel from '../models/Model.js'
+import log from '../services/log.js'
+import { defineScript } from './scriptHelper.js'
+
+defineScript({
+  name: 'exampleScript',
+  description: 'Example script demonstrating the defineScript pattern',
+  args: (yargs) =>
+    yargs
+      .option('modelId', { type: 'string', demandOption: true, describe: 'The model ID to look up' })
+      .option('dryRun', { type: 'boolean', default: false, describe: 'Preview without making changes' }),
+  run: async (args) => {
+    log.info({ modelId: args.modelId, dryRun: args.dryRun }, 'Running example script')
+
+    const model = await ModelModel.findOne({ id: args.modelId })
+    if (!model) {
+      throw new Error(`Model '${args.modelId}' not found`)
+    }
+
+    log.info({ name: model.name }, 'Found model')
+  },
+})

--- a/backend/src/scripts/generateOpenApiSpecs.ts
+++ b/backend/src/scripts/generateOpenApiSpecs.ts
@@ -7,18 +7,27 @@ import { resolve } from 'path'
 
 import log from '../services/log.js'
 import { generateSwaggerSpec, generateV3SwaggerSpec } from '../services/specification.js'
+import { defineScript } from './scriptHelper.js'
 
-async function main() {
-  const outDir = process.argv[2] || resolve(import.meta.dirname, '../../openapi-specs')
+defineScript({
+  name: 'generateOpenApiSpecs',
+  description: 'Generate OpenAPI specification files for v2 and v3 APIs',
+  connectToMongo: false,
+  args: (yargs) =>
+    yargs.option('outDir', {
+      type: 'string',
+      default: resolve(import.meta.dirname, '../../openapi-specs'),
+      describe: 'Output directory for the generated spec files',
+    }),
+  run: async (args) => {
+    mkdirSync(args.outDir, { recursive: true })
 
-  mkdirSync(outDir, { recursive: true })
+    const v2Spec = generateSwaggerSpec()
+    const v3Spec = generateV3SwaggerSpec()
 
-  const v2Spec = generateSwaggerSpec()
-  const v3Spec = generateV3SwaggerSpec()
+    writeFileSync(resolve(args.outDir, 'swagger-v2.json'), JSON.stringify(v2Spec, null, 2))
+    writeFileSync(resolve(args.outDir, 'swagger-v3.json'), JSON.stringify(v3Spec, null, 2))
 
-  writeFileSync(resolve(outDir, 'swagger-v2.json'), JSON.stringify(v2Spec, null, 2))
-  writeFileSync(resolve(outDir, 'swagger-v3.json'), JSON.stringify(v3Spec, null, 2))
-
-  log.info(`OpenAPI specs written to ${outDir}`)
-}
-main()
+    log.info(`OpenAPI specs written to ${args.outDir}`)
+  },
+})

--- a/backend/src/scripts/scriptHelper.ts
+++ b/backend/src/scripts/scriptHelper.ts
@@ -1,0 +1,106 @@
+import { existsSync } from 'fs'
+import { createRequire } from 'module'
+import mongoose from 'mongoose'
+import { join } from 'path'
+import yargs, { type ArgumentsCamelCase, type Argv } from 'yargs'
+import { hideBin } from 'yargs/helpers'
+
+import log from '../services/log.js'
+import { getConnectionURI } from '../utils/database.js'
+
+const require = createRequire(import.meta.url)
+
+type ScriptArgs = Record<string, unknown>
+interface ScriptDefinition<T extends ScriptArgs> {
+  name: string
+  description: string
+  args: (y: Argv) => Argv<T>
+  run: (args: ArgumentsCamelCase<T>) => Promise<void>
+  connectToMongo?: boolean
+}
+
+function isRunningInDocker() {
+  return existsSync('/.dockerenv') || process.env.DOCKER_CONTAINER === 'true'
+}
+
+function getScriptConnectionURI(): string {
+  if (isRunningInDocker()) {
+    return getConnectionURI()
+  }
+
+  const configDir = join(import.meta.dirname, '../../config')
+  const dockerConfigs = ['dev_docker_compose.cjs', 'prod_docker_compose.cjs']
+
+  for (const file of dockerConfigs) {
+    const filePath = join(configDir, file)
+    if (!existsSync(filePath)) {
+      continue
+    }
+
+    const dockerConfig = require(filePath)
+    if (dockerConfig?.mongo?.uri) {
+      try {
+        const uri = new URL(dockerConfig.mongo.uri)
+
+        if (!['mongodb:', 'mongodb+srv:'].includes(uri.protocol)) {
+          throw new Error('Unsupported MongoDB protocol')
+        }
+
+        uri.hostname = 'localhost'
+        uri.searchParams.set('directConnection', 'true')
+        uri.searchParams.delete('replicaSet')
+        return uri.toString()
+      } catch (err) {
+        log.warn({ err, file }, 'Invalid MongoDB configuration')
+      }
+    }
+  }
+
+  return getConnectionURI()
+}
+
+async function connectForScript() {
+  if (Number(mongoose.connection.readyState) === 1) {
+    return
+  }
+
+  mongoose.set('strictQuery', false)
+  mongoose.set('strictPopulate', false)
+  mongoose.set('updatePipeline', true)
+
+  const uri = getScriptConnectionURI()
+  await mongoose.connect(uri)
+  log.info('Connected to Mongoose')
+}
+
+async function disconnectForScript() {
+  await mongoose.disconnect()
+  log.info({ log: false }, 'Disconnected from Mongoose')
+}
+
+export function defineScript<T extends ScriptArgs>(def: ScriptDefinition<T>) {
+  const argv = def.args(
+    yargs(hideBin(process.argv)).scriptName(def.name).usage(`${def.description}\n\nUsage: $0 [options]`),
+  )
+
+  async function execute() {
+    const args = await argv.strict().help().argv
+
+    try {
+      if (def.connectToMongo !== false) {
+        await connectForScript()
+      }
+
+      await def.run(args)
+    } catch (err) {
+      log.error(err, 'Script failed')
+      process.exitCode = 1
+    } finally {
+      if (def.connectToMongo !== false && mongoose.connection.readyState !== 0) {
+        await disconnectForScript()
+      }
+    }
+  }
+
+  execute()
+}

--- a/backend/src/scripts/scriptHelper.ts
+++ b/backend/src/scripts/scriptHelper.ts
@@ -1,14 +1,9 @@
-import { existsSync } from 'fs'
-import { createRequire } from 'module'
 import mongoose from 'mongoose'
-import { join } from 'path'
 import yargs, { type ArgumentsCamelCase, type Argv } from 'yargs'
 import { hideBin } from 'yargs/helpers'
 
 import log from '../services/log.js'
-import { getConnectionURI } from '../utils/database.js'
-
-const require = createRequire(import.meta.url)
+import { connectToMongoose, disconnectFromMongoose } from '../utils/database.js'
 
 type ScriptArgs = Record<string, unknown>
 interface ScriptDefinition<T extends ScriptArgs> {
@@ -17,65 +12,6 @@ interface ScriptDefinition<T extends ScriptArgs> {
   args: (y: Argv) => Argv<T>
   run: (args: ArgumentsCamelCase<T>) => Promise<void>
   connectToMongo?: boolean
-}
-
-function isRunningInDocker() {
-  return existsSync('/.dockerenv') || process.env.DOCKER_CONTAINER === 'true'
-}
-
-function getScriptConnectionURI(): string {
-  if (isRunningInDocker()) {
-    return getConnectionURI()
-  }
-
-  const configDir = join(import.meta.dirname, '../../config')
-  const dockerConfigs = ['dev_docker_compose.cjs', 'prod_docker_compose.cjs']
-
-  for (const file of dockerConfigs) {
-    const filePath = join(configDir, file)
-    if (!existsSync(filePath)) {
-      continue
-    }
-
-    const dockerConfig = require(filePath)
-    if (dockerConfig?.mongo?.uri) {
-      try {
-        const uri = new URL(dockerConfig.mongo.uri)
-
-        if (!['mongodb:', 'mongodb+srv:'].includes(uri.protocol)) {
-          throw new Error('Unsupported MongoDB protocol')
-        }
-
-        uri.hostname = 'localhost'
-        uri.searchParams.set('directConnection', 'true')
-        uri.searchParams.delete('replicaSet')
-        return uri.toString()
-      } catch (err) {
-        log.warn({ err, file }, 'Invalid MongoDB configuration')
-      }
-    }
-  }
-
-  return getConnectionURI()
-}
-
-async function connectForScript() {
-  if (Number(mongoose.connection.readyState) === 1) {
-    return
-  }
-
-  mongoose.set('strictQuery', false)
-  mongoose.set('strictPopulate', false)
-  mongoose.set('updatePipeline', true)
-
-  const uri = getScriptConnectionURI()
-  await mongoose.connect(uri)
-  log.info('Connected to Mongoose')
-}
-
-async function disconnectForScript() {
-  await mongoose.disconnect()
-  log.info({ log: false }, 'Disconnected from Mongoose')
 }
 
 export function defineScript<T extends ScriptArgs>(def: ScriptDefinition<T>) {
@@ -88,7 +24,7 @@ export function defineScript<T extends ScriptArgs>(def: ScriptDefinition<T>) {
 
     try {
       if (def.connectToMongo !== false) {
-        await connectForScript()
+        await connectToMongoose()
       }
 
       await def.run(args)
@@ -97,7 +33,7 @@ export function defineScript<T extends ScriptArgs>(def: ScriptDefinition<T>) {
       process.exitCode = 1
     } finally {
       if (def.connectToMongo !== false && mongoose.connection.readyState !== 0) {
-        await disconnectForScript()
+        await disconnectFromMongoose()
       }
     }
   }

--- a/backend/src/scripts/scriptHelper.ts
+++ b/backend/src/scripts/scriptHelper.ts
@@ -16,7 +16,14 @@ interface ScriptDefinition<T extends ScriptArgs> {
 
 export function defineScript<T extends ScriptArgs>(def: ScriptDefinition<T>) {
   const argv = def.args(
-    yargs(hideBin(process.argv)).scriptName(def.name).usage(`${def.description}\n\nUsage: $0 [options]`),
+    yargs(hideBin(process.argv))
+      .scriptName(def.name)
+      .usage(`${def.description}\n\nUsage: $0 [options]`)
+      .epilogue(
+        'Run inside the backend container/pod:\n' +
+          `  docker compose exec backend npx tsx src/scripts/${def.name}.ts [options]\n` +
+          `  kubectl exec -it deploy/backend -- npx tsx src/scripts/${def.name}.ts [options]`,
+      ),
   )
 
   async function execute() {

--- a/backend/src/services/schedule/scheduler.ts
+++ b/backend/src/services/schedule/scheduler.ts
@@ -17,28 +17,36 @@ export type LifecycleReviewJobData = {
 
 export const LIFECYCLE_REVIEW_EMAIL_JOB = 'sendLifeCycleReviewEmail'
 
-log.info('Scheduler initialising...')
-const agenda = new Agenda({
-  backend: new MongoBackend({
-    address: getConnectionURI(),
-  }),
-})
-
+let agenda: Agenda | undefined
 let started = false
+
+function getOrCreateAgenda(): Agenda {
+  if (!agenda) {
+    log.info('Scheduler initialising...')
+    agenda = new Agenda({
+      backend: new MongoBackend({
+        address: getConnectionURI(),
+      }),
+    })
+  }
+  return agenda
+}
 
 export async function startScheduler(jobRegistrars: JobRegistrar[] = []) {
   if (started) {
-    return agenda
+    return getOrCreateAgenda()
   }
+
+  const instance = getOrCreateAgenda()
 
   log.info('Scheduler starting up...')
 
-  agenda.on('error', (err) => {
+  instance.on('error', (err) => {
     log.error({ err }, 'Agenda error')
   })
 
   try {
-    await agenda.start()
+    await instance.start()
     started = true
     log.info('Scheduler started')
   } catch (err) {
@@ -47,9 +55,9 @@ export async function startScheduler(jobRegistrars: JobRegistrar[] = []) {
   }
 
   // Assign jobs after agenda has started so that they can use `getScheduler`
-  await Promise.all(jobRegistrars.map((registerJob) => registerJob(agenda)))
+  await Promise.all(jobRegistrars.map((registerJob) => registerJob(instance)))
 
-  return agenda
+  return instance
 }
 
 export function registerLifecycleReviewJob(agenda: Agenda) {
@@ -103,7 +111,7 @@ export async function scheduleLifeCycleReviewEmails(modelId: string, reviewId: s
 }
 
 export function getScheduler(): Agenda {
-  if (!started) {
+  if (!started || !agenda) {
     throw new Error('Scheduler has not been started')
   }
   return agenda

--- a/lib/landing/scripts/generate.js
+++ b/lib/landing/scripts/generate.js
@@ -113,7 +113,7 @@ async function run() {
    *
    * You must run the following command first:
    * cd backend
-   * npm run script generateOpenApiSpecs
+   * npx tsx src/scripts/generateOpenApiSpecs.ts
    */
   mkdirSync('./public/api/docs', { recursive: true })
   cp('../../backend/openapi-specs/swagger-v2.json', './public/api/docs/')


### PR DESCRIPTION
- Add new `backend/src/scripts/scriptHelper.ts` with associated `backend/src/scripts/README.md` and `backend/src/scripts/exampleScript.ts` for easier to manage scripts
  - Safely handle named args
  - Standardise `run` function
  - Add help text
  - Add optional MongoDB connection helper
- Update `backend/src/scripts/generateOpenApiSpecs.ts` to new approach and associated callers
- Make `backend/src/services/schedule/scheduler.ts` lazily load agenda to prevent MongoDB errors from scripts that don't connect to MongoDB
- All "old" scripts can still be run with `npm run script -- <scriptName>`