### PR TITLE
Import & export empty model card revision

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -93,6 +93,7 @@
         "@types/sanitize-html": "^2.16.1",
         "@types/semver": "^7.7.1",
         "@types/shelljs": "^0.10.0",
+        "@types/showdown": "^2.0.6",
         "@types/supertest": "^7.2.0",
         "@types/tar-stream": "^3.1.4",
         "@typescript-eslint/eslint-plugin": "^8.60.1",
@@ -5603,6 +5604,13 @@
         "@types/node": "*",
         "fast-glob": "^3.3.2"
       }
+    },
+    "node_modules/@types/showdown": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/@types/showdown/-/showdown-2.0.6.tgz",
+      "integrity": "sha512-pTvD/0CIeqe4x23+YJWlX2gArHa8G0J0Oh6GKaVXV7TAeickpkkZiNOgFcFcmLQ5lB/K0qBJL1FtRYltBfbGCQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/superagent": {
       "version": "8.1.9",

--- a/backend/package.json
+++ b/backend/package.json
@@ -5,7 +5,8 @@
   "scripts": {
     "start": "tsx src/index.ts",
     "dev": "nodemon",
-    "build": "tsc && mkdir -p dist/src/services/smtp/templates && cp src/services/smtp/templates/*.hbs dist/src/services/smtp/templates/",
+    "copy-templates": "cd src && find . -name '*.hbs' | cpio -pdm ../dist/src",
+    "build": "tsc && npm run copy-templates",
     "test": "vitest",
     "lint": "eslint --cache --cache-location node_modules/.cache/eslint/ --max-warnings=0",
     "style": "prettier --write .",

--- a/backend/package.json
+++ b/backend/package.json
@@ -105,6 +105,7 @@
     "@types/sanitize-html": "^2.16.1",
     "@types/semver": "^7.7.1",
     "@types/shelljs": "^0.10.0",
+    "@types/showdown": "^2.0.6",
     "@types/supertest": "^7.2.0",
     "@types/tar-stream": "^3.1.4",
     "@typescript-eslint/eslint-plugin": "^8.60.1",

--- a/backend/src/services/mirroredModel/exporters/base.ts
+++ b/backend/src/services/mirroredModel/exporters/base.ts
@@ -316,6 +316,7 @@ export abstract class BaseExporter {
   async finalise() {
     log.trace(this.logData, `Finalising ${this.constructor.name}.`)
 
+    // Non-null assertion operator used due to `withStreams` performing assertion
     await finaliseTarGzUpload(this.tarStream!, this.uploadPromise!)
 
     log.trace(this.logData, `Finished finalising ${this.constructor.name}.`)

--- a/backend/src/services/model.ts
+++ b/backend/src/services/model.ts
@@ -783,9 +783,8 @@ export async function saveImportedModelCard(modelCardRevision: Omit<ModelCardRev
     mirrored: true,
   })
 
-  if (!foundModelCardRevision && !(modelCardRevision.version === 1 && modelCardRevision.metadata === undefined)) {
+  if (!foundModelCardRevision) {
     // This model card did not already exist in Mongo, so it is a new model card. Return it to be audited.
-    // Conditionally ignore model cards with a version number of 1 as these will be blank if created from schema.
     const newModelCardRevision = new ModelCardRevisionModel({ ...modelCardRevision, mirrored: true })
     await newModelCardRevision.save()
     return modelCardRevision
@@ -793,7 +792,8 @@ export async function saveImportedModelCard(modelCardRevision: Omit<ModelCardRev
 }
 
 /**
- * Note that we do not authorise that the user can access the model here.
+ * @remarks
+ * Note that we do _not_ authorise that the user can access the model here.
  * This function should only be used during the import model card process.
  * Do not expose this functionality to users.
  */

--- a/backend/src/services/modelCardExport.ts
+++ b/backend/src/services/modelCardExport.ts
@@ -1,4 +1,7 @@
+import { readFileSync } from 'fs'
+import Handlebars from 'handlebars'
 import { outdent } from 'outdent'
+import { resolve } from 'path'
 import showdown from 'showdown'
 
 import { CollaboratorEntry, ModelInterface } from '../models/Model.js'
@@ -10,6 +13,10 @@ import { UserInterface } from '../models/User.js'
 import { GetModelCardVersionOptionsKeys } from '../types/enums.js'
 import { getModelById, getModelCard, getRoleEntities } from './model.js'
 import { getSchemaById } from './schema.js'
+
+const modelCardTemplate = Handlebars.compile(
+  readFileSync(resolve(import.meta.dirname, 'templates', 'modelCardExport.hbs'), 'utf-8'),
+)
 
 type Common = {
   title: string
@@ -161,37 +168,7 @@ export async function renderToHtml(
   converter.setFlavor('github')
   const body = converter.makeHtml(markdown)
 
-  const html = `
-    <html>
-      <head>
-        <style>
-          body { margin: 0px; font-family: Helvetica; color: #1e1e1e; background-color: #f9f9f9; }
-          h1 { text-align: center }
-          h2 { margin-top: 32px; margin-bottom: 16px }
-          h3 { margin-top: 24px; margin-bottom: 8px }
-          h4 { margin-top: 16px; margin-bottom: 8px }
-          h5 { margin-top: 16px; margin-bottom: 8px }
-          h6 { margin-top: 16px; margin-bottom: 8px }
-          p { margin-top: 8px; margin-bottom: 8px }
-          table { border-spacing: 0px; }
-          td, th { border-bottom: 1px solid rgba(81, 81, 81, 1); padding: 8px; }
-          tbody > tr:last-child > td { border-bottom: 0; }
-        </style>
-      </head>
-      <body>
-        <div style="padding-left: 8px; height: 64px; width: 100%; background: linear-gradient(276deg, rgba(214,37,96,1) 0%, rgba(84,39,142,1) 100%)">
-          <div style="line-height: 64px; color: white; font-size: 20px; text-align: left; max-width: 900px; margin: auto">
-            Bailo
-          </div>
-        </div>
-        <div style="margin: 8px; max-width: 900px; margin: auto; margin-bottom: 16px; overflow-wrap: break-word">
-          ${body}
-        </div>
-      </body>
-    </html>
-  `
-
-  return html
+  return modelCardTemplate({ body })
 }
 
 function renderMarkdownReviewTable(reviewExports: ReviewExport[]) {

--- a/backend/src/services/templates/modelCardExport.hbs
+++ b/backend/src/services/templates/modelCardExport.hbs
@@ -1,0 +1,63 @@
+<html>
+  <head>
+    <style>
+      body {
+        margin: 0px;
+        font-family: Helvetica;
+        color: #1e1e1e;
+        background-color: #f9f9f9;
+      }
+      h1 {
+        text-align: center;
+      }
+      h2 {
+        margin-top: 32px;
+        margin-bottom: 16px;
+      }
+      h3 {
+        margin-top: 24px;
+        margin-bottom: 8px;
+      }
+      h4 {
+        margin-top: 16px;
+        margin-bottom: 8px;
+      }
+      h5 {
+        margin-top: 16px;
+        margin-bottom: 8px;
+      }
+      h6 {
+        margin-top: 16px;
+        margin-bottom: 8px;
+      }
+      p {
+        margin-top: 8px;
+        margin-bottom: 8px;
+      }
+      table {
+        border-spacing: 0px;
+      }
+      td,
+      th {
+        border-bottom: 1px solid rgba(81, 81, 81, 1);
+        padding: 8px;
+      }
+      tbody > tr:last-child > td {
+        border-bottom: 0;
+      }
+    </style>
+  </head>
+  <body>
+    <div
+      style='padding-left: 8px; height: 64px; width: 100%; background: linear-gradient(276deg, rgba(214,37,96,1) 0%, rgba(84,39,142,1) 100%)'
+    >
+      <div style='line-height: 64px; color: white; font-size: 20px; text-align: left; max-width: 900px; margin: auto'>
+        Bailo
+      </div>
+    </div>
+    <div style='margin: 8px; max-width: 900px; margin: auto; margin-bottom: 16px; overflow-wrap: break-word'>
+      {{! Use triple-stash to use raw/un-escaped value https://handlebarsjs.com/guide/expressions.html#html-escaping }}
+      {{{body}}}
+    </div>
+  </body>
+</html>

--- a/backend/test/services/model.spec.ts
+++ b/backend/test/services/model.spec.ts
@@ -769,15 +769,16 @@ describe('services > model', () => {
       expect(ModelCardRevisionModelMock.save).not.toHaveBeenCalled()
     })
 
-    test('not save version 1 with undefined metadata even when no existing revision', async () => {
+    test('save version 1 with undefined metadata', async () => {
       // create from schema has v1 be undefined
       const revisionV1 = { ...modelCardRevision, version: 1, metadata: undefined }
       ModelCardRevisionModelMock.findOne.mockResolvedValueOnce(undefined)
 
       const result = await saveImportedModelCard(revisionV1 as any)
 
-      expect(result).toBeUndefined()
-      expect(ModelCardRevisionModelMock.save).not.toHaveBeenCalled()
+      expect(schemaMock.validateContentAgainstSchema).not.toHaveBeenCalled()
+      expect(ModelCardRevisionModelMock.save).toHaveBeenCalled()
+      expect(result).toEqual(revisionV1)
     })
 
     test('should validate version 1 with defined metadata', async () => {


### PR DESCRIPTION
This PR adds functionality to import the empty model card from when the new schema is selected for the source model. Previously, this was ignored as it failed validation, but now validation is conditionally skipped for the first revision when also `undefined`.

This PR also refactors `renderToHtml` to use a Handlebars template file as with `backend/src/services/smtp/templates/email.hbs`.