### PR TITLE
Validate mirrored model state from combined cards

### DIFF
--- a/backend/src/services/model.ts
+++ b/backend/src/services/model.ts
@@ -626,13 +626,12 @@ export async function updateModel(user: UserInterface, modelId: string, modelDif
   }
 
   if (modelDiff.state && model.card) {
-    let valid: boolean
-    if (model.kind === EntryKind.MirroredModel) {
-      const mergedCard = deepMergePreferFirst(model.card.metadata, model.mirroredCard?.metadata || {})
-      valid = (await validateContentAgainstSchema(model.card.schemaId, mergedCard, modelDiff.state)).valid
-    } else {
-      valid = (await validateContentAgainstSchema(model.card.schemaId, model.card.metadata, modelDiff.state)).valid
-    }
+    const card =
+      model.kind === EntryKind.MirroredModel && model.mirroredCard?.metadata
+        ? deepMergePreferFirst(model.card.metadata, model.mirroredCard?.metadata)
+        : model.card.metadata
+    const { valid } = await validateContentAgainstSchema(model.card.schemaId, card, modelDiff.state)
+
     if (!valid) {
       throw BadReq(`Model metadata could not be validated against the schema, for ${modelDiff.state} state.`)
     }

--- a/backend/src/services/model.ts
+++ b/backend/src/services/model.ts
@@ -31,6 +31,7 @@ import {
 import { fromEntity, toEntity } from '../utils/entity.js'
 import { BadReq, Forbidden, InternalError, NotFound } from '../utils/error.js'
 import { convertStringToId } from '../utils/id.js'
+import { deepMergePreferFirst } from '../utils/object.js'
 import { authResponseToUserPermission } from '../utils/permissions.js'
 import { useTransaction } from '../utils/transactions.js'
 import { getAccessRequestsByModel, removeAccessRequests } from './accessRequest.js'
@@ -625,7 +626,13 @@ export async function updateModel(user: UserInterface, modelId: string, modelDif
   }
 
   if (modelDiff.state && model.card) {
-    const { valid } = await validateContentAgainstSchema(model.card.schemaId, model.card.metadata, modelDiff.state)
+    let valid: boolean
+    if (model.kind === EntryKind.MirroredModel) {
+      const mergedCard = deepMergePreferFirst(model.card.metadata, model.mirroredCard?.metadata || {})
+      valid = (await validateContentAgainstSchema(model.card.schemaId, mergedCard, modelDiff.state)).valid
+    } else {
+      valid = (await validateContentAgainstSchema(model.card.schemaId, model.card.metadata, modelDiff.state)).valid
+    }
     if (!valid) {
       throw BadReq(`Model metadata could not be validated against the schema, for ${modelDiff.state} state.`)
     }

--- a/backend/src/utils/object.ts
+++ b/backend/src/utils/object.ts
@@ -26,7 +26,10 @@ export function getPropValue<T = unknown>(source: unknown, path: string): T | un
   }, source)
 }
 
-export function deepMergePreferFirst<T extends object, U extends object>(first: T, second: U): T & U {
+export function deepMergePreferFirst<TPreferred extends object, TFallback extends object>(
+  first: TPreferred,
+  second: TFallback,
+): TPreferred & TFallback {
   return mergeWith({}, second, first, (objValue, srcValue) => {
     // Arrays: first object wins completely
     if (Array.isArray(objValue) || Array.isArray(srcValue)) {
@@ -40,5 +43,5 @@ export function deepMergePreferFirst<T extends object, U extends object>(first: 
 
     // Return undefined to let lodash continue normal deep merge.
     return undefined
-  }) as T & U
+  }) as TPreferred & TFallback
 }

--- a/backend/src/utils/object.ts
+++ b/backend/src/utils/object.ts
@@ -1,4 +1,6 @@
-export function deepFreeze(object) {
+import { mergeWith } from 'lodash-es'
+
+export function deepFreeze(object: object) {
   // Retrieve the property names defined on object
   const propNames = Reflect.ownKeys(object)
 
@@ -22,4 +24,21 @@ export function getPropValue<T = unknown>(source: unknown, path: string): T | un
   return trimmedPath.split('.').reduce<any>((acc, key) => {
     return acc != null ? acc[key] : undefined
   }, source)
+}
+
+export function deepMergePreferFirst<T extends object, U extends object>(first: T, second: U): T & U {
+  return mergeWith({}, second, first, (objValue, srcValue) => {
+    // Arrays: first object wins completely
+    if (Array.isArray(objValue) || Array.isArray(srcValue)) {
+      return srcValue ?? objValue
+    }
+
+    // Primitives: first object wins when present
+    if (srcValue !== undefined && (srcValue === null || typeof srcValue !== 'object')) {
+      return srcValue
+    }
+
+    // Return undefined to let lodash continue normal deep merge.
+    return undefined
+  }) as T & U
 }

--- a/backend/src/utils/object.ts
+++ b/backend/src/utils/object.ts
@@ -1,6 +1,6 @@
 import { mergeWith } from 'lodash-es'
 
-export function deepFreeze(object: object) {
+export function deepFreeze(object) {
   // Retrieve the property names defined on object
   const propNames = Reflect.ownKeys(object)
 

--- a/backend/test/services/model.spec.ts
+++ b/backend/test/services/model.spec.ts
@@ -707,6 +707,93 @@ describe('services > model', () => {
     )
   })
 
+  test('updateModel > validates mirrored model state against merged card and mirroredCard metadata', async () => {
+    const saveMock = vi.fn()
+    const testModel = {
+      name: 'mirrored model',
+      kind: EntryKind.MirroredModel,
+      card: {
+        schemaId: 'test-schema',
+        version: 1,
+        metadata: { overview: { name: 'Local Name' } },
+      },
+      mirroredCard: {
+        schemaId: 'test-schema',
+        version: 1,
+        metadata: { overview: { description: 'Mirrored Description' } },
+      },
+      collaborators: [],
+      settings: { mirror: { sourceModelId: 'source' }, ungovernedAccess: false, allowTemplating: false },
+      save: saveMock,
+    }
+    ModelModelMock.findOne.mockResolvedValueOnce(testModel)
+    vi.mocked(authorisation.model).mockResolvedValue({ success: true, id: '' })
+    schemaMock.validateContentAgainstSchema.mockResolvedValueOnce({ valid: true, errors: [] })
+
+    await updateModel({} as any, 'test123', { state: 'Production' })
+
+    expect(schemaMock.validateContentAgainstSchema).toHaveBeenCalledWith(
+      'test-schema',
+      { overview: { name: 'Local Name', description: 'Mirrored Description' } },
+      'Production',
+    )
+    expect(saveMock).toHaveBeenCalled()
+  })
+
+  test('updateModel > throws when mirrored model combined card fails state validation', async () => {
+    const testModel = {
+      name: 'mirrored model',
+      kind: EntryKind.MirroredModel,
+      card: {
+        schemaId: 'test-schema',
+        version: 1,
+        metadata: {},
+      },
+      mirroredCard: {
+        schemaId: 'test-schema',
+        version: 1,
+        metadata: {},
+      },
+      collaborators: [],
+      settings: { mirror: { sourceModelId: 'source' }, ungovernedAccess: false, allowTemplating: false },
+    }
+    ModelModelMock.findOne.mockResolvedValueOnce(testModel)
+    vi.mocked(authorisation.model).mockResolvedValue({ success: true, id: '' })
+    schemaMock.validateContentAgainstSchema.mockResolvedValueOnce({ valid: false, errors: [] })
+
+    await expect(() => updateModel({} as any, 'test123', { state: 'Production' })).rejects.toThrow(
+      'Model metadata could not be validated against the schema, for Production state.',
+    )
+  })
+
+  test('updateModel > validates mirrored model with missing mirroredCard using only local card', async () => {
+    const saveMock = vi.fn()
+    const testModel = {
+      name: 'mirrored model',
+      kind: EntryKind.MirroredModel,
+      card: {
+        schemaId: 'test-schema',
+        version: 1,
+        metadata: { overview: { name: 'Local' } },
+      },
+      mirroredCard: undefined,
+      collaborators: [],
+      settings: { mirror: { sourceModelId: 'source' }, ungovernedAccess: false, allowTemplating: false },
+      save: saveMock,
+    }
+    ModelModelMock.findOne.mockResolvedValueOnce(testModel)
+    vi.mocked(authorisation.model).mockResolvedValue({ success: true, id: '' })
+    schemaMock.validateContentAgainstSchema.mockResolvedValueOnce({ valid: true, errors: [] })
+
+    await updateModel({} as any, 'test123', { state: 'Production' })
+
+    expect(schemaMock.validateContentAgainstSchema).toHaveBeenCalledWith(
+      'test-schema',
+      { overview: { name: 'Local' } },
+      'Production',
+    )
+  })
+
   test('createModelCardFromSchema > should throw an error when attempting to change a model from mirrored to standard', async () => {
     vi.mocked(authorisation.model).mockResolvedValue({
       info: 'Cannot alter a mirrored model.',

--- a/backend/test/utils/object.spec.ts
+++ b/backend/test/utils/object.spec.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from 'vitest'
 
-import { deepFreeze, getPropValue } from '../../src/utils/object.js'
+import { deepFreeze, deepMergePreferFirst, getPropValue } from '../../src/utils/object.js'
 
 describe('utils > object', () => {
   test('deepFreeze', () => {
@@ -39,5 +39,43 @@ describe('utils > object', () => {
     expect(getPropValue(source, 'a.x.c')).toBeUndefined()
     expect(getPropValue(source, '')).toStrictEqual(source)
     expect(getPropValue(source, '   ')).toStrictEqual(source)
+  })
+
+  describe('deepMergePreferFirst', () => {
+    test('first object primitives win over second', () => {
+      expect(deepMergePreferFirst({ a: 'first' }, { a: 'second', b: 'only-second' })).toStrictEqual({
+        a: 'first',
+        b: 'only-second',
+      })
+    })
+
+    test('first object arrays win completely', () => {
+      expect(deepMergePreferFirst({ tags: ['a'] }, { tags: ['b', 'c'] })).toStrictEqual({ tags: ['a'] })
+    })
+
+    test('deeply merges nested objects', () => {
+      expect(
+        deepMergePreferFirst(
+          { overview: { name: 'local' } },
+          { overview: { name: 'mirrored', description: 'mirrored-desc' } },
+        ),
+      ).toStrictEqual({ overview: { name: 'local', description: 'mirrored-desc' } })
+    })
+
+    test('fills in keys missing from first object', () => {
+      expect(deepMergePreferFirst({}, { a: 1, nested: { b: 2 } })).toStrictEqual({ a: 1, nested: { b: 2 } })
+    })
+
+    test('handles null values in first object', () => {
+      expect(deepMergePreferFirst({ a: null }, { a: 'fallback' })).toStrictEqual({ a: null })
+    })
+
+    test('does not mutate input objects', () => {
+      const first = { a: 1 }
+      const second = { b: 2 }
+      deepMergePreferFirst(first, second)
+      expect(first).toStrictEqual({ a: 1 })
+      expect(second).toStrictEqual({ b: 2 })
+    })
   })
 })

--- a/frontend/test/utils/formUtils.spec.ts
+++ b/frontend/test/utils/formUtils.spec.ts
@@ -1,5 +1,10 @@
 import { StepNoRender } from 'types/types'
-import { deepMergePreferFirst, getFormStats, setFormDataPropertiesToUndefined } from 'utils/formUtils'
+import {
+  deepMergePreferFirst,
+  getFormStats,
+  isQuestionAnswered,
+  setFormDataPropertiesToUndefined,
+} from 'utils/formUtils'
 import { describe, expect, it } from 'vitest'
 
 describe('Form utils', () => {
@@ -84,6 +89,51 @@ describe('Form utils', () => {
     it('non-mirrored models only count local state', () => {
       const stats = getFormStats(baseStep, false)
       expect(stats.totalAnswers).toBe(1)
+    })
+  })
+
+  describe('isQuestionAnswered', () => {
+    const makeFormContext = (state: any, mirroredState?: any, mirroredModel = false) =>
+      ({ state, mirroredState, mirroredModel }) as any
+
+    it('returns true for answered string field', () => {
+      const context = makeFormContext({ overview: { name: 'Test' } })
+      expect(isQuestionAnswered('root_overview_name', { type: 'string' }, context)).toBe(true)
+    })
+
+    it('returns false for empty string field', () => {
+      const context = makeFormContext({ overview: { name: '' } })
+      expect(isQuestionAnswered('root_overview_name', { type: 'string' }, context)).toBe(false)
+    })
+
+    it('returns false for missing field', () => {
+      const context = makeFormContext({})
+      expect(isQuestionAnswered('root_overview_name', { type: 'string' }, context)).toBe(false)
+    })
+
+    it('falls back to mirrored value when local is empty for mirrored models', () => {
+      const context = makeFormContext({ overview: { name: '' } }, { overview: { name: 'Mirrored' } }, true)
+      expect(isQuestionAnswered('root_overview_name', { type: 'string' }, context)).toBe(true)
+    })
+
+    it('prefers local value over mirrored when both exist', () => {
+      const context = makeFormContext({ overview: { name: 'Local' } }, { overview: { name: 'Mirrored' } }, true)
+      expect(isQuestionAnswered('root_overview_name', { type: 'string' }, context)).toBe(true)
+    })
+
+    it('does not use mirrored value for non-mirrored models', () => {
+      const context = makeFormContext({ overview: { name: '' } }, { overview: { name: 'Mirrored' } }, false)
+      expect(isQuestionAnswered('root_overview_name', { type: 'string' }, context)).toBe(false)
+    })
+
+    it('falls back to mirrored array when local array is empty (DataCardSelector edge case)', () => {
+      const context = makeFormContext({ dataCards: [] }, { dataCards: ['card-1', 'card-2'] }, true)
+      expect(isQuestionAnswered('root_dataCards', { type: 'array', items: { type: 'string' } }, context)).toBe(true)
+    })
+
+    it('returns false when both local and mirrored arrays are empty', () => {
+      const context = makeFormContext({ dataCards: [] }, { dataCards: [] }, true)
+      expect(isQuestionAnswered('root_dataCards', { type: 'array', items: { type: 'string' } }, context)).toBe(false)
     })
   })
 })

--- a/frontend/test/utils/formUtils.spec.ts
+++ b/frontend/test/utils/formUtils.spec.ts
@@ -1,4 +1,5 @@
-import { setFormDataPropertiesToUndefined } from 'utils/formUtils'
+import { StepNoRender } from 'types/types'
+import { deepMergePreferFirst, getFormStats, setFormDataPropertiesToUndefined } from 'utils/formUtils'
 import { describe, expect, it } from 'vitest'
 
 describe('Form utils', () => {
@@ -16,5 +17,73 @@ describe('Form utils', () => {
       },
     }
     expect(JSON.stringify(setFormDataPropertiesToUndefined(sourceObject))).toBe(JSON.stringify(expectedResult))
+  })
+
+  describe('deepMergePreferFirst', () => {
+    it('prefers first object values for primitives', () => {
+      const result = deepMergePreferFirst({ a: 'local' }, { a: 'mirrored', b: 'only-mirrored' })
+      expect(result).toEqual({ a: 'local', b: 'only-mirrored' })
+    })
+
+    it('prefers first object arrays over second', () => {
+      const result = deepMergePreferFirst({ tags: ['a'] }, { tags: ['b', 'c'] })
+      expect(result).toEqual({ tags: ['a'] })
+    })
+
+    it('deeply merges nested objects', () => {
+      const result = deepMergePreferFirst(
+        { overview: { name: 'local-name' } },
+        { overview: { name: 'mirrored-name', description: 'mirrored-desc' } },
+      )
+      expect(result).toEqual({ overview: { name: 'local-name', description: 'mirrored-desc' } })
+    })
+
+    it('fills in missing keys from second object', () => {
+      const result = deepMergePreferFirst({}, { a: 'from-mirrored', nested: { b: 'deep' } })
+      expect(result).toEqual({ a: 'from-mirrored', nested: { b: 'deep' } })
+    })
+  })
+
+  describe('getFormStats with mirrored models', () => {
+    const baseSchema = {
+      title: 'Test',
+      type: 'object',
+      properties: {
+        name: { type: 'string' },
+        description: { type: 'string' },
+      },
+      required: ['name', 'description'],
+    }
+    const baseStep: StepNoRender = {
+      schema: baseSchema,
+      state: { name: 'local-name' },
+      mirroredState: { description: 'mirrored-desc' },
+      index: 0,
+      section: 'test',
+      type: 'Form',
+      schemaRef: 'test',
+      shouldValidate: false,
+      isComplete: () => false,
+    }
+
+    it('counts answers from combined state for mirrored models', () => {
+      const stats = getFormStats(baseStep, true)
+      expect(stats.totalAnswers).toBe(2)
+      expect(stats.formCompleted).toBe(true)
+    })
+
+    it('local values take precedence over mirrored values', () => {
+      const step: StepNoRender = {
+        ...baseStep,
+        mirroredState: { name: 'mirrored-name', description: 'mirrored-desc' },
+      }
+      const stats = getFormStats(step, true)
+      expect(stats.totalAnswers).toBe(2)
+    })
+
+    it('non-mirrored models only count local state', () => {
+      const stats = getFormStats(baseStep, false)
+      expect(stats.totalAnswers).toBe(1)
+    })
   })
 })

--- a/frontend/utils/formUtils.ts
+++ b/frontend/utils/formUtils.ts
@@ -250,11 +250,14 @@ export function deepMergePreferFirst<TPreferred extends object, TFallback extend
 }
 
 function getPreferFirstValue(firstValue: unknown, secondValue: unknown): unknown {
-  // Picks a value, preferring first when both exist
-  if (firstValue !== undefined && firstValue !== null && firstValue !== '') {
-    return firstValue
+  // Picks first value when it has meaningful content, otherwise falls back to second.
+  if (firstValue === undefined || firstValue === null || firstValue === '') {
+    return secondValue
   }
-  return secondValue
+  if (Array.isArray(firstValue) && firstValue.length === 0) {
+    return secondValue
+  }
+  return firstValue
 }
 
 /**

--- a/frontend/utils/formUtils.ts
+++ b/frontend/utils/formUtils.ts
@@ -1,6 +1,6 @@
 import { Registry, RegistryWidgetsType } from '@rjsf/utils'
 import { Validator } from 'jsonschema'
-import { cloneDeep, dropRight, get, omit, remove } from 'lodash-es'
+import { cloneDeep, dropRight, get, mergeWith, omit, remove } from 'lodash-es'
 import { Dispatch, SetStateAction } from 'react'
 import CheckboxInput from 'src/MuiForms/CheckboxInput'
 import CustomTextInput from 'src/MuiForms/CustomTextInput'
@@ -228,6 +228,32 @@ export const getState = (id: string, formContext: Registry['formContext']) => {
     .reduce((prev, cur) => prev && prev[cur], formContext.state)
 }
 
+// Mirrors backend `deepMergePreferFirst`
+export function deepMergePreferFirst<T extends object, U extends object>(first: T, second: U): T & U {
+  return mergeWith({}, second, first, (objValue, srcValue) => {
+    // Arrays: first object wins completely
+    if (Array.isArray(objValue) || Array.isArray(srcValue)) {
+      return srcValue ?? objValue
+    }
+
+    // Primitives: first object wins when present
+    if (srcValue !== undefined && (srcValue === null || typeof srcValue !== 'object')) {
+      return srcValue
+    }
+
+    // Return undefined to let lodash continue normal deep merge.
+    return undefined
+  }) as T & U
+}
+
+function getPreferFirstValue(firstValue: unknown, secondValue: unknown): unknown {
+  // Picks a value, preferring first when both exist
+  if (firstValue !== undefined && firstValue !== null && firstValue !== '') {
+    return firstValue
+  }
+  return secondValue
+}
+
 /**
  * Look up the compare-mode "from" local-card value for a field, mirroring `getState`. Returns
  * `undefined` when the current form isn't running in compare mode (i.e. no `compareFromState` was
@@ -282,7 +308,11 @@ export function isQuestionAnswered(id: string, schema: any, formContext: Registr
     return false
   }
 
-  const value = getState(id, formContext)
+  // For mirrored models, a field is answered if present in either local or source card (local value preferred)
+  const localValue = getState(id, formContext)
+  const value = formContext.mirroredModel
+    ? getPreferFirstValue(localValue, getMirroredState(id, formContext))
+    : localValue
 
   if (isPrimitiveSchema(schema)) {
     return isAnswered(value)
@@ -409,13 +439,13 @@ export function getFormStats(step?: StepNoRender, mirroredModel?: boolean, requi
   }
 
   const totalQuestions = countQuestionsFromSchema(step.schema, requiredByModelState)
-  const totalAnswers = countAnswersFromSchemaAndState(
-    step.schema,
-    mirroredModel ? step.mirroredState : step.state,
-    requiredByModelState,
-  )
+  // Mirrored models validate against the combined card with local values preferred to source values
+  const stateForValidation = mirroredModel
+    ? deepMergePreferFirst(step.state || {}, step.mirroredState || {})
+    : step.state
+  const totalAnswers = countAnswersFromSchemaAndState(step.schema, stateForValidation, requiredByModelState)
 
-  // If more answers given than required answers then return 100% otherwise calulate percentage
+  // If more answers given than required answers then return 100% otherwise calculate percentage
   const percentageQuestionsComplete =
     totalQuestions === 0 ? 100 : Math.min(100, roundToOneDecimal((totalAnswers / totalQuestions) * 100))
 

--- a/frontend/utils/formUtils.ts
+++ b/frontend/utils/formUtils.ts
@@ -229,7 +229,10 @@ export const getState = (id: string, formContext: Registry['formContext']) => {
 }
 
 // Mirrors backend `deepMergePreferFirst`
-export function deepMergePreferFirst<T extends object, U extends object>(first: T, second: U): T & U {
+export function deepMergePreferFirst<TPreferred extends object, TFallback extends object>(
+  first: TPreferred,
+  second: TFallback,
+): TPreferred & TFallback {
   return mergeWith({}, second, first, (objValue, srcValue) => {
     // Arrays: first object wins completely
     if (Array.isArray(objValue) || Array.isArray(srcValue)) {
@@ -243,7 +246,7 @@ export function deepMergePreferFirst<T extends object, U extends object>(first: 
 
     // Return undefined to let lodash continue normal deep merge.
     return undefined
-  }) as T & U
+  }) as TPreferred & TFallback
 }
 
 function getPreferFirstValue(firstValue: unknown, secondValue: unknown): unknown {


### PR DESCRIPTION
Update mirrored model state validation to evaluate the merged model card data (`card` + `mirroredCard`) rather than validating only the mirrored model's local card content.

Prior to this PR, model state verification for mirrored models only considered fields present in the mirrored model card. This can incorrectly block state transitions when required fields are satisfied by the source model card.