### PR TITLE
Correct manifest list typeguard

### DIFF
--- a/backend/src/scripts/traceImageDigests.ts
+++ b/backend/src/scripts/traceImageDigests.ts
@@ -3,6 +3,7 @@ import { issueAccessToken } from '../routes/v1/registryAuth.js'
 import log from '../services/log.js'
 import { isRegistryError } from '../types/RegistryError.js'
 import { connectToMongoose, disconnectFromMongoose } from '../utils/database.js'
+import { isManifestList } from '../utils/registryResponses.js'
 
 const digestsToSearchFor: string[] = []
 
@@ -46,7 +47,7 @@ async function script() {
           tag,
         })
 
-        if (!manifest || 'manifests' in manifest) {
+        if (!manifest || isManifestList(manifest)) {
           continue
         }
 

--- a/backend/src/services/images/getImageLayers.ts
+++ b/backend/src/services/images/getImageLayers.ts
@@ -2,7 +2,7 @@ import { getImageTagManifests } from '../../clients/registry.js'
 import { ImageRef } from '../../models/Release.js'
 import { isRegistryError } from '../../types/RegistryError.js'
 import { InternalError, NotFound } from '../../utils/error.js'
-import { Descriptors, ImageManifestV2 } from '../../utils/registryResponses.js'
+import { Descriptors, ImageManifestV2, isManifestList } from '../../utils/registryResponses.js'
 
 /**
  * @remarks
@@ -16,7 +16,7 @@ export async function getImageLayers(repositoryToken: string, image: ImageRef): 
       throw InternalError('Registry manifest body missing.', { image })
     }
 
-    if ('manifests' in manifestResponse.body) {
+    if (isManifestList(manifestResponse.body)) {
       return (
         await Promise.all(
           manifestResponse.body.manifests.map(async (manifest) =>
@@ -46,8 +46,12 @@ export async function getLayersForImage(
 ): Promise<Descriptors[]> {
   const manifest = manifestParam ?? (await getImageTagManifests(repositoryToken, imageRef)).body
 
-  if (!manifest || 'manifests' in manifest) {
+  if (!manifest) {
     throw InternalError('The registry returned a response but the body was missing.', { manifest })
+  }
+
+  if (isManifestList(manifest)) {
+    throw InternalError('Expected a single image manifest but received a manifest list.', { manifest })
   }
 
   return [manifest.config, ...manifest.layers]

--- a/backend/src/services/mirroredModel/importers/image.ts
+++ b/backend/src/services/mirroredModel/importers/image.ts
@@ -14,6 +14,7 @@ import config from '../../../utils/config.js'
 import { InternalError } from '../../../utils/error.js'
 import {
   ImageManifestV2,
+  isManifestList,
   ManifestListV2,
   ManifestResponseBodySchema,
   OCIEmptyMediaType,
@@ -200,7 +201,7 @@ export class ImageImporter extends BaseImporter {
         },
       ])
 
-      if ('manifests' in this.manifestBody) {
+      if (isManifestList(this.manifestBody)) {
         // For fat manifests, upload platform-specific manifests first (by digest)
         log.debug(
           { ...this.logData, manifestCount: this.manifestBody.manifests.length },
@@ -258,7 +259,7 @@ export class ImageImporter extends BaseImporter {
       log.debug(
         {
           image: { modelId: this.metadata.mirroredModelId, imageName: this.imageName, imageTag: this.imageTag },
-          isFatManifest: 'manifests' in this.manifestBody,
+          isFatManifest: isManifestList(this.manifestBody),
           ...this.logData,
         },
         'Completed registry upload',

--- a/backend/src/services/mirroredModel/mirroredModel.ts
+++ b/backend/src/services/mirroredModel/mirroredModel.ts
@@ -18,7 +18,7 @@ import { dedupeByKey } from '../../utils/array.js'
 import config from '../../utils/config.js'
 import { BadReq, Forbidden, InternalError } from '../../utils/error.js'
 import { shortId } from '../../utils/id.js'
-import { ManifestListV2 } from '../../utils/registryResponses.js'
+import { isManifestList, ManifestListV2 } from '../../utils/registryResponses.js'
 import { getHttpsAgent } from '../http.js'
 import { getImageLayers } from '../images/getImageLayers.js'
 import log from '../log.js'
@@ -354,7 +354,7 @@ export async function addCompressedRegistryImageComponents(
     })
   }
 
-  const isFatManifest = 'manifests' in tagManifest
+  const isFatManifest = isManifestList(tagManifest)
 
   log.debug(
     {

--- a/backend/src/services/registry.ts
+++ b/backend/src/services/registry.ts
@@ -27,7 +27,13 @@ import {
   SeverityCounts,
 } from '../types/types.js'
 import { BadReq, Forbidden, InternalError, NotFound } from '../utils/error.js'
-import { Descriptors, ImageManifestV2, ManifestListV2, OCIEmptyMediaType } from '../utils/registryResponses.js'
+import {
+  Descriptors,
+  ImageManifestV2,
+  isManifestList,
+  ManifestListV2,
+  OCIEmptyMediaType,
+} from '../utils/registryResponses.js'
 import { platformToString } from '../utils/registryUtils.js'
 import { useTransaction } from '../utils/transactions.js'
 import { getLayersForImage } from './images/getImageLayers.js'
@@ -198,7 +204,7 @@ export async function getModelImageWithScanResults(
   let platform: string | undefined
 
   let layerRef: ImageRef
-  if ('manifests' in body) {
+  if (isManifestList(body)) {
     if (!digest) {
       throw BadReq('Must provide digest for multiplatform image', { imageRef })
     }
@@ -243,7 +249,7 @@ export async function listModelImagesWithScanResults(
               return []
             }
 
-            if ('manifests' in manifestResponse.body) {
+            if (isManifestList(manifestResponse.body)) {
               return Promise.all(
                 manifestResponse.body.manifests.map(async (manifest) => {
                   const layers = await getLayersForImage(repositoryToken, { ...img, digest: manifest.digest })
@@ -324,7 +330,7 @@ async function getTagDigestReferenceMap(
       if (rootDigest) {
         refs.add(rootDigest)
       }
-      if (body && 'manifests' in body) {
+      if (body && isManifestList(body)) {
         for (const manifest of body.manifests) {
           if (manifest.digest) {
             refs.add(manifest.digest)
@@ -441,7 +447,7 @@ async function renameMultiManifest(
       }
 
       const { body: childManifest } = await getImageTagManifests(multiRepositoryToken, digestRef)
-      if (!childManifest || 'manifests' in childManifest) {
+      if (!childManifest || isManifestList(childManifest)) {
         throw InternalError('Platform manifest missing.', { digestRef })
       }
 
@@ -582,7 +588,7 @@ export async function renameImage(user: UserInterface, source: ImageTagRef, dest
     })
   }
 
-  if ('manifests' in manifest.body) {
+  if (isManifestList(manifest.body)) {
     await renameMultiManifest(source, destination, manifest.body, multiRepositoryToken, sourceDigest)
   } else {
     await renameStandardManifest(source, destination, manifest.body, multiRepositoryToken, sourceDigest)

--- a/backend/src/utils/registryResponses.ts
+++ b/backend/src/utils/registryResponses.ts
@@ -186,8 +186,13 @@ export const ManifestListV2Schema = z.object({
 })
 export type ManifestListV2 = z.infer<typeof ManifestListV2Schema>
 
-// TODO: handle multi-platform images
 export const ManifestResponseBodySchema = z.union([ImageManifestV2Schema, ManifestListV2Schema])
+export function isManifestList(manifest: ImageManifestV2 | ManifestListV2): manifest is ManifestListV2 {
+  if ('mediaType' in manifest && ManifestListMediaTypeSchema.safeParse(manifest.mediaType).success) {
+    return true
+  }
+  return 'manifests' in manifest
+}
 
 export const ManifestResponseHeadersSchema = CommonRegistryHeadersSchema.extend({
   'docker-content-digest': HeaderValueSchema,

--- a/backend/test/services/images/getImageLayers.spec.ts
+++ b/backend/test/services/images/getImageLayers.spec.ts
@@ -27,6 +27,56 @@ describe('services > images > getImageLayers', () => {
     expect(result).toEqual([{ digest: 'sha256:config' }, { digest: 'sha256:layer1' }, { digest: 'sha256:layer2' }])
   })
 
+  test('return layers from manifest list by fetching each platform manifest', async () => {
+    registryMocks.getImageTagManifests
+      .mockResolvedValueOnce({
+        body: {
+          mediaType: 'application/vnd.docker.distribution.manifest.list.v2+json',
+          manifests: [
+            { digest: 'sha256:amd64digest', mediaType: 'application/vnd.docker.distribution.manifest.v2+json' },
+            { digest: 'sha256:arm64digest', mediaType: 'application/vnd.docker.distribution.manifest.v2+json' },
+          ],
+        },
+      })
+      .mockResolvedValueOnce({
+        body: {
+          config: { digest: 'sha256:config1' },
+          layers: [{ digest: 'sha256:layer1' }],
+        },
+      })
+      .mockResolvedValueOnce({
+        body: {
+          config: { digest: 'sha256:config2' },
+          layers: [{ digest: 'sha256:layer2' }],
+        },
+      })
+
+    const result = await getImageLayers('token', {
+      repository: 'repo',
+      name: 'image',
+      tag: 'latest',
+    } as any)
+
+    expect(result).toEqual([
+      { digest: 'sha256:config1' },
+      { digest: 'sha256:layer1' },
+      { digest: 'sha256:config2' },
+      { digest: 'sha256:layer2' },
+    ])
+
+    expect(registryMocks.getImageTagManifests).toHaveBeenCalledTimes(3)
+    expect(registryMocks.getImageTagManifests).toHaveBeenNthCalledWith(2, 'token', {
+      repository: 'repo',
+      name: 'image',
+      digest: 'sha256:amd64digest',
+    })
+    expect(registryMocks.getImageTagManifests).toHaveBeenNthCalledWith(3, 'token', {
+      repository: 'repo',
+      name: 'image',
+      digest: 'sha256:arm64digest',
+    })
+  })
+
   test('throw InternalError when manifest body is missing', async () => {
     registryMocks.getImageTagManifests.mockResolvedValueOnce({})
 
@@ -75,5 +125,18 @@ describe('services > images > getImageLayers', () => {
     await expect(
       getLayersForImage('token', { repository: 'repo', name: 'image', tag: 'latest' } as any),
     ).rejects.toThrow(/^The registry returned a response but the body was missing./)
+  })
+
+  test('getLayersForImage > throws InternalError when response is a manifest list', async () => {
+    registryMocks.getImageTagManifests.mockResolvedValueOnce({
+      body: {
+        mediaType: 'application/vnd.docker.distribution.manifest.list.v2+json',
+        manifests: [{ digest: 'sha256:abc' }],
+      },
+    })
+
+    await expect(
+      getLayersForImage('token', { repository: 'repo', name: 'image', tag: 'latest' } as any),
+    ).rejects.toThrow(/^Expected a single image manifest but received a manifest list./)
   })
 })


### PR DESCRIPTION
Added `isManifestList()` type guard that checks `mediaType` against `ManifestListMediaTypeSchema` as per the OCI & Docker specs, with `'manifests' in` fallback for manifests missing `mediaType`.