### PR TITLE
Chore/dependabot and pinned version SHA improvements

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.12-trixie
+FROM python:3.12-trixie@sha256:7ad6d21a25a94b2c00e685e82c2fd298de814353d9ee0e3f7f2cd4fca063df60
 
 LABEL dev.containers.image.node.version="26" \
       dev.containers.image.python.version="3.12"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,294 +1,292 @@
-# Basic dependabot.yml file with
-# minimum configuration for two package managers
-
 version: 2
 updates:
-  # Enable version updates for npm
+  # Root package.json (workspaces orchestrator)
   - package-ecosystem: 'npm'
-    # Look for `package.json` and `lock` files in the `root` directory
     directory: '/'
-    # Check the npm registry for updates every month
     schedule:
       interval: 'monthly'
     versioning-strategy: increase
-    # Limit the number of open pull requests for node dependencies
     open-pull-requests-limit: 25
-    # group related packages into one PR
-    # dependabot doesn't support YAML aliases so this is copied-and-pasted for all npm ecosystems https://github.com/dependabot/dependabot-core/issues/1582
     groups:
-      react-stack:
-        patterns:
-          - react
-          - react-dom
-          - next
-          - "@next/*"
-          - "@mdx-js/*"
-      mui-stack:
-        patterns:
-          - "@mui/*"
-          - "@emotion/*"
-          - styled-components
-      eslint-stack:
-        patterns:
-          - eslint
-          - eslint-*
-          - "@eslint/*"
-          - "@typescript-eslint/*"
-      typescript-stack:
-        patterns:
-          - typescript
-          - ts-node
-          - "vite-tsconfig-paths"
-      testing-stack:
-        patterns:
-          - vitest
-          - "@vitest/*"
-          - "@testing-library/*"
-          - cypress
-          - supertest
-          - jsdom
-      aws-sdk-stack:
-        patterns:
-          - "@aws-sdk/*"
-          - "@smithy/*"
-      rjsf-stack:
-        patterns:
-          - "@rjsf/*"
-      opentelemetry-stack:
-        patterns:
-          - "@opentelemetry/*"
-          - "@vercel/otel"
       formatting-stack:
         patterns:
           - prettier
-          - eslint-plugin-prettier
-      markdown-stack:
-        patterns:
-          - markdown-*
-          - remark-*
-          - rehype-*
-          - "@uiw/react-markdown-preview"
-          - "@uiw/react-md-editor"
+          - lint-staged
+          - husky
 
+  # Frontend
   - package-ecosystem: 'npm'
-    # Look for `package.json` and `lock` files in the `/frontend` directory
     directory: '/frontend'
     schedule:
       interval: 'monthly'
     versioning-strategy: increase
     open-pull-requests-limit: 25
-    # dependabot doesn't support YAML aliases so this is copied-and-pasted for all npm ecosystems https://github.com/dependabot/dependabot-core/issues/1582
     groups:
       react-stack:
         patterns:
           - react
           - react-dom
+          - react-diff-viewer-continued
+          - react-to-print
           - next
-          - "@next/*"
-          - "@mdx-js/*"
+          - next-router-mock
+          - '@next/*'
+          - '@mdx-js/*'
+          - '@vitejs/plugin-react'
       mui-stack:
         patterns:
-          - "@mui/*"
-          - "@emotion/*"
-          - styled-components
+          - '@mui/*'
+          - '@emotion/*'
+          - notistack
       eslint-stack:
         patterns:
           - eslint
           - eslint-*
-          - "@eslint/*"
-          - "@typescript-eslint/*"
-      typescript-stack:
-        patterns:
-          - typescript
-          - ts-node
-          - "vite-tsconfig-paths"
+          - '@eslint/*'
+          - '@typescript-eslint/*'
       testing-stack:
         patterns:
           - vitest
-          - "@vitest/*"
-          - "@testing-library/*"
+          - '@testing-library/*'
           - cypress
-          - supertest
+          - cypress-axe
+          - axe-core
           - jsdom
-      aws-sdk-stack:
-        patterns:
-          - "@aws-sdk/*"
-          - "@smithy/*"
       rjsf-stack:
         patterns:
-          - "@rjsf/*"
-      opentelemetry-stack:
-        patterns:
-          - "@opentelemetry/*"
-          - "@vercel/otel"
-      formatting-stack:
-        patterns:
-          - prettier
-          - eslint-plugin-prettier
+          - '@rjsf/*'
       markdown-stack:
         patterns:
           - markdown-*
           - remark-*
           - rehype-*
-          - "@uiw/react-markdown-preview"
-          - "@uiw/react-md-editor"
-
-  - package-ecosystem: 'npm'
-    # Look for `package.json` and `lock` files in the `/lib/landing` directory
-    directory: '/lib/landing'
-    schedule:
-      interval: 'monthly'
-    versioning-strategy: increase
-    open-pull-requests-limit: 25
-    # dependabot doesn't support YAML aliases so this is copied-and-pasted for all npm ecosystems https://github.com/dependabot/dependabot-core/issues/1582
-    groups:
-      react-stack:
+          - '@uiw/react-markdown-preview'
+          - '@uiw/react-md-editor'
+      types-stack:
         patterns:
-          - react
-          - react-dom
-          - next
-          - "@next/*"
-          - "@mdx-js/*"
-      mui-stack:
-        patterns:
-          - "@mui/*"
-          - "@emotion/*"
-          - styled-components
-      eslint-stack:
-        patterns:
-          - eslint
-          - eslint-*
-          - "@eslint/*"
-          - "@typescript-eslint/*"
+          - '@types/*'
       typescript-stack:
         patterns:
           - typescript
-          - ts-node
-          - "vite-tsconfig-paths"
-      testing-stack:
+      utility-stack:
         patterns:
-          - vitest
-          - "@vitest/*"
-          - "@testing-library/*"
-          - cypress
-          - supertest
-          - jsdom
-      aws-sdk-stack:
+          - lodash-es
+          - semver
+          - uuid
+          - clsx
+          - dayjs
+          - pretty-bytes
+          - randomcolor
+          - http-status-codes
+          - is-docker
+          - js-cookie
+          - jsonschema
+          - sharp
+      data-fetching-stack:
         patterns:
-          - "@aws-sdk/*"
-          - "@smithy/*"
-      rjsf-stack:
+          - swr
+          - axios
+      swc-optional-stack:
         patterns:
-          - "@rjsf/*"
-      opentelemetry-stack:
+          - '@next/swc-*'
+      telemetry-stack:
         patterns:
-          - "@opentelemetry/*"
-          - "@vercel/otel"
+          - '@vercel/otel'
       formatting-stack:
         patterns:
           - prettier
-          - eslint-plugin-prettier
-      markdown-stack:
-        patterns:
-          - markdown-*
-          - remark-*
-          - rehype-*
-          - "@uiw/react-markdown-preview"
-          - "@uiw/react-md-editor"
+          - '@fontsource/*'
 
+  # Backend
   - package-ecosystem: 'npm'
-    # Look for `package.json` and `lock` files in the `/backend` directory
     directory: '/backend'
     schedule:
       interval: 'monthly'
     versioning-strategy: increase
     open-pull-requests-limit: 25
-    # dependabot doesn't support YAML aliases so this is copied-and-pasted for all npm ecosystems https://github.com/dependabot/dependabot-core/issues/1582
+    groups:
+      aws-sdk-stack:
+        patterns:
+          - '@aws-sdk/*'
+          - '@smithy/*'
+      opentelemetry-stack:
+        patterns:
+          - '@opentelemetry/*'
+      eslint-stack:
+        patterns:
+          - eslint
+          - eslint-*
+          - '@eslint/*'
+          - '@typescript-eslint/*'
+          - typescript-eslint
+      testing-stack:
+        patterns:
+          - vitest
+          - '@vitest/*'
+          - '@anatine/zod-mock'
+          - supertest
+      mongoose-stack:
+        patterns:
+          - mongoose
+          - mongodb
+          - connect-mongo
+          - '@agendajs/mongo-backend'
+          - agenda
+      logging-stack:
+        patterns:
+          - pino
+          - pino-*
+          - morgan
+      typescript-stack:
+        patterns:
+          - typescript
+          - tsx
+          - vite
+          - vite-tsconfig-paths
+      types-stack:
+        patterns:
+          - '@types/*'
+      express-stack:
+        patterns:
+          - express
+          - express-rate-limit
+          - express-session
+          - body-parser
+          - helmet
+          - swagger-ui-express
+      email-stack:
+        patterns:
+          - mjml
+          - nodemailer
+          - handlebars
+      validation-stack:
+        patterns:
+          - zod
+          - zod-error
+          - '@asteasolutions/zod-to-openapi'
+          - jsonschema
+          - json-schema-traverse
+      utility-stack:
+        patterns:
+          - lodash-es
+          - semver
+          - uuid
+          - nanoid
+          - bytes
+          - chalk
+          - dedent-js
+          - outdent
+          - yargs
+          - utility-types
+          - p-queue
+          - node-cache
+          - globals
+      auth-stack:
+        patterns:
+          - grant
+          - jsonwebtoken
+          - bcryptjs
+      file-handling-stack:
+        patterns:
+          - tar-stream
+          - content-disposition
+          - form-data
+          - sanitize-html
+          - showdown
+          - xmlbuilder2
+      network-stack:
+        patterns:
+          - node-fetch
+          - proxy-agent
+          - undici
+          - qs
+      scanning-stack:
+        patterns:
+          - clamscan
+      misc-stack:
+        patterns:
+          - app-root-path
+          - config
+          - dev-null
+          - nodemon
+          - shelljs
+          - '@huggingface/hub'
+      formatting-stack:
+        patterns:
+          - prettier
+
+  # Landing page
+  - package-ecosystem: 'npm'
+    directory: '/lib/landing'
+    schedule:
+      interval: 'monthly'
+    versioning-strategy: increase
+    open-pull-requests-limit: 25
     groups:
       react-stack:
         patterns:
           - react
           - react-dom
           - next
-          - "@next/*"
-          - "@mdx-js/*"
+          - '@next/*'
+          - '@mdx-js/*'
       mui-stack:
         patterns:
-          - "@mui/*"
-          - "@emotion/*"
+          - '@mui/*'
+          - '@emotion/*'
           - styled-components
       eslint-stack:
         patterns:
           - eslint
           - eslint-*
-          - "@eslint/*"
-          - "@typescript-eslint/*"
-      typescript-stack:
-        patterns:
-          - typescript
-          - ts-node
-          - "vite-tsconfig-paths"
-      testing-stack:
-        patterns:
-          - vitest
-          - "@vitest/*"
-          - "@testing-library/*"
-          - cypress
-          - supertest
-          - jsdom
-      aws-sdk-stack:
-        patterns:
-          - "@aws-sdk/*"
-          - "@smithy/*"
-      rjsf-stack:
-        patterns:
-          - "@rjsf/*"
-      opentelemetry-stack:
-        patterns:
-          - "@opentelemetry/*"
-          - "@vercel/otel"
-      formatting-stack:
-        patterns:
-          - prettier
-          - eslint-plugin-prettier
       markdown-stack:
         patterns:
-          - markdown-*
           - remark-*
           - rehype-*
-          - "@uiw/react-markdown-preview"
-          - "@uiw/react-md-editor"
+      types-stack:
+        patterns:
+          - '@types/*'
+      utility-stack:
+        patterns:
+          - dedent-js
+          - shelljs
+          - swagger-ui-dist
+          - swiper
+          - typescript
 
-  # Enable version updates for Docker
+  # Docker images
   - package-ecosystem: 'docker'
-    # Look for a `Dockerfile` in these directories
     directories:
       - '/'
       - '/backend'
       - '/frontend'
       - '/lib/artefactscan_api'
-    # Check for updates once a week
     schedule:
       interval: 'weekly'
+    groups:
+      node-images:
+        patterns:
+          - node
+      python-images:
+        patterns:
+          - python
 
-  # Enable version updates for Docker Compose
+  # Docker Compose
   - package-ecosystem: 'docker-compose'
-    # Look for docker-compose in these directories
     directories:
       - '/'
-    # Check for updates once a week
     schedule:
       interval: 'weekly'
 
+  # Helm
   - package-ecosystem: 'helm'
     directories:
       - '/infrastructure/helm/bailo'
     schedule:
       interval: 'weekly'
 
-  # Enable version updates for python bailo package
+  # Python - bailo client library
   - package-ecosystem: 'pip'
-    # Look for a `requirements*` or `pyproject.toml` in these directories
     directories:
       - '/lib/python'
     schedule:
@@ -296,29 +294,63 @@ updates:
     versioning-strategy: increase
     open-pull-requests-limit: 10
 
-  # Enable version updates for python artefactscan api
+  # Python - artefactscan API
   - package-ecosystem: 'pip'
-    # Look for a `requirements*` or `pyproject.toml` in these directories
     directories:
       - '/lib/artefactscan_api'
     schedule:
       interval: 'weekly'
     versioning-strategy: increase
     open-pull-requests-limit: 10
+    groups:
+      scanning-stack:
+        patterns:
+          - modelscan
+          - modelscan[*]
+          - oras
+      server-stack:
+        patterns:
+          - fastapi
+          - fastapi[*]
+          - uvicorn
+          - pydantic_settings
+          - python-multipart
+          - content-size-limit-asgi
+      testing-stack:
+        patterns:
+          - pytest
+          - pytest-*
+          - pre_commit
 
-  # Enable version updates for python docs
+  # Python - backend docs
   - package-ecosystem: 'pip'
-    # Look for a `requirements*` or `pyproject.toml` in these directories
     directories:
       - '/backend/docs'
     schedule:
       interval: 'weekly'
     versioning-strategy: increase
     open-pull-requests-limit: 10
+    groups:
+      sphinx-stack:
+        patterns:
+          - sphinx
+          - sphinx-*
+          - myst_parser
+          - nbsphinx
+      dev-tools-stack:
+        patterns:
+          - pre_commit
+          - ipython
 
-  # Set update schedule for GitHub Actions
+  # GitHub Actions
   - package-ecosystem: 'github-actions'
     directory: '/'
     schedule:
       interval: 'monthly'
-    open-pull-requests-limit: 12
+    open-pull-requests-limit: 10
+    groups:
+      github-actions:
+        patterns:
+          - actions/*
+          - github/*
+          - docker/*

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,12 +7,6 @@ updates:
       interval: 'monthly'
     versioning-strategy: increase
     open-pull-requests-limit: 25
-    groups:
-      formatting-stack:
-        patterns:
-          - prettier
-          - lint-staged
-          - husky
 
   # Frontend
   - package-ecosystem: 'npm'
@@ -26,8 +20,6 @@ updates:
         patterns:
           - react
           - react-dom
-          - react-diff-viewer-continued
-          - react-to-print
           - next
           - next-router-mock
           - '@next/*'
@@ -65,37 +57,6 @@ updates:
       types-stack:
         patterns:
           - '@types/*'
-      typescript-stack:
-        patterns:
-          - typescript
-      utility-stack:
-        patterns:
-          - lodash-es
-          - semver
-          - uuid
-          - clsx
-          - dayjs
-          - pretty-bytes
-          - randomcolor
-          - http-status-codes
-          - is-docker
-          - js-cookie
-          - jsonschema
-          - sharp
-      data-fetching-stack:
-        patterns:
-          - swr
-          - axios
-      swc-optional-stack:
-        patterns:
-          - '@next/swc-*'
-      telemetry-stack:
-        patterns:
-          - '@vercel/otel'
-      formatting-stack:
-        patterns:
-          - prettier
-          - '@fontsource/*'
 
   # Backend
   - package-ecosystem: 'npm'
@@ -136,16 +97,6 @@ updates:
         patterns:
           - pino
           - pino-*
-          - morgan
-      typescript-stack:
-        patterns:
-          - typescript
-          - tsx
-          - vite
-          - vite-tsconfig-paths
-      types-stack:
-        patterns:
-          - '@types/*'
       express-stack:
         patterns:
           - express
@@ -153,67 +104,18 @@ updates:
           - express-session
           - body-parser
           - helmet
-          - swagger-ui-express
-      email-stack:
-        patterns:
-          - mjml
-          - nodemailer
-          - handlebars
       validation-stack:
         patterns:
           - zod
           - zod-error
           - '@asteasolutions/zod-to-openapi'
-          - jsonschema
-          - json-schema-traverse
-      utility-stack:
+      types-stack:
         patterns:
-          - lodash-es
-          - semver
-          - uuid
-          - nanoid
-          - bytes
-          - chalk
-          - dedent-js
-          - outdent
-          - yargs
-          - utility-types
-          - p-queue
-          - node-cache
-          - globals
-      auth-stack:
+          - '@types/*'
+      vite-stack:
         patterns:
-          - grant
-          - jsonwebtoken
-          - bcryptjs
-      file-handling-stack:
-        patterns:
-          - tar-stream
-          - content-disposition
-          - form-data
-          - sanitize-html
-          - showdown
-          - xmlbuilder2
-      network-stack:
-        patterns:
-          - node-fetch
-          - proxy-agent
-          - undici
-          - qs
-      scanning-stack:
-        patterns:
-          - clamscan
-      misc-stack:
-        patterns:
-          - app-root-path
-          - config
-          - dev-null
-          - nodemon
-          - shelljs
-          - '@huggingface/hub'
-      formatting-stack:
-        patterns:
-          - prettier
+          - vite
+          - vite-tsconfig-paths
 
   # Landing page
   - package-ecosystem: 'npm'
@@ -246,13 +148,6 @@ updates:
       types-stack:
         patterns:
           - '@types/*'
-      utility-stack:
-        patterns:
-          - dedent-js
-          - shelljs
-          - swagger-ui-dist
-          - swiper
-          - typescript
 
   # Docker images
   - package-ecosystem: 'docker'
@@ -337,17 +232,13 @@ updates:
           - sphinx-*
           - myst_parser
           - nbsphinx
-      dev-tools-stack:
-        patterns:
-          - pre_commit
-          - ipython
 
   # GitHub Actions
   - package-ecosystem: 'github-actions'
     directory: '/'
     schedule:
       interval: 'monthly'
-    open-pull-requests-limit: 10
+    open-pull-requests-limit: 12
     groups:
       github-actions:
         patterns:

--- a/.github/workflows/artefactscan.yml
+++ b/.github/workflows/artefactscan.yml
@@ -15,9 +15,9 @@ jobs:
     outputs:
       relevant: ${{ steps.filter.outputs.relevant }}
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       # Restrict PR execution to files that affect this workflow to reduce CI runtime and GitHub Actions consumption
-      - uses: dorny/paths-filter@v4
+      - uses: dorny/paths-filter@7b450fff21473bca461d4b92ce414b9d0420d706 # v4.0.2
         id: filter
         with:
           filters: |
@@ -34,15 +34,15 @@ jobs:
         python-version: ['3.10', '3.12']
 
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v7
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: ${{ matrix.python-version }}
 
       - name: Cache pip dependencies
-        uses: actions/cache@v6
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: ~/.cache/pip
           key: ${{ runner.os }}-pip-${{ matrix.python-version }}

--- a/.github/workflows/build.js.yml
+++ b/.github/workflows/build.js.yml
@@ -61,16 +61,16 @@ jobs:
 
     steps:
       # Clone repository
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 2
 
       # Setup BuildX
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
 
       - name: Build ${{ matrix.component.name }} image
-        uses: docker/build-push-action@v7
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
         with:
           context: ${{ matrix.component.context }}
           build-contexts: ${{ matrix.component.additional_contexts || '' }}
@@ -142,7 +142,7 @@ jobs:
 
       - name: Log in to GHCR
         if: steps.push_targets.outputs.push_release == 'true' || steps.push_targets.outputs.push_artefactscan == 'true'
-        uses: docker/login-action@v4
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -150,7 +150,7 @@ jobs:
 
       - name: Push backend & frontend images to GHCR
         if: steps.push_targets.outputs.push_release == 'true'
-        uses: docker/build-push-action@v7
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
         with:
           context: ${{ matrix.component.context }}
           build-contexts: ${{ matrix.component.additional_contexts || '' }}
@@ -163,7 +163,7 @@ jobs:
 
       - name: Push artefactscan image to GHCR
         if: steps.push_targets.outputs.push_artefactscan == 'true'
-        uses: docker/build-push-action@v7
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
         with:
           context: ${{ matrix.component.context }}
           build-contexts: ${{ matrix.component.additional_contexts || '' }}
@@ -175,7 +175,7 @@ jobs:
           cache-from: type=gha,scope=${{ matrix.component.cache_scope }}
 
       - name: Upload artifact
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: ${{ matrix.component.artifact }}
           path: ${{ matrix.component.tar }}
@@ -188,16 +188,16 @@ jobs:
 
     steps:
       # Clone repository
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Use Node.js
-        uses: actions/setup-node@v7
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: 26
           cache: "npm"
 
       - name: Cache npm dependencies
-        uses: actions/cache@v6
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: ~/.npm
           key: ${{ runner.os }}-node-${{ hashFiles('**package-lock.json') }}
@@ -227,11 +227,11 @@ jobs:
 
     steps:
       # Clone repository
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       # Setup BuildX
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
 
       # jq is required so that `npm ci` is not needed to generate certs
       - name: Install jq
@@ -239,7 +239,7 @@ jobs:
 
       # Get Bailo Docker images
       - name: Download artifact
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           pattern: bailo_*
           path: /tmp
@@ -248,7 +248,7 @@ jobs:
         run: ls -R /tmp/bailo_*
 
       - name: Start minikube
-        uses: medyagh/setup-minikube@latest
+        uses: medyagh/setup-minikube@e9e035a86bbc3caea26a450bd4dbf9d0c453682e # v0.0.21
         with:
           driver: docker
           kubernetes-version: v1.35.0
@@ -388,31 +388,31 @@ jobs:
 
     steps:
       # Clone repository
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Set up Node.js
-        uses: actions/setup-node@v7
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: 26
           cache: "npm"
 
       # Setup BuildX
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
 
       # Get Bailo Docker images
       - name: Download artifact
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: bailo_backend
           path: /tmp
       - name: Download artifact
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: bailo_frontend
           path: /tmp
       - name: Download artifact
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: bailo_artefactscan
           path: /tmp
@@ -475,7 +475,7 @@ jobs:
           --wait --wait-timeout 60
 
       # e2e with Cypress
-      - uses: cypress-io/github-action@v7
+      - uses: cypress-io/github-action@fa4a118725a8f001170d49631ea89e5d66fee626 # v7.4.1
         if: matrix.job_name == 'end_to_end'
         with:
           wait-on: 'http://localhost:8080/api/v2/config/ui, http://localhost:8080'
@@ -486,13 +486,13 @@ jobs:
       # Python integration
       - name: Set up Python
         if: matrix.job_name == 'integration_python'
-        uses: actions/setup-python@v7
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: "3.14"
 
       - name: Cache python pip
         if: matrix.job_name == 'integration_python'
-        uses: actions/cache@v6
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: ~/.cache/pip
           key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements*.txt') }}
@@ -532,7 +532,7 @@ jobs:
           PYTEST_RUN_PATH: "lib/python"
 
       # Upload all artifacts & logs
-      - uses: actions/upload-artifact@v7
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         if: failure() && matrix.job_name == 'end_to_end'
         with:
           name: cypress-screenshots-e2e
@@ -546,7 +546,7 @@ jobs:
         if: always()
         run: cat logs/stack.log
 
-      - uses: actions/upload-artifact@v7
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         if: always() && matrix.job_name == 'end_to_end'
         with:
           name: logs

--- a/.github/workflows/codeql.js.yml
+++ b/.github/workflows/codeql.js.yml
@@ -32,11 +32,11 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       # Initializes the CodeQL tools for scanning.
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v4.37.3
+        uses: github/codeql-action/init@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4.37.3
         # Override language selection by uncommenting this and choosing your languages
         with:
           languages: javascript-typescript, python, actions
@@ -58,4 +58,4 @@ jobs:
       #     make release
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v4.37.3
+        uses: github/codeql-action/analyze@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4.37.3

--- a/.github/workflows/docs-style.yml
+++ b/.github/workflows/docs-style.yml
@@ -15,9 +15,9 @@ jobs:
     outputs:
       relevant: ${{ steps.filter.outputs.relevant }}
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       # Restrict PR execution to files that affect this workflow to reduce CI runtime and GitHub Actions consumption
-      - uses: dorny/paths-filter@v4
+      - uses: dorny/paths-filter@7b450fff21473bca461d4b92ce414b9d0420d706 # v4.0.2
         id: filter
         with:
           filters: |
@@ -32,6 +32,6 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Check docs style guide compliance
         run: bash frontend/scripts/check-docs-style.sh

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Apply labels
-        uses: actions/labeler@v7
+        uses: actions/labeler@bf12e9b00b37c5c0ca2b87b79b2daf7891dbda13 # v7.0.0
         with:
           repo-token: "${{ secrets.GITHUB_TOKEN }}"
           configuration-path: ".github/labeler.yml"

--- a/.github/workflows/python-publish-test.yml
+++ b/.github/workflows/python-publish-test.yml
@@ -17,21 +17,21 @@ jobs:
       files-changed-output: ${{ steps.files-changed.outputs.any_changed }}
 
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
 
       # Check for changed init file (for new version)
       - name: Get changed init files
         id: files-changed
-        uses: tj-actions/changed-files@v47
+        uses: tj-actions/changed-files@9426d40962ed5378910ee2e21d5f8c6fcbf2dd96 # v47.0.6
         with:
           files: |
             lib/python/src/bailo/__init__.py
 
       # Setup Python
       - name: Set up Python
-        uses: actions/setup-python@v7
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: "3.14"
 
@@ -47,7 +47,7 @@ jobs:
 
       # Upload Bailo artifact
       - name: Store the distribution packages
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: python-package-distributions
           path: lib/python/dist/
@@ -69,7 +69,7 @@ jobs:
       #Retrieve Bailo artifact
       - name: Download all the dists
         if: needs.build.outputs.files-changed-output == 'true'
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: python-package-distributions
           path: lib/python/dist/
@@ -77,7 +77,7 @@ jobs:
       # Publish artifact to TestPyPI
       - name: Publish distribution to TestPyPI
         if: needs.build.outputs.files-changed-output == 'true'
-        uses: pypa/gh-action-pypi-publish@release/v1
+        uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33 # v1.14.2
         with:
           packages-dir: lib/python/dist/
           repository-url: https://test.pypi.org/legacy/

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -15,21 +15,21 @@ jobs:
       files-changed-output: ${{ steps.files-changed.outputs.any_changed }}
 
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
 
       # Check for changed init file (for new version)
       - name: Get changed init files
         id: files-changed
-        uses: tj-actions/changed-files@v47
+        uses: tj-actions/changed-files@9426d40962ed5378910ee2e21d5f8c6fcbf2dd96 # v47.0.6
         with:
           files: |
             lib/python/src/bailo/__init__.py
 
       # Setup Python
       - name: Set up Python
-        uses: actions/setup-python@v7
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: "3.14"
 
@@ -45,7 +45,7 @@ jobs:
 
       # Upload Bailo artifact
       - name: Store the distribution packages
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: python-package-distributions
           path: lib/python/dist/
@@ -67,7 +67,7 @@ jobs:
       # Retrieve Bailo artifact
       - name: Download all the dists
         if: needs.build.outputs.files-changed-output == 'true'
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: python-package-distributions
           path: lib/python/dist/
@@ -75,6 +75,6 @@ jobs:
       # Publish artifact to PyPI
       - name: Publish distribution to PyPI
         if: needs.build.outputs.files-changed-output == 'true'
-        uses: pypa/gh-action-pypi-publish@release/v1
+        uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33 # v1.14.2
         with:
           packages-dir: lib/python/dist/

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -15,9 +15,9 @@ jobs:
     outputs:
       relevant: ${{ steps.filter.outputs.relevant }}
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       # Restrict PR execution to files that affect this workflow to reduce CI runtime and GitHub Actions consumption
-      - uses: dorny/paths-filter@v4
+      - uses: dorny/paths-filter@7b450fff21473bca461d4b92ce414b9d0420d706 # v4.0.2
         id: filter
         with:
           filters: |
@@ -34,15 +34,15 @@ jobs:
       pylint: ${{ steps.pylint.outputs.status }}
 
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Set up Python
-        uses: actions/setup-python@v7
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: "3.14"
 
       - name: Cache pip dependencies
-        uses: actions/cache@v6
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: ~/.cache/pip
           key: ${{ runner.os }}-pip-static-${{ hashFiles('lib/python/pyproject.toml') }}-python3.14
@@ -79,15 +79,15 @@ jobs:
         python-version: ['3.10', '3.11', '3.12', '3.13', '3.14']
 
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v7
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: ${{ matrix.python-version }}
 
       - name: Cache pip dependencies
-        uses: actions/cache@v6
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: ~/.cache/pip
           key: ${{ runner.os }}-pip-test-${{ matrix.python-version }}-${{ hashFiles('lib/python/pyproject.toml') }}

--- a/.github/workflows/web.yml
+++ b/.github/workflows/web.yml
@@ -26,9 +26,9 @@ jobs:
     outputs:
       relevant: ${{ steps.filter.outputs.relevant }}
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       # Restrict PR execution to files that affect this workflow to reduce CI runtime and GitHub Actions consumption
-      - uses: dorny/paths-filter@v4
+      - uses: dorny/paths-filter@7b450fff21473bca461d4b92ce414b9d0420d706 # v4.0.2
         id: filter
         with:
           filters: |
@@ -47,13 +47,13 @@ jobs:
         working-directory: backend/docs
 
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Install pandoc
         run: sudo apt install pandoc
 
       - name: Setup Python
-        uses: actions/setup-python@v7
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: "3.14"
 
@@ -66,7 +66,7 @@ jobs:
         run: |
           make html
       - name: Upload artifact
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: python-docs
           path: ./backend/docs/python-docs/html
@@ -82,22 +82,22 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Download Python Docs
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: python-docs
           path: ./backend/docs/python-docs/html
 
       - name: Setup Node
-        uses: actions/setup-node@v7
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: 26
           cache: "npm"
 
       - name: Setup Pages
-        uses: actions/configure-pages@v6
+        uses: actions/configure-pages@45bfe0192ca1faeb007ade9deae92b16b8254a0d # v6.0.0
         with:
           # Automatically inject basePath in your Next.js configuration file and disable
           # server side image optimization (https://nextjs.org/docs/api-reference/next/image#unoptimized).
@@ -106,7 +106,7 @@ jobs:
           static_site_generator: next
 
       - name: Restore cache
-        uses: actions/cache@v6
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: |
             ~/.npm
@@ -136,7 +136,7 @@ jobs:
         env:
           BASE_PATH: "/Bailo"
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v5
+        uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5.0.0
         with:
           path: ./lib/landing/out
 
@@ -156,4 +156,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v5
+        uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128 # v5.0.0

--- a/Dockerfile.standalone
+++ b/Dockerfile.standalone
@@ -14,7 +14,7 @@
 #       docker run --rm -p 4318:8080 --network dev_internal --name second-bailo second-bailo:latest
 #       Access UI at http://localhost:4318/
 
-FROM python:3.14-trixie AS sphinx-docs
+FROM python:3.14-trixie@sha256:55dd7c1ea6c2b2c45a26d797187706eb9e5e0046f8e54fd759e38647b505c36b AS sphinx-docs
 ENV PYTHONDONTWRITEBYTECODE=1 \
     PYTHONUNBUFFERED=1
 RUN --mount=type=cache,target=/var/cache/apt,sharing=locked --mount=type=cache,target=/var/lib/apt \
@@ -26,7 +26,7 @@ COPY backend/docs .
 RUN --mount=type=cache,target=/root/.cache/pip pip install --upgrade bailo -r requirements.txt
 RUN make dirhtml
 
-FROM node:26.5.0-alpine AS backend
+FROM node:26.5.0-alpine@sha256:e88a35be04478413b7c71c455cd9865de9b9360e1f43456be5951032d7ac1a66 AS backend
 RUN apk add --no-cache libc6-compat && \
     apk update
 WORKDIR /app
@@ -35,7 +35,7 @@ RUN --mount=type=cache,target=/cache/npm npm ci --cache=/cache/npm
 COPY backend .
 RUN npm run build
 
-FROM node:26.5.0-alpine AS frontend
+FROM node:26.5.0-alpine@sha256:e88a35be04478413b7c71c455cd9865de9b9360e1f43456be5951032d7ac1a66 AS frontend
 ENV NEXT_TELEMETRY_DISABLED=1
 RUN apk add --no-cache libc6-compat && \
     apk update
@@ -46,7 +46,7 @@ COPY frontend .
 RUN --mount=type=cache,target=/cache/npm npm install sharp@0.33.5 --cache=/cache/npm
 RUN npm run build
 
-FROM ubuntu:noble
+FROM ubuntu:noble@sha256:4fbb8e6a8395de5a7550b33509421a2bafbc0aab6c06ba2cef9ebffbc7092d90
 ENV DEBIAN_FRONTEND=noninteractive
 # Cache packages with run cache, update system packages, install packages
 RUN --mount=type=cache,target=/var/cache/apt,sharing=locked --mount=type=cache,target=/var/lib/apt \

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1
 
-FROM python:3.14.2-trixie AS sphinx-docs
+FROM python:3.14.2-trixie@sha256:4878b7ad12a3c49e49c775ea617df0d2169605eaffc5ede31977e1c3dd913eae AS sphinx-docs
 
 # Prevents Python from writing pyc files, and from buffering stdout and stderr to avoid situations where the application crashes without emitting any logs due to buffering.
 ENV PYTHONDONTWRITEBYTECODE=1 \
@@ -25,7 +25,7 @@ RUN --mount=type=cache,target=/root/.cache/pip pip install -e /app/python -r req
 
 RUN make html
 
-FROM node:26.5.0-alpine AS node-base
+FROM node:26.5.0-alpine@sha256:e88a35be04478413b7c71c455cd9865de9b9360e1f43456be5951032d7ac1a66 AS node-base
 
 RUN apk add --no-cache libc6-compat ca-certificates && \
     apk update

--- a/compose.prod.yaml
+++ b/compose.prod.yaml
@@ -2,7 +2,7 @@ name: bailo-prod
 
 services:
   clamd:
-    image: clamav/clamav:1.4.3_base
+    image: clamav/clamav:1.4.3_base@sha256:629a3050df6a706aedb31859fbb8139e9aaf8f56b0ffefbf251b8358a7c9e76c
     networks:
       internal:
     healthcheck:
@@ -34,13 +34,13 @@ services:
     ports:
       - 1080:1080
       - 1025:1025
-    image: marlonb/mailcrab:v1.8.0
+    image: marlonb/mailcrab:v1.8.0@sha256:8d19e5c1ffe1750993da7bd63724331ccc0bd226159cc4dfa89156209fe34b4a
 
   webhook-tester:
     networks:
       default:
       internal:
-    image: tarampampam/webhook-tester:2.3.0
+    image: tarampampam/webhook-tester:2.3.0@sha256:85818267b450d3d386cad6510c561e09b974183ed2832c373bc83b125fc1b221
     command: serve --auto-create-sessions
     ports:
       - 8082:8080

--- a/compose.yaml
+++ b/compose.yaml
@@ -8,7 +8,7 @@ configs:
 
 services:
   mongo:
-    image: mongodb/mongodb-community-server:8.3.7-ubi9
+    image: mongodb/mongodb-community-server:8.3.7-ubi9@sha256:5df20e4e490389b1d2c728e2b5c374aaec7be0c70a11fb7ce17661cf4a2c0432
     networks:
       internal:
     environment:
@@ -37,7 +37,7 @@ services:
       - 27017:27017
 
   minio:
-    image: bitnamilegacy/minio:2025.7.23
+    image: bitnamilegacy/minio:2025.7.23@sha256:8935e75fa5d11295c17171e4aa49efe390a1193cd7f12e4d21b92af9ffef09d7
     networks:
       internal:
     environment:
@@ -47,7 +47,7 @@ services:
       - minioVolume:/bitnami/minio
 
   nginx:
-    image: nginxinc/nginx-unprivileged:1.31.2-alpine3.23-slim
+    image: nginxinc/nginx-unprivileged:1.31.2-alpine3.23-slim@sha256:eed3e4c2f3f9285e80610238e0b18fe1bf311c50559434db1969b1cfabd5518b
     networks:
       default:
       internal:

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1
 
-FROM node:26.5.0-alpine AS base
+FROM node:26.5.0-alpine@sha256:e88a35be04478413b7c71c455cd9865de9b9360e1f43456be5951032d7ac1a66 AS base
 ENV NEXT_TELEMETRY_DISABLED=1
 
 RUN apk add --no-cache libc6-compat ca-certificates && \

--- a/infrastructure/helm/bailo/values.yaml
+++ b/infrastructure/helm/bailo/values.yaml
@@ -159,7 +159,7 @@ mongodb:
   image:
     registry: docker.io
     repository: bitnamilegacy/mongodb
-    tag: 8.0.13-debian-12-r0
+    tag: 8.0.13-debian-12-r0@sha256:2579e968033ec9f97035e91a215a4fb3943eb706eb3871b3d0d1d072e2f45605
 
 # MinIO Dependencies
 minio:
@@ -195,13 +195,13 @@ minio:
   image:
     registry: docker.io
     repository: bitnamilegacy/minio
-    tag: 2025.7.23-debian-12-r1
+    tag: 2025.7.23-debian-12-r1@sha256:ba958aa5e12c8b1426dd95de61d8f1ed14741efa0ec730019ed57086930a4299
     debug: true
 
 # Registry Dependencies
 registry:
   repository: registry
-  tag: 3.1.1
+  tag: 3.1.1@sha256:1be55279f18a2fe1a74edf2664cac61c1bea305b7b4642dab412e7affdcb3e33
   enabled: true
   protocol: "https"
   #host: "bailo-registry" # service name
@@ -229,7 +229,7 @@ federation:
 # Nginx Dependencies
 nginxAuth:
   repository: nginxinc/nginx-unprivileged # runs Nginx as non-root unprivileged user.
-  tag: 1.31.1-alpine3.23-slim
+  tag: 1.31.1-alpine3.23-slim@sha256:762e8e4e5e103817c4158400fc3753c8e713ff8153b8c3afbb458ae4572bc9a3
   #host: "bailo-nginx" # service name
   port: 8080
   #certDir: "/certs"
@@ -239,7 +239,7 @@ nginxAuth:
 # Mail
 mail:
   enabled: true
-  image: marlonb/mailcrab:v1.6.5
+  image: marlonb/mailcrab:v1.6.5@sha256:36fe6d71fdedc7f3ae7a2765b8f4357334cee31c8bd84b69e2f067fa25b33aa4
 
 # Openshift specific configuration
 openshift:
@@ -384,7 +384,7 @@ frontend:
 clamav:
   enabled: false
   runAsUser: 1002
-  image: clamav/clamav:1.4.3_base # https://docs.clamav.net/manual/Installing/Docker.html#the-official-images-on-docker-hub
+  image: clamav/clamav:1.4.3_base@sha256:629a3050df6a706aedb31859fbb8139e9aaf8f56b0ffefbf251b8358a7c9e76c # https://docs.clamav.net/manual/Installing/Docker.html#the-official-images-on-docker-hub
   concurrency: 2
   streamMaxLength: 2G
   port: 3310

--- a/lib/artefactscan_api/Dockerfile
+++ b/lib/artefactscan_api/Dockerfile
@@ -3,7 +3,7 @@
 ARG UID=65532
 ARG GID=65532
 
-FROM python:3.12.13-slim-trixie AS build
+FROM python:3.12.13-slim-trixie@sha256:57cd7c3a7a273101a6485ba99423ee568157882804b1124b4dd04266317710de AS build
 
 ENV PYTHONDONTWRITEBYTECODE=1 \
     PYTHONUNBUFFERED=1 \
@@ -22,7 +22,7 @@ RUN --mount=type=cache,target=/root/.cache/pip \
     pip install --no-compile -r requirements.txt
 
 
-FROM python:3.12.13-slim-trixie AS base
+FROM python:3.12.13-slim-trixie@sha256:57cd7c3a7a273101a6485ba99423ee568157882804b1124b4dd04266317710de AS base
 ARG UID
 ARG GID
 
@@ -37,7 +37,7 @@ RUN groupadd --gid ${GID} appuser && \
 
 WORKDIR /app
 
-FROM aquasec/trivy:0.72.0 AS trivy
+FROM aquasec/trivy:0.72.0@sha256:cffe3f5161a47a6823fbd23d985795b3ed72a4c806da4c4df16266c02accdd6f AS trivy
 
 FROM base AS dev
 


### PR DESCRIPTION
- Update dependabot groups to have fewer total PRs
- Pin GitHub Actions to a full-length commit SHA - closes #3913
- Pin Dockerfile, compose & helm images to SHAs

To manually check the GitHub Action SHAs use:
```bash
resolve_sha() {
  local repo="$1" tag="$2"
  local sha type
  read sha type < <(gh api "repos/$repo/git/ref/tags/$tag" --jq '[.object.sha, .object.type] | @tsv')
  if [ "$type" = "tag" ]; then
    sha=$(gh api "repos/$repo/git/tags/$sha" --jq '.object.sha')
  fi
  echo "$sha"
}

grep -rn 'uses:.*@[0-9a-f]\{40\}' .github/workflows/ | while read -r line; do
  # Extract repo, sha, and version comment
  repo=$(echo "$line" | grep -oP 'uses: \K[^@]+')
  pinned_sha=$(echo "$line" | grep -oP '@\K[0-9a-f]{40}')
  tag=$(echo "$line" | grep -oP '# \K\S+')
  # Strip subpath (e.g. github/codeql-action/init -> github/codeql-action)
  api_repo=$(echo "$repo" | sed 's|^\([^/]*/[^/]*\).*|\1|')
  expected=$(resolve_sha "$api_repo" "$tag")
  if [ "$pinned_sha" = "$expected" ]; then
    echo "OK: $repo@$tag"
  else
    echo "MISMATCH: $repo@$tag pinned=$pinned_sha expected=$expected"
  fi
done
```

Docker (requires crane):
```bash
grep -rn '^FROM.*@sha256:' \
  frontend/Dockerfile backend/Dockerfile Dockerfile.standalone \
  .devcontainer/Dockerfile lib/artefactscan_api/Dockerfile | \
while read -r line; do
  img=$(echo "$line" | grep -oP 'FROM \K\S+' | sed 's/ AS.*//')
  tag_ref="${img%%@*}"
  pinned="${img##*@}"
  expected=$(crane digest "$tag_ref" 2>/dev/null)
  if [ "$pinned" = "$expected" ]; then
    echo "OK: $tag_ref"
  else
    echo "MISMATCH: $tag_ref pinned=$pinned expected=$expected"
  fi
done
```

Docker compose (requires crane):
**Important: `distribution/distribution` has an expected mismatch due to us using an untagged future digest**
```bash
grep -rn 'image:.*@sha256:' compose.yaml compose.override.yaml compose.prod.yaml | \
while read -r line; do
  img=$(echo "$line" | grep -oP 'image: \K\S+')
  tag_ref="${img%%@*}"
  pinned="${img##*@}"
  expected=$(crane digest "$tag_ref" 2>/dev/null)
  if [ "$pinned" = "$expected" ]; then
    echo "OK: $tag_ref"
  else
    echo "MISMATCH: $tag_ref pinned=$pinned expected=$expected"
  fi
done
```

Helm (requires crane):
```bash
file=infrastructure/helm/bailo/values.yaml

# Inline image: fields (mailcrab, clamav)
grep -n 'image:.*@sha256:' "$file" | while read -r line; do
  img=$(echo "$line" | grep -oP 'image: \K\S+')
  tag_ref="${img%%@*}"
  pinned="${img##*@}"
  expected=$(crane digest "$tag_ref" 2>/dev/null)
  if [ "$pinned" = "$expected" ]; then
    echo "OK: $tag_ref"
  else
    echo "MISMATCH: $tag_ref pinned=$pinned expected=$expected"
  fi
done

# repository/tag fields (mongodb, minio, registry, nginx)
# Reconstruct full image ref from consecutive repository + tag lines
grep -n 'repository:\|tag:.*@sha256:' "$file" | while read -r line; do
  if echo "$line" | grep -q 'repository:'; then
    repo=$(echo "$line" | grep -oP 'repository: \K\S+')
  elif echo "$line" | grep -q 'tag:.*@sha256:'; then
    tag_digest=$(echo "$line" | grep -oP 'tag: \K\S+')
    tag_ref="$repo:${tag_digest%%@*}"
    pinned="${tag_digest##*@}"
    expected=$(crane digest "$tag_ref" 2>/dev/null)
    if [ "$pinned" = "$expected" ]; then
      echo "OK: $tag_ref"
    else
      echo "MISMATCH: $tag_ref pinned=$pinned expected=$expected"
    fi
  fi
done
```