### PR TITLE
Update `Dockerfile.standalone`

### DIFF
--- a/Dockerfile.standalone
+++ b/Dockerfile.standalone
@@ -14,10 +14,9 @@
 #       docker run --rm -p 4318:8080 --network dev_internal --name second-bailo second-bailo:latest
 #       Access UI at http://localhost:4318/
 
-ARG MAILCRAB_VERSION=v1.6.4
-
 FROM chrislusf/seaweedfs:4.40@sha256:52194fba4fecd0083c842158b3a902ba6e04a63619b2b0efcd08007bdb6a4602 AS seaweedfs-bin
 FROM distribution/distribution@sha256:1eda63c5b5ba2c53b8b7e7071d7e67ca42e93c4ea5d9015c2b8160eb09a95d61 AS registry-bin
+FROM marlonb/mailcrab:v1.8.0@sha256:8d19e5c1ffe1750993da7bd63724331ccc0bd226159cc4dfa89156209fe34b4a AS mailcrab-bin
 
 FROM python:3.14.2-trixie@sha256:4878b7ad12a3c49e49c775ea617df0d2169605eaffc5ede31977e1c3dd913eae AS sphinx-docs
 ENV PYTHONDONTWRITEBYTECODE=1 \
@@ -95,10 +94,7 @@ ENV REGISTRY_HTTP_TLS_CERTIFICATE=/app/backend/certs/cert.pem \
 
 COPY infrastructure/standalone/registry.conf /registry.conf
 
-ARG MAILCRAB_VERSION
-RUN wget -q https://github.com/tweedegolf/mailcrab/releases/download/${MAILCRAB_VERSION}/mailcrab-linux-x86-64-gnu-${MAILCRAB_VERSION} && \
-    install -m755 mailcrab-linux-x86-64-gnu-${MAILCRAB_VERSION} /usr/local/bin/mailcrab && \
-    rm -f mailcrab-linux-x86-64-gnu-${MAILCRAB_VERSION}
+COPY --from=mailcrab-bin /app/mailcrab /usr/local/bin/mailcrab
 
 # Backend
 WORKDIR /app/backend

--- a/Dockerfile.standalone
+++ b/Dockerfile.standalone
@@ -10,24 +10,33 @@
 #       docker compose up
 #       Access UI at localhost:8080
 # Then run your 2nd instance using this file with
-#       docker build . -t second-bailo -f Dockerfile.standalone
+#       docker build . -t second-bailo -f Dockerfile.standalone --build-context python=./lib/python
 #       docker run --rm -p 4318:8080 --network dev_internal --name second-bailo second-bailo:latest
 #       Access UI at http://localhost:4318/
 
-FROM python:3.14-trixie@sha256:55dd7c1ea6c2b2c45a26d797187706eb9e5e0046f8e54fd759e38647b505c36b AS sphinx-docs
+ARG MAILCRAB_VERSION=v1.6.4
+
+FROM chrislusf/seaweedfs:4.40@sha256:52194fba4fecd0083c842158b3a902ba6e04a63619b2b0efcd08007bdb6a4602 AS seaweedfs-bin
+FROM distribution/distribution@sha256:1eda63c5b5ba2c53b8b7e7071d7e67ca42e93c4ea5d9015c2b8160eb09a95d61 AS registry-bin
+
+FROM python:3.14.2-trixie@sha256:4878b7ad12a3c49e49c775ea617df0d2169605eaffc5ede31977e1c3dd913eae AS sphinx-docs
 ENV PYTHONDONTWRITEBYTECODE=1 \
     PYTHONUNBUFFERED=1
-RUN --mount=type=cache,target=/var/cache/apt,sharing=locked --mount=type=cache,target=/var/lib/apt \
-    rm -f /etc/apt/apt.conf.d/docker-clean; echo 'Binary::apt::APT::Keep-Downloaded-Packages "true";' > /etc/apt/apt.conf.d/keep-cache && \
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked --mount=type=cache,target=/var/lib/apt,sharing=locked \
+    rm -f /etc/apt/apt.conf.d/docker-clean && \
+    echo 'Binary::apt::APT::Keep-Downloaded-Packages "true";' > /etc/apt/apt.conf.d/keep-cache && \
     apt-get update && \
     apt-get install -y --no-install-recommends pandoc
 WORKDIR /app/docs
 COPY backend/docs .
-RUN --mount=type=cache,target=/root/.cache/pip pip install --upgrade bailo -r requirements.txt
-RUN make dirhtml
+COPY --from=python pyproject.toml /app/python/
+COPY --from=python README.md /app/python/
+COPY --from=python src /app/python/src
+RUN --mount=type=cache,target=/root/.cache/pip pip install -e /app/python -r requirements.txt
+RUN make html
 
 FROM node:26.5.1-alpine@sha256:233761595746769ebfdb6090f44fc7cdf818ae0ce62d2b37e0367723b9823e36 AS backend
-RUN apk add --no-cache libc6-compat && \
+RUN apk add --no-cache libc6-compat ca-certificates && \
     apk update
 WORKDIR /app
 COPY backend/package*.json ./
@@ -37,13 +46,12 @@ RUN npm run build
 
 FROM node:26.5.1-alpine@sha256:233761595746769ebfdb6090f44fc7cdf818ae0ce62d2b37e0367723b9823e36 AS frontend
 ENV NEXT_TELEMETRY_DISABLED=1
-RUN apk add --no-cache libc6-compat && \
+RUN apk add --no-cache libc6-compat ca-certificates && \
     apk update
 WORKDIR /app
 COPY frontend/package*.json ./
 RUN --mount=type=cache,target=/cache/npm npm ci --cache=/cache/npm
 COPY frontend .
-RUN --mount=type=cache,target=/cache/npm npm install sharp@0.33.5 --cache=/cache/npm
 RUN npm run build
 
 FROM ubuntu:noble@sha256:561618e2c15bf2397621dd04f96926663a3b5616c189cf7e38db7e82f5c538ea
@@ -60,11 +68,8 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked --mount=type=cache,t
     apt-get install -y --no-install-recommends nodejs
 
 VOLUME /seaweed-data
-RUN wget -q https://github.com/seaweedfs/seaweedfs/releases/download/4.40/linux_amd64.tar.gz && \
-    tar -xzf linux_amd64.tar.gz weed && \
-    install -m755 weed /usr/local/bin/weed && \
-    rm -f linux_amd64.tar.gz weed && \
-    mkdir -p /etc/seaweedfs /seaweed-data
+COPY --from=seaweedfs-bin /usr/bin/weed /usr/local/bin/weed
+RUN mkdir -p /etc/seaweedfs /seaweed-data
 COPY infrastructure/seaweedfs/s3_config.json /etc/seaweedfs/s3_config.json
 
 RUN --mount=type=cache,target=/var/cache/apt,sharing=locked --mount=type=cache,target=/var/lib/apt \
@@ -76,9 +81,7 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked --mount=type=cache,t
 
 COPY infrastructure/standalone/nginx.conf /etc/nginx/nginx.conf
 
-RUN wget -q https://github.com/distribution/distribution/releases/download/v3.0.0/registry_3.0.0_linux_amd64.tar.gz && \
-    tar -xvf registry_3.0.0_linux_amd64.tar.gz registry && \
-    install -m755 registry /usr/local/bin/
+COPY --from=registry-bin /bin/registry /usr/local/bin/registry
 
 ENV REGISTRY_HTTP_TLS_CERTIFICATE=/app/backend/certs/cert.pem \
     REGISTRY_HTTP_TLS_KEY=/app/backend/certs/key.pem \
@@ -92,8 +95,10 @@ ENV REGISTRY_HTTP_TLS_CERTIFICATE=/app/backend/certs/cert.pem \
 
 COPY infrastructure/standalone/registry.conf /registry.conf
 
-RUN wget -q https://github.com/tweedegolf/mailcrab/releases/download/v1.6.4/mailcrab-linux-x86-64-gnu-v1.6.4 && \
-    install -m755 mailcrab-linux-x86-64-gnu-v1.6.4 /usr/local/bin/mailcrab
+ARG MAILCRAB_VERSION
+RUN wget -q https://github.com/tweedegolf/mailcrab/releases/download/${MAILCRAB_VERSION}/mailcrab-linux-x86-64-gnu-${MAILCRAB_VERSION} && \
+    install -m755 mailcrab-linux-x86-64-gnu-${MAILCRAB_VERSION} /usr/local/bin/mailcrab && \
+    rm -f mailcrab-linux-x86-64-gnu-${MAILCRAB_VERSION}
 
 # Backend
 WORKDIR /app/backend

--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ The above `docker compose` approaches are preferred, however we also provide a m
 run in standalone mode, not development mode (http://localhost:8080). Not for production use:
 
 ```bash
-docker build -t "bailo:standalone" -f ./Dockerfile.standalone .
+docker build -t "bailo:standalone" -f ./Dockerfile.standalone --build-context python=./lib/python .
 docker run --name bailo -p 8080:8080 -d bailo:standalone
 ```
 

--- a/frontend/pages/docs/administration/getting-started/deployment-architecture.mdx
+++ b/frontend/pages/docs/administration/getting-started/deployment-architecture.mdx
@@ -109,7 +109,7 @@ The main instance is then available at `http://localhost:8080`.
 Build and run the standalone image from the repository root:
 
 ```bash
-docker build . -t second-bailo -f Dockerfile.standalone
+docker build . -t second-bailo -f Dockerfile.standalone --build-context python=./lib/python
 docker run --rm -p 4318:8080 --network dev_internal --name second-bailo second-bailo:latest
 ```
 

--- a/infrastructure/standalone/supervisord.conf
+++ b/infrastructure/standalone/supervisord.conf
@@ -4,7 +4,7 @@ logfile=/dev/null
 logfile_maxbytes=0
 
 [program:seaweedfs]
-command=weed server -dir=/seaweed-data -master.port=9333 -volume.port=8080 -volume.max=100 -filer -filer.port=8888 -s3 -s3.port=8333 -s3.config=/etc/seaweedfs/s3_config.json
+command=weed server -dir=/seaweed-data -master.port=9333 -volume.port=9380 -volume.max=100 -filer -filer.port=8888 -s3 -s3.port=8333 -s3.config=/etc/seaweedfs/s3_config.json
 stdout_logfile=/dev/fd/1
 stdout_logfile_maxbytes=0
 redirect_stderr=true


### PR DESCRIPTION
Better align `Dockerfile.standalone` with the various compose stacks by:
- using `lib/python` build context
- pulling images and copying binaries for required services (e.g. seaweedfs) rather than downloading binaries
- bumping versions to match those in various compose files