### PR TITLE
Fix initial redirect

### DIFF
--- a/backend/global.d.ts
+++ b/backend/global.d.ts
@@ -14,6 +14,7 @@ declare namespace Express {
     session: {
       destroy: (callback) => void
       grant: any
+      loginRedirect?: string
     }
   }
 

--- a/backend/src/connectors/authentication/oauth.ts
+++ b/backend/src/connectors/authentication/oauth.ts
@@ -17,6 +17,30 @@ const OauthEntityKind = {
   Group: 'group',
 } as const
 
+// Redirect users to the Market Place if the callback is unsafe cross origin ect.
+const defaultLoginRedirect = '/'
+
+function getSafeLoginRedirect(redirect: unknown): string {
+  if (typeof redirect !== 'string' || redirect.startsWith('//')) {
+    return defaultLoginRedirect
+  }
+
+  if (!redirect.startsWith('/')) {
+    return defaultLoginRedirect
+  }
+
+  try {
+    const baseUrl = new URL(
+      `${config.app.protocol || 'http'}://${config.app.host || 'localhost'}${config.app.port ? `:${config.app.port}` : ''}`,
+    )
+    const redirectUrl = new URL(redirect, baseUrl)
+
+    return `${redirectUrl.pathname}${redirectUrl.search}${redirectUrl.hash}`
+  } catch {
+    return defaultLoginRedirect
+  }
+}
+
 export class OauthAuthenticationConnector extends BaseAuthenticationConnector {
   constructor() {
     super()
@@ -66,7 +90,14 @@ export class OauthAuthenticationConnector extends BaseAuthenticationConnector {
   getRoutes() {
     const router = Router()
     router.get('/api/login', (req, res) => {
+      req.session.loginRedirect = getSafeLoginRedirect(req.query.redirect)
       res.redirect(`/api/connect/${config.oauth.provider}/login`)
+    })
+
+    router.get('/api/login/callback', (req, res) => {
+      const redirect = getSafeLoginRedirect(req.session.loginRedirect)
+      delete req.session.loginRedirect
+      res.redirect(redirect)
     })
 
     router.get('/api/logout', (req, res) => {

--- a/backend/src/connectors/authentication/oauth.ts
+++ b/backend/src/connectors/authentication/oauth.ts
@@ -21,7 +21,7 @@ const OauthEntityKind = {
 const defaultLoginRedirect = '/'
 
 function getSafeLoginRedirect(redirect: unknown): string {
-  if (typeof redirect !== 'string' || redirect.startsWith('//')) {
+  if (typeof redirect !== 'string') {
     return defaultLoginRedirect
   }
 
@@ -30,6 +30,16 @@ function getSafeLoginRedirect(redirect: unknown): string {
   }
 
   try {
+    const decodedPath = decodeURIComponent(redirect.split(/[?#]/, 1)[0]) // Normalise encoded paths
+    if (
+      decodedPath.startsWith('//') || // Double path
+      decodedPath.includes('\\') || // Backslash
+      /[\r\n]/.test(decodedPath) || // Newline
+      decodedPath.split('/').some((segment) => segment === '.' || segment === '..') // Path traversal
+    ) {
+      return defaultLoginRedirect
+    }
+
     const baseUrl = new URL(
       `${config.app.protocol || 'http'}://${config.app.host || 'localhost'}${config.app.port ? `:${config.app.port}` : ''}`,
     )

--- a/backend/test/connectors/authentication/__snapshots__/oauth.spec.ts.snap
+++ b/backend/test/connectors/authentication/__snapshots__/oauth.spec.ts.snap
@@ -98,6 +98,37 @@ exports[`connectors > authentication > oauth > getRoutes > returns expected rout
       "methods": {
         "get": true,
       },
+      "path": "/api/login/callback",
+      "stack": [
+        Layer {
+          "handle": [Function],
+          "keys": [],
+          "matchers": [
+            [Function],
+          ],
+          "method": "get",
+          "name": "<anonymous>",
+          "params": undefined,
+          "path": undefined,
+          "slash": false,
+        },
+      ],
+    },
+    "slash": false,
+  },
+  Layer {
+    "handle": [Function],
+    "keys": [],
+    "matchers": [
+      [Function],
+    ],
+    "name": "handle",
+    "params": undefined,
+    "path": undefined,
+    "route": Route {
+      "methods": {
+        "get": true,
+      },
       "path": "/api/logout",
       "stack": [
         Layer {

--- a/backend/test/connectors/authentication/oauth.spec.ts
+++ b/backend/test/connectors/authentication/oauth.spec.ts
@@ -1,4 +1,5 @@
-import { Request, Response } from 'express'
+import express, { Request, Response } from 'express'
+import supertest from 'supertest'
 import { describe, expect, test, vi } from 'vitest'
 
 import { RoleKeys, Roles } from '../../../src/connectors/authentication/constants.js'
@@ -72,6 +73,50 @@ describe('connectors > authentication > oauth', () => {
     const router = await connector.getRoutes()
 
     expect(router.stack).toMatchSnapshot()
+  })
+
+  test.each([
+    ['/model/example?tab=files#content', '/model/example?tab=files#content'],
+    ['https://malicious.example/path', '/'],
+    ['//malicious.example/path', '/'],
+    ['not-a-path', '/'],
+  ])(
+    'getRoutes > redirects through login and returns to a safe location',
+    async (requestedRedirect, expectedRedirect) => {
+      const session = { grant: undefined, loginRedirect: undefined as string | undefined }
+      const app = express()
+      app.use((req, _res, next) => {
+        req.session = session as Request['session']
+        next()
+      })
+      app.use(new OauthAuthenticationConnector().getRoutes())
+
+      const loginResponse = await supertest(app).get('/api/login').query({ redirect: requestedRedirect })
+
+      expect(loginResponse.status).toBe(302)
+      expect(loginResponse.headers.location).toBe(`/api/connect/${config.oauth.provider}/login`)
+      expect(session.loginRedirect).toBe(expectedRedirect)
+
+      const callbackResponse = await supertest(app).get('/api/login/callback')
+
+      expect(callbackResponse.status).toBe(302)
+      expect(callbackResponse.headers.location).toBe(expectedRedirect)
+      expect(session.loginRedirect).toBeUndefined()
+    },
+  )
+
+  test('getRoutes > callback defaults to the home page when no redirect was stored', async () => {
+    const app = express()
+    app.use((req, _res, next) => {
+      req.session = { grant: undefined } as Request['session']
+      next()
+    })
+    app.use(new OauthAuthenticationConnector().getRoutes())
+
+    const response = await supertest(app).get('/api/login/callback')
+
+    expect(response.status).toBe(302)
+    expect(response.headers.location).toBe('/')
   })
 
   test('queryEntities > returns in expected format', async () => {

--- a/backend/test/connectors/authentication/oauth.spec.ts
+++ b/backend/test/connectors/authentication/oauth.spec.ts
@@ -79,7 +79,14 @@ describe('connectors > authentication > oauth', () => {
     ['/model/example?tab=files#content', '/model/example?tab=files#content'],
     ['https://malicious.example/path', '/'],
     ['//malicious.example/path', '/'],
+    ['/../secret', '/'],
+    ['/%2e%2e/secret', '/'],
+    ['/folder/..%2fsecret', '/'],
     ['not-a-path', '/'],
+    [String.raw`/\evil`, '/'],
+    ['/%2F%2Fmalicious.example', '/'],
+    ['/%5C%5Cevil', '/'],
+    ['/%0d%0aLocation:https://evil.example', '/'],
   ])(
     'getRoutes > redirects through login and returns to a safe location',
     async (requestedRedirect, expectedRedirect) => {

--- a/frontend/test/utils/loginUtils.spec.ts
+++ b/frontend/test/utils/loginUtils.spec.ts
@@ -1,0 +1,24 @@
+import { getLoginUrl } from 'utils/loginUtils'
+import { describe, expect, it } from 'vitest'
+
+describe('login utils', () => {
+  it('includes the current path, query string, and fragment in the login URL', () => {
+    const url = getLoginUrl({
+      pathname: '/model/example',
+      search: '?tab=files',
+      hash: '#content',
+    })
+
+    expect(url).toBe('/api/login?redirect=%2Fmodel%2Fexample%3Ftab%3Dfiles%23content')
+  })
+
+  it('uses the home page when it is the current location', () => {
+    const url = getLoginUrl({
+      pathname: '/',
+      search: '',
+      hash: '',
+    })
+
+    expect(url).toBe('/api/login?redirect=%2F')
+  })
+})

--- a/frontend/utils/loginUtils.ts
+++ b/frontend/utils/loginUtils.ts
@@ -1,3 +1,10 @@
+type LoginLocation = Pick<Location, 'pathname' | 'search' | 'hash'>
+
+export const getLoginUrl = (location: LoginLocation) => {
+  const redirect = `${location.pathname}${location.search}${location.hash}`
+  return `/api/login?redirect=${encodeURIComponent(redirect)}`
+}
+
 export const redirectToLoginPage = () => {
-  window.location.href = '/api/login'
+  window.location.href = getLoginUrl(window.location)
 }


### PR DESCRIPTION
Ensure path safety with tests. Route users to api/login/callback

Callback redirect is redundant in our config.