### PR TITLE
Prevent docker and user ownership errors on build

### DIFF
--- a/compose.override.yaml
+++ b/compose.override.yaml
@@ -13,6 +13,7 @@ services:
     volumes:
       - ./frontend:/app
       - /app/node_modules/@next # use container-built @next SWC binaries (musl), not the host's (e.g. glibc)
+      - /app/.next # prevent `uncaughtException [Error: EACCES: permission denied, open '.../Bailo/frontend/.next/...']` on `npm run build`
     build:
       target: dev
 

--- a/frontend/.dockerignore
+++ b/frontend/.dockerignore
@@ -25,6 +25,7 @@ node_modules/
 # Next.js build output
 .next
 out
+next-env.d.ts
 
 # cache
 cache

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -22,5 +22,5 @@
     "noImplicitAny": false
   },
   "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", "vitest.config.mts", "**/*.mdx"],
-  "exclude": ["node_modules"]
+  "exclude": ["node_modules", "public/docs-search-index.generated.json"]
 }


### PR DESCRIPTION
Prevents various build permission issues from `npm run build` in `frontend` for build artefacts that docker may generate (and are therefore often owned by root user).