### PR TITLE
De-duplicate frontend components

### DIFF
--- a/frontend/src/common/DisplayDialog.tsx
+++ b/frontend/src/common/DisplayDialog.tsx
@@ -1,0 +1,37 @@
+import Button from '@mui/material/Button'
+import Dialog from '@mui/material/Dialog'
+import DialogActions from '@mui/material/DialogActions'
+import DialogContent from '@mui/material/DialogContent'
+import DialogTitle from '@mui/material/DialogTitle'
+import { ReactNode } from 'react'
+import { Transition } from 'src/common/Transition'
+
+type DisplayDialogProps = {
+  open: boolean
+  onClose: () => void
+  title: string
+  children: ReactNode
+  maxWidth?: 'xs' | 'sm' | 'md' | 'lg' | 'xl'
+  titleColor?: string
+}
+
+export default function DisplayDialog({
+  open,
+  onClose,
+  title,
+  children,
+  maxWidth = 'sm',
+  titleColor,
+}: DisplayDialogProps) {
+  return (
+    <Dialog fullWidth open={open} onClose={onClose} maxWidth={maxWidth} slots={{ transition: Transition }}>
+      <DialogTitle color={titleColor}>{title}</DialogTitle>
+      <DialogContent>{children}</DialogContent>
+      <DialogActions>
+        <Button variant='contained' onClick={onClose}>
+          Close
+        </Button>
+      </DialogActions>
+    </Dialog>
+  )
+}

--- a/frontend/src/common/ExportPreviewDialog.tsx
+++ b/frontend/src/common/ExportPreviewDialog.tsx
@@ -1,0 +1,67 @@
+import { Button, Dialog, DialogActions, DialogContent, Divider, Stack, Typography } from '@mui/material'
+import { useTheme } from '@mui/material/styles'
+import Image from 'next/image'
+import logo from 'public/horizontal-dark.png'
+import { ReactNode, useRef } from 'react'
+import { useReactToPrint } from 'react-to-print'
+import { Transition } from 'src/common/Transition'
+
+type ExportPreviewDialogProps = {
+  open: boolean
+  setOpen: (isOpen: boolean) => void
+  documentTitle: string
+  children: ReactNode
+  maxWidth?: 'md' | 'lg'
+  titleColor?: string
+}
+
+export default function ExportPreviewDialog({
+  open,
+  setOpen,
+  documentTitle,
+  children,
+  maxWidth = 'md',
+  titleColor,
+}: ExportPreviewDialogProps) {
+  const theme = useTheme()
+  const contentRef = useRef<HTMLDivElement>(null)
+  const handlePrint = useReactToPrint({
+    contentRef,
+    documentTitle: documentTitle.replace(' ', '_'),
+  })
+
+  const handleExportOnClick = () => {
+    if (contentRef) {
+      handlePrint()
+    }
+  }
+
+  return (
+    <Dialog open={open} onClose={() => setOpen(false)} fullWidth maxWidth={maxWidth} slots={{ transition: Transition }}>
+      <DialogContent ref={contentRef}>
+        <Stack spacing={2} divider={<Divider />}>
+          <Stack direction='row' sx={{ alignItems: 'center' }}>
+            <Image src={logo} alt='bailo logo' width={180} height={70} />
+            <Typography
+              variant='h4'
+              component='h1'
+              color={titleColor ?? theme.palette.secondary.main}
+              sx={{ fontWeight: 'bold', pl: 1 }}
+            >
+              {documentTitle}
+            </Typography>
+          </Stack>
+          {children}
+        </Stack>
+      </DialogContent>
+      <DialogActions>
+        <Button color='secondary' variant='outlined' onClick={() => setOpen(false)}>
+          Close
+        </Button>
+        <Button color='secondary' variant='contained' onClick={handleExportOnClick}>
+          Export
+        </Button>
+      </DialogActions>
+    </Dialog>
+  )
+}

--- a/frontend/src/common/renderQueryState.tsx
+++ b/frontend/src/common/renderQueryState.tsx
@@ -1,0 +1,16 @@
+import { ReactElement } from 'react'
+import Loading from 'src/common/Loading'
+import MessageAlert from 'src/MessageAlert'
+import { ErrorInfo } from 'utils/fetcher'
+
+export default function renderQueryState(errors: (ErrorInfo | undefined)[], isLoading: boolean): ReactElement | null {
+  for (const error of errors) {
+    if (error) {
+      return <MessageAlert message={error.info.message} severity='error' />
+    }
+  }
+  if (isLoading) {
+    return <Loading />
+  }
+  return null
+}

--- a/frontend/src/entry/model/AccessRequests.tsx
+++ b/frontend/src/entry/model/AccessRequests.tsx
@@ -2,11 +2,10 @@ import Create from '@mui/icons-material/Create'
 import { Box, Button, Container, Stack } from '@mui/material'
 import { useGetAccessRequestsForModelId } from 'actions/accessRequest'
 import { memoize } from 'lodash-es'
-import Loading from 'src/common/Loading'
 import Paginate from 'src/common/Paginate'
+import renderQueryState from 'src/common/renderQueryState'
 import AccessRequestDisplay from 'src/entry/model/accessRequests/AccessRequestDisplay'
 import Link from 'src/Link'
-import MessageAlert from 'src/MessageAlert'
 import { EntryInterface } from 'types/types'
 
 type AccessRequestsProps = {
@@ -20,12 +19,9 @@ export default function AccessRequests({ model }: AccessRequestsProps) {
     <AccessRequestDisplay accessRequest={data} key={data.metadata.overview.name} />
   ))
 
-  if (isAccessRequestsLoading) {
-    return <Loading />
-  }
-
-  if (isAccessRequestsError) {
-    return <MessageAlert message={isAccessRequestsError.info.message} severity='error' />
+  const queryState = renderQueryState([isAccessRequestsError], isAccessRequestsLoading)
+  if (queryState) {
+    return queryState
   }
 
   return (

--- a/frontend/src/entry/model/InferenceServices.tsx
+++ b/frontend/src/entry/model/InferenceServices.tsx
@@ -5,6 +5,7 @@ import { useRouter } from 'next/router'
 import { useContext, useEffect, useMemo, useState } from 'react'
 import EmptyBlob from 'src/common/EmptyBlob'
 import Loading from 'src/common/Loading'
+import renderQueryState from 'src/common/renderQueryState'
 import Restricted from 'src/common/Restricted'
 import UiConfigContext from 'src/contexts/uiConfigContext'
 import InferenceDisplay from 'src/entry/model/inferencing/InferenceDisplay'
@@ -94,16 +95,9 @@ export default function InferenceServices({ model }: InferenceProps) {
     router.push(`/model/${model.id}/inference/new`)
   }
 
-  if (isInferencesError) {
-    return <MessageAlert message={isInferencesError.info.message} severity='error' />
-  }
-
-  if (isTokensError) {
-    return <MessageAlert message={isTokensError.info.message} severity='error' />
-  }
-
-  if (isTokensLoading) {
-    return <Loading />
+  const queryState = renderQueryState([isInferencesError, isTokensError], isTokensLoading)
+  if (queryState) {
+    return queryState
   }
 
   return (

--- a/frontend/src/entry/model/ModelFileManagement.tsx
+++ b/frontend/src/entry/model/ModelFileManagement.tsx
@@ -3,13 +3,12 @@ import { Box, Button, Chip, Container, Stack, Typography } from '@mui/material'
 import { useGetModelFiles } from 'actions/entry'
 import { useGetReleasesForModelId } from 'actions/release'
 import { useContext, useState } from 'react'
-import Loading from 'src/common/Loading'
 import Paginate from 'src/common/Paginate'
+import renderQueryState from 'src/common/renderQueryState'
 import Restricted from 'src/common/Restricted'
 import ArtefactScanningInfoContext from 'src/contexts/artefactScanningInfoContext'
 import FileDisplay from 'src/entry/model/files/FileDisplay'
 import FileUploadDialog from 'src/entry/model/files/FileUploadDialog'
-import MessageAlert from 'src/MessageAlert'
 import { EntryInterface, EntryKind } from 'types/types'
 
 type FilesProps = {
@@ -43,16 +42,9 @@ export default function Files({ model }: FilesProps) {
     </Box>
   )
 
-  if (isModelFilesError) {
-    return <MessageAlert message={isModelFilesError.info.message} severity='error' />
-  }
-
-  if (isModelFilesLoading || isReleasesLoading) {
-    return <Loading />
-  }
-
-  if (isReleasesError) {
-    return <MessageAlert message={isReleasesError.info.message} severity='error' />
+  const queryState = renderQueryState([isModelFilesError, isReleasesError], isModelFilesLoading || isReleasesLoading)
+  if (queryState) {
+    return queryState
   }
   return (
     <>

--- a/frontend/src/entry/model/Releases.tsx
+++ b/frontend/src/entry/model/Releases.tsx
@@ -4,11 +4,10 @@ import { useGetReleasesForModelId } from 'actions/release'
 import { memoize } from 'lodash-es'
 import { useRouter } from 'next/router'
 import semver from 'semver'
-import Loading from 'src/common/Loading'
 import Paginate from 'src/common/Paginate'
+import renderQueryState from 'src/common/renderQueryState'
 import Restricted from 'src/common/Restricted'
 import ReleaseDisplay from 'src/entry/model/releases/ReleaseDisplay'
-import MessageAlert from 'src/MessageAlert'
 import { EntryInterface } from 'types/types'
 
 type ReleasesProps = {
@@ -37,12 +36,9 @@ export default function Releases({ model, readOnly = false }: ReleasesProps) {
     router.push(`/model/${model.id}/release/new`)
   }
 
-  if (isReleasesLoading) {
-    return <Loading />
-  }
-
-  if (isReleasesError) {
-    return <MessageAlert message={isReleasesError.info.message} severity='error' />
+  const queryState = renderQueryState([isReleasesError], isReleasesLoading)
+  if (queryState) {
+    return queryState
   }
 
   return (

--- a/frontend/src/entry/model/files/FileUploadDialog.tsx
+++ b/frontend/src/entry/model/files/FileUploadDialog.tsx
@@ -6,6 +6,7 @@ import { AxiosProgressEvent } from 'axios'
 import { ChangeEvent, useCallback, useContext, useMemo, useState } from 'react'
 import EmptyBlob from 'src/common/EmptyBlob'
 import FileUploadProgressDisplay, { FailedFileUpload, FileUploadProgress } from 'src/common/FileUploadProgressDisplay'
+import { Transition } from 'src/common/Transition'
 import UiConfigContext from 'src/contexts/uiConfigContext'
 import FileToBeUploaded from 'src/entry/model/files/FileToBeUploaded'
 import MessageAlert from 'src/MessageAlert'
@@ -151,7 +152,7 @@ export default function FileUploadDialog({ open, onDialogClose, model, mutateMod
   )
 
   return (
-    <Dialog open={open} onClose={onDialogClose} maxWidth='md' fullWidth>
+    <Dialog open={open} onClose={onDialogClose} maxWidth='md' fullWidth slots={{ transition: Transition }}>
       <DialogContent>
         <Stack spacing={2}>
           <label htmlFor='add-files-button' style={{ width: '100%', display: 'flex', justifyContent: 'center' }}>

--- a/frontend/src/entry/model/mirroredModels/ReleaseSelector.tsx
+++ b/frontend/src/entry/model/mirroredModels/ReleaseSelector.tsx
@@ -20,13 +20,12 @@ import { useGetReleasesForModelId } from 'actions/release'
 import { memoize } from 'lodash-es'
 import { useCallback, useMemo, useState } from 'react'
 import HelpDialog from 'src/common/HelpDialog'
-import Loading from 'src/common/Loading'
 import MirrorInfo from 'src/common/MirrorInfo'
 import Paginate from 'src/common/Paginate'
+import renderQueryState from 'src/common/renderQueryState'
 import ReleaseAssetsAccordion from 'src/entry/model/releases/ReleaseAssetsAccordion'
 import ReleaseAssetsMainText from 'src/entry/model/releases/ReleaseAssetsMainText'
 import ReleaseAccessRequestReviewSummary from 'src/entry/model/reviews/ReleaseAccessRequestReviewSummary'
-import MessageAlert from 'src/MessageAlert'
 import { EntryInterface, ReleaseInterface } from 'types/types'
 
 type ReleaseSelectorProps = {
@@ -139,12 +138,9 @@ export default function ReleaseSelector({
     )
   })
 
-  if (isReleasesError) {
-    return <MessageAlert message={isReleasesError.info.message} severity='error' />
-  }
-
-  if (isReleasesLoading) {
-    return <Loading />
+  const queryState = renderQueryState([isReleasesError], isReleasesLoading)
+  if (queryState) {
+    return queryState
   }
 
   return (

--- a/frontend/src/entry/model/releases/AssociatedReleasesDialog.tsx
+++ b/frontend/src/entry/model/releases/AssociatedReleasesDialog.tsx
@@ -1,5 +1,4 @@
-import { Button, Dialog, DialogActions, DialogContent, DialogTitle } from '@mui/material'
-import { Transition } from 'src/common/Transition'
+import DisplayDialog from 'src/common/DisplayDialog'
 import AssociatedReleasesList from 'src/entry/model/releases/AssociatedReleasesList'
 import { ReleaseInterface } from 'types/types'
 
@@ -19,16 +18,8 @@ export default function AssociatedReleasesDialog({
   onClose,
 }: AssociatedReleasesDialogProps) {
   return (
-    <Dialog fullWidth open={open} onClose={onClose} maxWidth='sm' slots={{ transition: Transition }}>
-      <DialogTitle>Associated Releases</DialogTitle>
-      <DialogContent>
-        <AssociatedReleasesList modelId={modelId} latestRelease={latestRelease} releases={sortedAssociatedReleases} />
-      </DialogContent>
-      <DialogActions>
-        <Button variant='contained' onClick={onClose}>
-          Close
-        </Button>
-      </DialogActions>
-    </Dialog>
+    <DisplayDialog open={open} onClose={onClose} title='Associated Releases'>
+      <AssociatedReleasesList modelId={modelId} latestRelease={latestRelease} releases={sortedAssociatedReleases} />
+    </DisplayDialog>
   )
 }

--- a/frontend/src/entry/model/releases/ExistingFileSelector.tsx
+++ b/frontend/src/entry/model/releases/ExistingFileSelector.tsx
@@ -17,9 +17,8 @@ import { useGetFilesForModel } from 'actions/file'
 import { memoize } from 'lodash-es'
 import prettyBytes from 'pretty-bytes'
 import { useCallback, useState } from 'react'
-import Loading from 'src/common/Loading'
 import Paginate from 'src/common/Paginate'
-import MessageAlert from 'src/MessageAlert'
+import renderQueryState from 'src/common/renderQueryState'
 import { EntryInterface, FileInterface, isFileInterface } from 'types/types'
 import { formatDateString } from 'utils/dateUtils'
 
@@ -121,12 +120,9 @@ export default function ExistingFileSelector({ model, existingReleaseFiles, onCh
     </ListItem>
   ))
 
-  if (isFilesError) {
-    return <MessageAlert message={isFilesError.info.message} severity='error' />
-  }
-
-  if (isFilesLoading) {
-    return <Loading />
+  const queryState = renderQueryState([isFilesError], isFilesLoading)
+  if (queryState) {
+    return queryState
   }
 
   return (

--- a/frontend/src/entry/model/releases/ReleaseDisplay.tsx
+++ b/frontend/src/entry/model/releases/ReleaseDisplay.tsx
@@ -1,11 +1,10 @@
 import { Box, Divider, Stack } from '@mui/material'
 import { useGetReleasesForModelId } from 'actions/release'
-import Loading from 'src/common/Loading'
+import renderQueryState from 'src/common/renderQueryState'
 import ReleaseAssetsAccordion from 'src/entry/model/releases/ReleaseAssetsAccordion'
 import ReleaseAssetsMainText from 'src/entry/model/releases/ReleaseAssetsMainText'
 import ReleaseAccessRequestReviewSummary from 'src/entry/model/reviews/ReleaseAccessRequestReviewSummary'
 import ReviewBanner from 'src/entry/model/reviews/ReviewBanner'
-import MessageAlert from 'src/MessageAlert'
 import { EntryInterface, ReleaseInterface } from 'types/types'
 
 export interface ReleaseDisplayProps {
@@ -18,12 +17,9 @@ export interface ReleaseDisplayProps {
 export default function ReleaseDisplay({ model, release, latestRelease, hideFileDownloads }: ReleaseDisplayProps) {
   const { isReleasesLoading, isReleasesError } = useGetReleasesForModelId(model.id)
 
-  if (isReleasesError) {
-    return <MessageAlert message={isReleasesError.info.message} severity='error' />
-  }
-
-  if (isReleasesLoading) {
-    return <Loading />
+  const queryState = renderQueryState([isReleasesError], isReleasesLoading)
+  if (queryState) {
+    return queryState
   }
 
   return (

--- a/frontend/src/entry/model/reviews/ReviewBanner.tsx
+++ b/frontend/src/entry/model/reviews/ReviewBanner.tsx
@@ -6,8 +6,7 @@ import { useTheme } from '@mui/material/styles'
 import { useHeadReviewRequestsForModel } from 'actions/review'
 import { useRouter } from 'next/router'
 import { useMemo } from 'react'
-import Loading from 'src/common/Loading'
-import MessageAlert from 'src/MessageAlert'
+import renderQueryState from 'src/common/renderQueryState'
 import { AccessRequestInterface, ReleaseInterface } from 'types/types'
 
 export type ReviewBannerProps =
@@ -41,12 +40,9 @@ export default function ReviewBanner({ release, accessRequest }: ReviewBannerPro
     router.push(`/model/${modelId}/${urlParam}/${semverOrAccessRequestId}/review`)
   }
 
-  if (isReviewsLoading) {
-    return <Loading />
-  }
-
-  if (isReviewsError) {
-    return <MessageAlert message={isReviewsError.info.message} severity='error' />
+  const queryState = renderQueryState([isReviewsError], isReviewsLoading)
+  if (queryState) {
+    return queryState
   }
 
   return (

--- a/frontend/src/entry/model/reviews/ReviewStatus.tsx
+++ b/frontend/src/entry/model/reviews/ReviewStatus.tsx
@@ -2,7 +2,7 @@ import Done from '@mui/icons-material/Done'
 import { Stack, Typography } from '@mui/material'
 import { useGetEntryRoles } from 'actions/entry'
 import { useContext, useMemo, useState } from 'react'
-import Loading from 'src/common/Loading'
+import renderQueryState from 'src/common/renderQueryState'
 import UiConfigContext from 'src/contexts/uiConfigContext'
 import { ChangesRequestedDisplay } from 'src/entry/model/reviews/ChangesRequestedDisplay'
 import MessageAlert from 'src/MessageAlert'
@@ -31,12 +31,9 @@ export default function ReviewStatus({ review, modelId, showCurrentUserResponses
     return dynamicRoles.find((role) => role.shortName === review.role)?.name
   }
 
-  if (isEntryRolesLoading) {
-    return <Loading />
-  }
-
-  if (isEntryRolesError) {
-    return <MessageAlert message={isEntryRolesError.info.message} severity='error' />
+  const queryState = renderQueryState([isEntryRolesError], isEntryRolesLoading)
+  if (queryState) {
+    return queryState
   }
 
   return (

--- a/frontend/src/entry/overview/EntryRoleList.tsx
+++ b/frontend/src/entry/overview/EntryRoleList.tsx
@@ -1,10 +1,9 @@
 import { Grid, Stack } from '@mui/material'
 import { useGetEntryRoles } from 'actions/entry'
 import { Fragment, useMemo } from 'react'
-import Loading from 'src/common/Loading'
+import renderQueryState from 'src/common/renderQueryState'
 import EntityNameDisplay from 'src/entry/EntityNameDisplay'
 import EntryRolesChipSet from 'src/entry/overview/EntryRolesChipSet'
-import MessageAlert from 'src/MessageAlert'
 import { EntryInterface } from 'types/types'
 
 type EntryRoleListProps = {
@@ -36,12 +35,9 @@ export default function EntryRoleList({ entry }: EntryRoleListProps) {
     [entry.collaborators, entryRoles],
   )
 
-  if (isEntryRolesLoading) {
-    return <Loading />
-  }
-
-  if (isEntryRolesError) {
-    return <MessageAlert message={isEntryRolesError.info.message} severity='error' />
+  const queryState = renderQueryState([isEntryRolesError], isEntryRolesLoading)
+  if (queryState) {
+    return queryState
   }
 
   return (

--- a/frontend/src/entry/overview/ExportEntryCardDialog.tsx
+++ b/frontend/src/entry/overview/ExportEntryCardDialog.tsx
@@ -1,13 +1,7 @@
-import { Button, DialogActions, DialogContent, Divider, Stack, Typography } from '@mui/material'
-import Dialog from '@mui/material/Dialog'
-import { useTheme } from '@mui/material/styles'
 import { Form } from '@rjsf/mui'
 import validator from '@rjsf/validator-ajv8'
-import Image from 'next/image'
-import logo from 'public/horizontal-dark.png'
-import { useMemo, useRef } from 'react'
-import { useReactToPrint } from 'react-to-print'
-import { Transition } from 'src/common/Transition'
+import { useMemo } from 'react'
+import ExportPreviewDialog from 'src/common/ExportPreviewDialog'
 import { ArrayFieldTemplate, DescriptionFieldTemplate, ObjectFieldTemplate } from 'src/Form/FormTemplates'
 import { EntryInterface, SplitSchemaNoRender } from 'types/types'
 import { widgets } from 'utils/formUtils'
@@ -20,19 +14,6 @@ type ExportEntryCardDialogProps = {
 }
 
 export default function ExportEntryCardDialog({ entry, splitSchema, open, setOpen }: ExportEntryCardDialogProps) {
-  const theme = useTheme()
-  const modelCardContentRef = useRef<HTMLDivElement>(null)
-  const exportModelCard = useReactToPrint({
-    contentRef: modelCardContentRef,
-    documentTitle: entry.name.replace(' ', '_'),
-  })
-
-  const handleExportOnClick = () => {
-    if (modelCardContentRef) {
-      exportModelCard()
-    }
-  }
-
   const steps = useMemo(() => {
     return splitSchema.steps.map((currentStep) => (
       <Form
@@ -60,34 +41,8 @@ export default function ExportEntryCardDialog({ entry, splitSchema, open, setOpe
   }, [splitSchema.steps])
 
   return (
-    <Dialog open={open} onClose={() => setOpen(false)} fullWidth maxWidth='md' slots={{ transition: Transition }}>
-      <DialogContent ref={modelCardContentRef}>
-        <Stack spacing={2} divider={<Divider />}>
-          <Stack direction='row' sx={{ alignItems: 'center' }}>
-            <Image src={logo} alt='bailo logo' width={180} height={70} />
-            <Typography
-              variant='h4'
-              component='h1'
-              color={theme.palette.secondary.main}
-              sx={{
-                fontWeight: 'bold',
-                pl: 1,
-              }}
-            >
-              {entry.name}
-            </Typography>
-          </Stack>
-          {steps}
-        </Stack>
-      </DialogContent>
-      <DialogActions>
-        <Button color='secondary' variant='outlined' onClick={() => setOpen(false)}>
-          Close
-        </Button>
-        <Button color='secondary' variant='contained' onClick={handleExportOnClick}>
-          Export
-        </Button>
-      </DialogActions>
-    </Dialog>
+    <ExportPreviewDialog open={open} setOpen={setOpen} documentTitle={entry.name}>
+      {steps}
+    </ExportPreviewDialog>
   )
 }

--- a/frontend/src/entry/overview/FormEditPage.tsx
+++ b/frontend/src/entry/overview/FormEditPage.tsx
@@ -28,7 +28,7 @@ import { useGetUiConfig } from 'actions/uiConfig'
 import * as _ from 'lodash-es'
 import { useRouter } from 'next/router'
 import React, { ChangeEvent, useContext, useEffect, useEffectEvent, useMemo, useState } from 'react'
-import Loading from 'src/common/Loading'
+import renderQueryState from 'src/common/renderQueryState'
 import Restricted from 'src/common/Restricted'
 import TextInputDialog from 'src/common/TextInputDialog'
 import UnsavedChangesContext from 'src/contexts/unsavedChangesContext'
@@ -276,16 +276,12 @@ export default function FormEditPage({ entry, mutateEntry }: FormEditPageProps) 
     })
   }
 
-  if (isSchemaError) {
-    return <MessageAlert message={isSchemaError.info.message} severity='error' />
-  }
-
-  if (isSchemaMigrationsError) {
-    return <MessageAlert message={isSchemaMigrationsError.info.message} severity='error' />
-  }
-
-  if (isSchemaMigrationsLoading || isSchemaLoading) {
-    return <Loading />
+  const queryState = renderQueryState(
+    [isSchemaError, isSchemaMigrationsError],
+    isSchemaMigrationsLoading || isSchemaLoading,
+  )
+  if (queryState) {
+    return queryState
   }
 
   return (

--- a/frontend/src/entry/overview/ImportModelCardTextDialog.tsx
+++ b/frontend/src/entry/overview/ImportModelCardTextDialog.tsx
@@ -3,6 +3,7 @@ import { Alert, Button, Dialog, DialogActions, DialogContent, DialogTitle, TextF
 import { postImportModelCardText } from 'actions/modelCard'
 import { useState } from 'react'
 import { Transition } from 'src/common/Transition'
+import MessageAlert from 'src/MessageAlert'
 import { getErrorMessage } from 'utils/fetcher'
 
 interface ImportModelCardTextDialogProps {
@@ -78,11 +79,7 @@ export default function ImportModelCardTextDialog({
             '& .MuiInputBase-input': { height: '100% !important', overflow: 'auto !important' },
           }}
         />
-        {errorMessage && (
-          <Alert severity='error' sx={{ mt: 2 }}>
-            {errorMessage}
-          </Alert>
-        )}
+        <MessageAlert message={errorMessage} severity='error' />
       </DialogContent>
       <DialogActions sx={{ pr: 2, pt: 0 }}>
         <Button variant='outlined' onClick={handleClose} disabled={loading}>

--- a/frontend/src/entry/overview/ReviewHistoryDialog.tsx
+++ b/frontend/src/entry/overview/ReviewHistoryDialog.tsx
@@ -1,9 +1,8 @@
-import { Box, Button, DialogActions, DialogContent, DialogTitle } from '@mui/material'
-import Dialog from '@mui/material/Dialog'
-import { useCallback } from 'react'
-import { Transition } from 'src/common/Transition'
+import { Box } from '@mui/material'
+import DisplayDialog from 'src/common/DisplayDialog'
 import ReviewComments from 'src/reviews/ReviewComments'
 import { EntryInterface, ReviewKind } from 'types/types'
+
 type ReviewHistoryDialogProps = {
   open: boolean
   onClose: () => void
@@ -12,28 +11,24 @@ type ReviewHistoryDialogProps = {
 }
 
 export default function ReviewHistoryDialog({ entry, mutateEntry, open, onClose }: ReviewHistoryDialogProps) {
-  const handleOnClose = useCallback(() => {
-    onClose()
-  }, [onClose])
-
   return (
-    <Dialog open={open} onClose={onClose} fullWidth slotProps={{ transition: Transition }} maxWidth='md'>
-      <DialogTitle color='primary'>Lifecycle review history for {entry.name}</DialogTitle>
-      <DialogContent>
-        <Box sx={{ mx: 'auto' }}>
-          <ReviewComments
-            parentId={entry['_id']}
-            entryId={entry.id}
-            kind={ReviewKind.LIFECYCLE}
-            isEdit={false}
-            mutator={mutateEntry}
-            showComments={false}
-          />
-        </Box>
-      </DialogContent>
-      <DialogActions>
-        <Button onClick={() => handleOnClose()}>Close</Button>
-      </DialogActions>
-    </Dialog>
+    <DisplayDialog
+      open={open}
+      onClose={onClose}
+      title={`Lifecycle review history for ${entry.name}`}
+      titleColor='primary'
+      maxWidth='md'
+    >
+      <Box sx={{ mx: 'auto' }}>
+        <ReviewComments
+          parentId={entry['_id']}
+          entryId={entry.id}
+          kind={ReviewKind.LIFECYCLE}
+          isEdit={false}
+          mutator={mutateEntry}
+          showComments={false}
+        />
+      </Box>
+    </DisplayDialog>
   )
 }

--- a/frontend/src/metrics/EntryMetrics.tsx
+++ b/frontend/src/metrics/EntryMetrics.tsx
@@ -4,7 +4,7 @@ import { useGetModelBreakdown, useGetOverviewMetrics } from 'actions/metrics'
 import { useGetSchemas } from 'actions/schema'
 import { useCallback, useMemo } from 'react'
 import { FilterMenuButton } from 'src/common/FilterMenuButton'
-import Loading from 'src/common/Loading'
+import renderQueryState from 'src/common/renderQueryState'
 import { useEntriesFilters } from 'src/hooks/useEntriesFilters'
 import MessageAlert from 'src/MessageAlert'
 import { MetricsBreakdownTable } from 'src/metrics/components/MetricsBreakdownTable'
@@ -103,16 +103,12 @@ export default function EntryMetrics() {
     })
   }, [setFilters])
 
-  if (isOverviewMetricsError) {
-    return <MessageAlert message={isOverviewMetricsError.info.message} />
-  }
-
-  if (isSchemasError) {
-    return <MessageAlert message={isSchemasError.info.message} />
-  }
-
-  if (isOverviewMetricsLoading || isSchemasLoading) {
-    return <Loading />
+  const queryState = renderQueryState(
+    [isOverviewMetricsError, isSchemasError],
+    isOverviewMetricsLoading || isSchemasLoading,
+  )
+  if (queryState) {
+    return queryState
   }
 
   const isClearDisabled =

--- a/frontend/src/metrics/MetricsExportPreview.tsx
+++ b/frontend/src/metrics/MetricsExportPreview.tsx
@@ -1,9 +1,6 @@
-import { Button, Container, Dialog, DialogActions, DialogContent, Divider, Stack, Typography } from '@mui/material'
-import Image from 'next/image'
-import logo from 'public/horizontal-dark.png'
-import { ReactElement, useRef } from 'react'
-import { useReactToPrint } from 'react-to-print'
-import { Transition } from 'src/common/Transition'
+import { Container } from '@mui/material'
+import { ReactElement } from 'react'
+import ExportPreviewDialog from 'src/common/ExportPreviewDialog'
 
 interface MetricsExportPreviewProps {
   open: boolean
@@ -18,40 +15,15 @@ export default function MetricsExportPreview({
   content,
   exportDocumentTitle,
 }: MetricsExportPreviewProps) {
-  const contentRef = useRef<HTMLDivElement>(null)
-
-  const exportMetricsOverview = useReactToPrint({
-    contentRef: contentRef,
-    documentTitle: exportDocumentTitle,
-  })
-
-  const handleExportOnClick = () => {
-    if (contentRef) {
-      exportMetricsOverview()
-    }
-  }
-
   return (
-    <Dialog open={open} onClose={() => setOpen(false)} fullWidth maxWidth='lg' slots={{ transition: Transition }}>
-      <DialogContent ref={contentRef}>
-        <Stack spacing={2} divider={<Divider />}>
-          <Stack direction='row' sx={{ alignItems: 'center' }}>
-            <Image src={logo} alt='bailo logo' width={180} height={70} />
-            <Typography variant='h4' component='h1' sx={{ pl: 1, fontWeight: 'bold' }} color='primary'>
-              {exportDocumentTitle}
-            </Typography>
-          </Stack>
-          <Container>{content}</Container>
-        </Stack>
-      </DialogContent>
-      <DialogActions>
-        <Button color='secondary' variant='outlined' onClick={() => setOpen(false)}>
-          Close
-        </Button>
-        <Button color='secondary' variant='contained' onClick={handleExportOnClick}>
-          Export
-        </Button>
-      </DialogActions>
-    </Dialog>
+    <ExportPreviewDialog
+      open={open}
+      setOpen={setOpen}
+      documentTitle={exportDocumentTitle}
+      maxWidth='lg'
+      titleColor='primary'
+    >
+      <Container>{content}</Container>
+    </ExportPreviewDialog>
   )
 }

--- a/frontend/src/metrics/OverviewMetrics.tsx
+++ b/frontend/src/metrics/OverviewMetrics.tsx
@@ -3,8 +3,7 @@ import { useGetOverviewMetrics } from 'actions/metrics'
 import { useGetSchemas } from 'actions/schema'
 import { useRouter } from 'next/router'
 import { useCallback, useMemo, useState } from 'react'
-import Loading from 'src/common/Loading'
-import MessageAlert from 'src/MessageAlert'
+import renderQueryState from 'src/common/renderQueryState'
 import MetricsHeader from 'src/metrics/components/MetricsHeader'
 import OverviewMetricsCharts from 'src/metrics/OverviewMetricsCharts'
 import { BreakdownQueryType, buildEntriesHref, buildEntriesTabHref, filterSelectTypes } from 'utils/metricsUtils'
@@ -51,12 +50,9 @@ export default function OverviewMetrics() {
     setSelectedOrganisation(newOrganisation)
   }, [])
 
-  if (isOverviewMetricsError) {
-    return <MessageAlert message={isOverviewMetricsError.info.message} />
-  }
-
-  if (isOverviewMetricsLoading) {
-    return <Loading />
+  const queryState = renderQueryState([isOverviewMetricsError], isOverviewMetricsLoading)
+  if (queryState) {
+    return queryState
   }
 
   return (

--- a/frontend/src/metrics/PolicyMetrics.tsx
+++ b/frontend/src/metrics/PolicyMetrics.tsx
@@ -7,8 +7,7 @@ import {
   useLifecyclePolicyMetrics,
 } from 'actions/metrics'
 import { ReactElement, useCallback, useMemo, useState } from 'react'
-import Loading from 'src/common/Loading'
-import MessageAlert from 'src/MessageAlert'
+import renderQueryState from 'src/common/renderQueryState'
 import MetricsHeader from 'src/metrics/components/MetricsHeader'
 import PolicyLifecycleMetricsCharts from 'src/metrics/PolicyLifecycleMetricsCharts'
 import PolicyNoReleasesMetricsCharts from 'src/metrics/PolicyNoReleasesMetricsCharts'
@@ -118,33 +117,22 @@ export default function PolicyMetrics() {
     unapprovedReleasesPolicyMetrics,
   ])
 
-  if (isRolePolicyMetricsError) {
-    return <MessageAlert message={isRolePolicyMetricsError.info.message} />
-  }
-
-  if (isNoReleasesPolicyMetricsError) {
-    return <MessageAlert message={isNoReleasesPolicyMetricsError.info.message} />
-  }
-
-  if (isUnapprovedReleasesPolicyMetricsError) {
-    return <MessageAlert message={isUnapprovedReleasesPolicyMetricsError.info.message} />
-  }
-
-  if (isLifecyclePolicyMetricsError) {
-    return <MessageAlert message={isLifecyclePolicyMetricsError.info.message} />
-  }
-  if (isEntryRolesError) {
-    return <MessageAlert message={isEntryRolesError.info.message} />
-  }
-
-  if (
+  const queryState = renderQueryState(
+    [
+      isRolePolicyMetricsError,
+      isNoReleasesPolicyMetricsError,
+      isUnapprovedReleasesPolicyMetricsError,
+      isLifecyclePolicyMetricsError,
+      isEntryRolesError,
+    ],
     isRolePolicyMetricsLoading ||
-    isNoReleasesPolicyMetricsLoading ||
-    isUnapprovedReleasesPolicyMetricsLoading ||
-    isLifecyclePolicyMetricsLoading ||
-    isEntryRolesLoading
-  ) {
-    return <Loading />
+      isNoReleasesPolicyMetricsLoading ||
+      isUnapprovedReleasesPolicyMetricsLoading ||
+      isLifecyclePolicyMetricsLoading ||
+      isEntryRolesLoading,
+  )
+  if (queryState) {
+    return queryState
   }
 
   return (

--- a/frontend/src/reviewRoles/ReviewRoleFormContainer.tsx
+++ b/frontend/src/reviewRoles/ReviewRoleFormContainer.tsx
@@ -19,7 +19,7 @@ import { useGetEntryRoles } from 'actions/entry'
 import { UpdateReviewRolesParams } from 'actions/reviewRoles'
 import { ChangeEvent, ReactElement, useCallback, useMemo, useState } from 'react'
 import LabelledInput from 'src/common/LabelledInput'
-import Loading from 'src/common/Loading'
+import renderQueryState from 'src/common/renderQueryState'
 import EntryAccessInput from 'src/entry/settings/EntryAccessInput'
 import Link from 'src/Link'
 import MessageAlert from 'src/MessageAlert'
@@ -73,12 +73,9 @@ export default function ReviewRoleFormContainer<
     )
   }, [draftFormData.defaultEntities, handleCollaboratorsChange])
 
-  if (isEntryRolesError) {
-    return <MessageAlert message={isEntryRolesError.info.message} />
-  }
-
-  if (isEntryRolesLoading) {
-    return <Loading />
+  const queryState = renderQueryState([isEntryRolesError], isEntryRolesLoading)
+  if (queryState) {
+    return queryState
   }
 
   return (

--- a/frontend/src/reviews/ReviewItem.tsx
+++ b/frontend/src/reviews/ReviewItem.tsx
@@ -2,9 +2,8 @@ import { Box, ListItem, ListItemButton, Stack, Typography } from '@mui/material'
 import { useGetCurrentUser } from 'actions/user'
 import { useRouter } from 'next/router'
 import { useCallback, useMemo } from 'react'
-import Loading from 'src/common/Loading'
+import renderQueryState from 'src/common/renderQueryState'
 import ReviewStatus from 'src/entry/model/reviews/ReviewStatus'
-import MessageAlert from 'src/MessageAlert'
 import ReviewRoleDisplay from 'src/reviews/ReviewRoleDisplay'
 import { ReviewKind, ReviewListStatus, ReviewListStatusKeys, ReviewRequestInterface } from 'types/types'
 import { formatDateStringAsDayMonthAndYear, timeDifference } from 'utils/dateUtils'
@@ -84,12 +83,9 @@ export default function ReviewItem({ review, status }: ReviewItemProps) {
     }
   }, [currentUser, editedAdornment, isArchivedLifecycleReview, review])
 
-  if (isCurrentUserError) {
-    return <MessageAlert message={isCurrentUserError.info.message} severity='error' />
-  }
-
-  if (isCurrentUserLoading) {
-    return <Loading />
+  const queryState = renderQueryState([isCurrentUserError], isCurrentUserLoading)
+  if (queryState) {
+    return queryState
   }
 
   return (

--- a/frontend/src/schemas/InformationDialog.tsx
+++ b/frontend/src/schemas/InformationDialog.tsx
@@ -1,7 +1,7 @@
-import { Button, Dialog, DialogActions, DialogContent, DialogTitle, Divider, Stack, Typography } from '@mui/material'
+import { Divider, Stack, Typography } from '@mui/material'
 import { useTheme } from '@mui/material/styles'
+import DisplayDialog from 'src/common/DisplayDialog'
 import MarkdownDisplay from 'src/common/MarkdownDisplay'
-import { Transition } from 'src/common/Transition'
 import { SchemaInterface } from 'types/types'
 
 type SchemaDialogProps = {
@@ -14,54 +14,46 @@ export default function InformationDialog({ open = false, onClose, schema }: Sch
   const theme = useTheme()
 
   return (
-    <Dialog fullWidth open={open} onClose={onClose} maxWidth='sm' slots={{ transition: Transition }}>
-      <DialogTitle>Schema information</DialogTitle>
-      <DialogContent>
-        <Stack spacing={2} divider={<Divider flexItem />}>
-          <Stack spacing={1}>
-            <Stack
-              direction='row'
-              spacing={1}
+    <DisplayDialog open={open} onClose={onClose} title='Schema information'>
+      <Stack spacing={2} divider={<Divider flexItem />}>
+        <Stack spacing={1}>
+          <Stack
+            direction='row'
+            spacing={1}
+            sx={{
+              alignItems: 'center',
+            }}
+          >
+            <Typography
               sx={{
-                alignItems: 'center',
+                fontWeight: 'bold',
+                color: theme.palette.primary.main,
               }}
             >
-              <Typography
-                sx={{
-                  fontWeight: 'bold',
-                  color: theme.palette.primary.main,
-                }}
-              >
-                ID:
-              </Typography>
-              <Typography>{schema.id}</Typography>
-            </Stack>
-            <Stack
-              direction='row'
-              spacing={1}
-              sx={{
-                alignItems: 'center',
-              }}
-            >
-              <Typography
-                sx={{
-                  fontWeight: 'bold',
-                  color: theme.palette.primary.main,
-                }}
-              >
-                Name:
-              </Typography>
-              <Typography>{schema.name}</Typography>
-            </Stack>
-            <MarkdownDisplay>{schema.description}</MarkdownDisplay>
+              ID:
+            </Typography>
+            <Typography>{schema.id}</Typography>
           </Stack>
+          <Stack
+            direction='row'
+            spacing={1}
+            sx={{
+              alignItems: 'center',
+            }}
+          >
+            <Typography
+              sx={{
+                fontWeight: 'bold',
+                color: theme.palette.primary.main,
+              }}
+            >
+              Name:
+            </Typography>
+            <Typography>{schema.name}</Typography>
+          </Stack>
+          <MarkdownDisplay>{schema.description}</MarkdownDisplay>
         </Stack>
-      </DialogContent>
-      <DialogActions>
-        <Button variant='contained' onClick={onClose}>
-          Close
-        </Button>
-      </DialogActions>
-    </Dialog>
+      </Stack>
+    </DisplayDialog>
   )
 }

--- a/frontend/src/schemas/SchemaButton.tsx
+++ b/frontend/src/schemas/SchemaButton.tsx
@@ -13,9 +13,8 @@ import {
 } from '@mui/material'
 import { useGetReviewRoles } from 'actions/reviewRoles'
 import { useMemo } from 'react'
-import Loading from 'src/common/Loading'
 import MarkdownDisplay from 'src/common/MarkdownDisplay'
-import MessageAlert from 'src/MessageAlert'
+import renderQueryState from 'src/common/renderQueryState'
 import { SchemaInterface } from 'types/types'
 
 interface SchemaButtonProps {
@@ -50,12 +49,9 @@ export default function SchemaButton({ schema, onClick, loading = false }: Schem
     [reviewRoles, schema.reviewRoles],
   )
 
-  if (isReviewRolesLoading) {
-    return <Loading />
-  }
-
-  if (isReviewRolesError) {
-    return <MessageAlert message={isReviewRolesError.info.message} severity='error' />
+  const queryState = renderQueryState([isReviewRolesError], isReviewRolesLoading)
+  if (queryState) {
+    return queryState
   }
   return (
     <Grid size={{ md: 6, sm: 12 }}>

--- a/frontend/src/schemas/SchemaCompare.tsx
+++ b/frontend/src/schemas/SchemaCompare.tsx
@@ -5,8 +5,7 @@ import { useTheme } from '@mui/material/styles'
 import { useGetSchemas } from 'actions/schema'
 import { SyntheticEvent, useCallback, useMemo, useState } from 'react'
 import ReactDiffViewer, { DiffMethod } from 'react-diff-viewer-continued'
-import Loading from 'src/common/Loading'
-import MessageAlert from 'src/MessageAlert'
+import renderQueryState from 'src/common/renderQueryState'
 import { SchemaInterface } from 'types/types'
 
 export default function SchemaCompare() {
@@ -49,12 +48,9 @@ export default function SchemaCompare() {
     }
   }, [beforeSchema, afterSchema, theme])
 
-  if (isSchemasError) {
-    return <MessageAlert message={isSchemasError.info.message} severity='error' />
-  }
-
-  if (isSchemasLoading) {
-    return <Loading />
+  const queryState = renderQueryState([isSchemasError], isSchemasLoading)
+  if (queryState) {
+    return queryState
   }
 
   return (

--- a/frontend/src/schemas/SchemaList.tsx
+++ b/frontend/src/schemas/SchemaList.tsx
@@ -6,7 +6,7 @@ import { deleteSchema, patchSchema, useGetSchemas } from 'actions/schema'
 import { MouseEvent, useCallback, useMemo, useState } from 'react'
 import ConfirmationDialogue from 'src/common/ConfirmationDialogue'
 import EmptyBlob from 'src/common/EmptyBlob'
-import Loading from 'src/common/Loading'
+import renderQueryState from 'src/common/renderQueryState'
 import Link from 'src/Link'
 import MessageAlert from 'src/MessageAlert'
 import SchemaListItem from 'src/schemas/SchemaListItem'
@@ -160,20 +160,12 @@ export default function SchemaList({ schemaKind }: SchemaDisplayProps) {
     ))
   }, [theme.palette.primary.main, objectsToDelete])
 
-  if (isSchemasError) {
-    return <MessageAlert message={isSchemasError.info.message} severity='error' />
-  }
-
-  if (isEntriesError) {
-    return <MessageAlert message={isEntriesError.info.message} severity='error' />
-  }
-
-  if (isReviewsError) {
-    return <MessageAlert message={isReviewsError.info.message} severity='error' />
-  }
-
-  if (isReviewsLoading || isEntriesLoading || isSchemasLoading) {
-    return <Loading />
+  const queryState = renderQueryState(
+    [isSchemasError, isEntriesError, isReviewsError],
+    isReviewsLoading || isEntriesLoading || isSchemasLoading,
+  )
+  if (queryState) {
+    return queryState
   }
 
   return (

--- a/frontend/src/schemas/SchemaMigrationList.tsx
+++ b/frontend/src/schemas/SchemaMigrationList.tsx
@@ -4,10 +4,9 @@ import { useTheme } from '@mui/material/styles'
 import { useGetSchemaMigrations } from 'actions/schemaMigration'
 import { memoize } from 'lodash-es'
 import CopyToClipboardButton from 'src/common/CopyToClipboardButton'
-import Loading from 'src/common/Loading'
 import Paginate from 'src/common/Paginate'
+import renderQueryState from 'src/common/renderQueryState'
 import Link from 'src/Link'
-import MessageAlert from 'src/MessageAlert'
 import { formatDateString } from 'utils/dateUtils'
 
 export default function SchemaMigrationList() {
@@ -72,12 +71,9 @@ export default function SchemaMigrationList() {
     </Stack>
   ))
 
-  if (isSchemaMigrationsError) {
-    return <MessageAlert message={isSchemaMigrationsError.info.message} severity='error' />
-  }
-
-  if (isSchemaMigrationsLoading) {
-    return <Loading />
+  const queryState = renderQueryState([isSchemaMigrationsError], isSchemaMigrationsLoading)
+  if (queryState) {
+    return queryState
   }
   return (
     <Container sx={{ my: 2 }}>

--- a/frontend/src/schemas/UpdateReviewRolesForSchemaDialog.tsx
+++ b/frontend/src/schemas/UpdateReviewRolesForSchemaDialog.tsx
@@ -17,8 +17,7 @@ import { useGetReviewRoles } from 'actions/reviewRoles'
 import { patchSchema } from 'actions/schema'
 import { useCallback, useMemo, useState } from 'react'
 import ConfirmationDialogue from 'src/common/ConfirmationDialogue'
-import Loading from 'src/common/Loading'
-import MessageAlert from 'src/MessageAlert'
+import renderQueryState from 'src/common/renderQueryState'
 import { SchemaInterface } from 'types/types'
 import { getErrorMessage } from 'utils/fetcher'
 import { plural } from 'utils/stringUtils'
@@ -106,12 +105,9 @@ export default function UpdateReviewRolesForSchemaDialog({
     [reviewRoles, checked, handleToggle],
   )
 
-  if (isReviewRolesError) {
-    return <MessageAlert message={isReviewRolesError.info.message} severity='error' />
-  }
-
-  if (isReviewRolesLoading) {
-    return <Loading />
+  const queryState = renderQueryState([isReviewRolesError], isReviewRolesLoading)
+  if (queryState) {
+    return queryState
   }
 
   return (

--- a/frontend/src/schemas/UsageListDialog.tsx
+++ b/frontend/src/schemas/UsageListDialog.tsx
@@ -3,9 +3,8 @@ import { useGetUsageBySchema } from 'actions/schema'
 import { useMemo } from 'react'
 import DisplayDialog from 'src/common/DisplayDialog'
 import EmptyBlob from 'src/common/EmptyBlob'
-import Loading from 'src/common/Loading'
+import renderQueryState from 'src/common/renderQueryState'
 import Link from 'src/Link'
-import MessageAlert from 'src/MessageAlert'
 import { SchemaInterface } from 'types/types'
 import { camelCaseToTitleCase } from 'utils/stringUtils'
 
@@ -68,12 +67,9 @@ export default function UsageListDialog({ open = false, onClose, schema }: Schem
     [data, schema.kind],
   )
 
-  if (isDataError) {
-    return <MessageAlert message={isDataError.info.message} severity='error' />
-  }
-
-  if (isDataLoading) {
-    return <Loading />
+  const queryState = renderQueryState([isDataError], isDataLoading)
+  if (queryState) {
+    return queryState
   }
 
   return (

--- a/frontend/src/schemas/UsageListDialog.tsx
+++ b/frontend/src/schemas/UsageListDialog.tsx
@@ -1,20 +1,9 @@
-import {
-  Button,
-  Dialog,
-  DialogActions,
-  DialogContent,
-  DialogTitle,
-  List,
-  ListItem,
-  ListItemButton,
-  ListItemText,
-  Typography,
-} from '@mui/material'
+import { List, ListItem, ListItemButton, ListItemText, Typography } from '@mui/material'
 import { useGetUsageBySchema } from 'actions/schema'
 import { useMemo } from 'react'
+import DisplayDialog from 'src/common/DisplayDialog'
 import EmptyBlob from 'src/common/EmptyBlob'
 import Loading from 'src/common/Loading'
-import { Transition } from 'src/common/Transition'
 import Link from 'src/Link'
 import MessageAlert from 'src/MessageAlert'
 import { SchemaInterface } from 'types/types'
@@ -88,16 +77,12 @@ export default function UsageListDialog({ open = false, onClose, schema }: Schem
   }
 
   return (
-    <Dialog fullWidth open={open} onClose={onClose} maxWidth='sm' slots={{ transition: Transition }}>
-      <DialogTitle>{`${camelCaseToTitleCase(schema.kind)}s associated to schema (${data.length})`}</DialogTitle>
-      <DialogContent>
-        {data.length ? dataList : <EmptyBlob text={`No associated ${camelCaseToTitleCase(schema.kind)}s`} />}
-      </DialogContent>
-      <DialogActions>
-        <Button variant='contained' onClick={onClose}>
-          Close
-        </Button>
-      </DialogActions>
-    </Dialog>
+    <DisplayDialog
+      open={open}
+      onClose={onClose}
+      title={`${camelCaseToTitleCase(schema.kind)}s associated to schema (${data.length})`}
+    >
+      {data.length ? dataList : <EmptyBlob text={`No associated ${camelCaseToTitleCase(schema.kind)}s`} />}
+    </DisplayDialog>
   )
 }


### PR DESCRIPTION
- `DisplayDialog` - new reusable close-only dialog component (`src/common/DisplayDialog.tsx`). Refactored 4 display dialogs to use it, fixing a `slotProps` bug in `ReviewHistoryDialog` (transition was not applied)
- `ExportPreviewDialog` - new shared export/print dialog (`src/common/ExportPreviewDialog.tsx`). Consolidated near-identical `ExportEntryCardDialog` and `MetricsExportPreview`
- `renderQueryState` - new utility function (`src/common/renderQueryState.tsx`) replacing repeated error/loading early-return guards across 22 files. Also fixes ~10 files in metrics/reviewRoles that were missing `severity='error'` on error alerts
- `FileUploadDialog` - added missing `slots={{ transition: Transition }}` for consistency with all other dialogs
- `ImportModelCardTextDialog` - swapped raw MUI `Alert` for `MessageAlert` for consistency