### PR TITLE
Fix missing UntrustedModel role in `getCurrentUser` endpoint

### DIFF
--- a/backend/src/connectors/authentication/silly.ts
+++ b/backend/src/connectors/authentication/silly.ts
@@ -29,8 +29,7 @@ export class SillyAuthenticationConnector extends BaseAuthenticationConnector {
   }
 
   async hasRole(_user: UserInterface, role: RoleKeys) {
-    const availableRoles = [Roles.Admin, Roles.Compliance, Roles.UntrustedModel]
-    return availableRoles.includes(role)
+    return Object.values(Roles).includes(role)
   }
 
   async queryEntities(_query: string) {

--- a/backend/src/routes/v3/entities/getCurrentUser.ts
+++ b/backend/src/routes/v3/entities/getCurrentUser.ts
@@ -34,10 +34,10 @@ registerPath(
 export const getCurrentUser = [
   async (req: Request, res: Response<GetCurrentUserResponse>): Promise<void> => {
     req.audit = AuditInfo.ViewCurrentUserInformation
-    const systemRoles = [
-      ...((await authentication.hasRole(req.user, Roles.Admin)) ? [Roles.Admin] : []),
-      ...((await authentication.hasRole(req.user, Roles.Compliance)) ? [Roles.Compliance] : []),
-    ]
+    const roleChecks = await Promise.all(
+      Object.values(Roles).map(async (role) => ((await authentication.hasRole(req.user, role)) ? role : undefined)),
+    )
+    const systemRoles = roleChecks.filter((role) => role !== undefined)
     const response = { user: { ...req.user, systemRoles } }
     await audit.onViewCurrentUserInformation(req, response)
 

--- a/backend/test/connectors/authentication/oauth.spec.ts
+++ b/backend/test/connectors/authentication/oauth.spec.ts
@@ -228,6 +228,28 @@ describe('connectors > authentication > oauth', () => {
     expect(result).toBe(false)
   })
 
+  test('hasRole > returns true if user is in the UntrustedModel group', async () => {
+    const connector = new OauthAuthenticationConnector()
+    const getEntityMembersSpy = vi
+      .spyOn(connector, 'getEntityMembers')
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce([user.dn])
+
+    const result = await connector.hasRole(user, Roles.UntrustedModel)
+
+    expect(result).toBe(true)
+    expect(getEntityMembersSpy).toHaveBeenCalledWith(toEntity('group', config.oauth.cognito.untrustedModelGroupName))
+  })
+
+  test('hasRole > returns false if user is not in the UntrustedModel group', async () => {
+    const connector = new OauthAuthenticationConnector()
+    vi.spyOn(connector, 'getEntityMembers').mockResolvedValueOnce([]).mockResolvedValueOnce([])
+
+    const result = await connector.hasRole(user, Roles.UntrustedModel)
+
+    expect(result).toBe(false)
+  })
+
   test('hasRole > admin access grants untrusted model role', async () => {
     const connector = new OauthAuthenticationConnector()
     const getEntityMembersSpy = vi.spyOn(connector, 'getEntityMembers').mockResolvedValueOnce([user.dn])

--- a/backend/test/connectors/authentication/silly.spec.ts
+++ b/backend/test/connectors/authentication/silly.spec.ts
@@ -37,6 +37,13 @@ describe('connectors > authentication > silly', () => {
     expect(result).toBe(true)
   })
 
+  test('hasRole > returns true for UntrustedModel role', async () => {
+    const connector = new SillyAuthenticationConnector()
+    const result = await connector.hasRole({} as any, Roles.UntrustedModel)
+
+    expect(result).toBe(true)
+  })
+
   test('hasRole > returns false for an unrecognised role', async () => {
     const connector = new SillyAuthenticationConnector()
     const result = await connector.hasRole({} as any, 'unknown-role' as any)

--- a/backend/test/routes/v3/entities/getCurrentUser.spec.ts
+++ b/backend/test/routes/v3/entities/getCurrentUser.spec.ts
@@ -23,7 +23,7 @@ vi.mock('../../../../src/connectors/authentication/index.js', () => ({
 }))
 
 describe('routes > v3 > entities > getCurrentUser', () => {
-  test('200 > returns user with no systemRoles when user has neither Admin nor Compliance', async () => {
+  test('200 > returns user with no systemRoles when user has no valid role', async () => {
     mockAuth.hasRole.mockResolvedValue(false)
 
     const res = await testGet('/api/v3/entities/me')
@@ -56,14 +56,25 @@ describe('routes > v3 > entities > getCurrentUser', () => {
     })
   })
 
-  test('200 > returns user with both admin and compliance systemRoles when user has both roles', async () => {
+  test('200 > returns user with systemRoles containing compliance when user is UntrustedModel', async () => {
+    mockAuth.hasRole.mockImplementation((_user: any, role: string) => Promise.resolve(role === 'untrusted-model'))
+
+    const res = await testGet('/api/v3/entities/me')
+
+    expect(res.statusCode).toBe(200)
+    expect(res.body).toEqual({
+      user: { dn: 'test-user', systemRoles: ['untrusted-model'] },
+    })
+  })
+
+  test('200 > returns user with all systemRoles when user has all roles', async () => {
     mockAuth.hasRole.mockResolvedValue(true)
 
     const res = await testGet('/api/v3/entities/me')
 
     expect(res.statusCode).toBe(200)
     expect(res.body).toEqual({
-      user: { dn: 'test-user', systemRoles: ['admin', 'compliance'] },
+      user: { dn: 'test-user', systemRoles: ['admin', 'compliance', 'untrusted-model'] },
     })
   })
 


### PR DESCRIPTION
Also replaces explicit list with inferred values, and updates related tests.