### PR TITLE
Create DA GET API, update audit and auth

### DIFF
--- a/backend/src/connectors/audit/Base.ts
+++ b/backend/src/connectors/audit/Base.ts
@@ -440,6 +440,12 @@ export const AuditInfo = {
     auditKind: AuditKind.Create,
     resourceKind: ResourceKind.DeploymentAssessment,
   },
+  ViewDeploymentAssessment: {
+    typeId: 'ViewDeploymentAssessment',
+    description: 'Deployment assessment viewed',
+    auditKind: AuditKind.View,
+    resourceKind: ResourceKind.DeploymentAssessment,
+  },
   ViewCurrentUserInformation: {
     typeId: 'ViewCurrentUserInformation',
     description: 'Viewed information about the user making the request',
@@ -556,7 +562,10 @@ export abstract class BaseAuditConnector {
   abstract onViewMetric(req: Request): Promise<void>
 
   abstract onCreateReview(req: Request, modelId: string): Promise<void>
+
   abstract onCreateDeploymentAssessment(req: Request, deploymentAssessment: DeploymentAssessmentDoc): Promise<void>
+  abstract onViewDeploymentAssessment(req: Request, deploymentAssessment: DeploymentAssessmentDoc): Promise<void>
+
   abstract onViewCurrentUserInformation(req: Request, userInformation: GetCurrentUserResponse): Promise<void>
 
   abstract onNotifyReviewers(req: Request, reviewId: string): Promise<void>

--- a/backend/src/connectors/audit/__mocks__/index.ts
+++ b/backend/src/connectors/audit/__mocks__/index.ts
@@ -76,7 +76,9 @@ const audit = {
   onViewMetric: vi.fn(),
 
   onCreateReview: vi.fn(),
+
   onCreateDeploymentAssessment: vi.fn(),
+  onViewDeploymentAssessment: vi.fn(),
 
   onViewCurrentUserInformation: vi.fn(),
 

--- a/backend/src/connectors/audit/silly.ts
+++ b/backend/src/connectors/audit/silly.ts
@@ -87,7 +87,8 @@ export class SillyAuditConnector extends BaseAuditConnector {
   async onDeleteReviewRole(_req: Request, _reviewRole: ReviewRoleDoc) {}
   async onViewMetric(_req: Request): Promise<void> {}
   async onCreateReview(_req: Request, _modelId: string) {}
-  async onCreateDeploymentAssessment(_req: Request, _deploymentAssessment: DeploymentAssessmentDoc) {}
+  async onCreateDeploymentAssessment(_req: Request, _deploymentAssessment: DeploymentAssessmentDoc): Promise<void> {}
+  async onViewDeploymentAssessment(_req: Request, _deploymentAssessment: DeploymentAssessmentDoc): Promise<void> {}
   async onViewCurrentUserInformation(_req: Request, _userInformation: GetCurrentUserResponse): Promise<void> {}
   async onNotifyReviewers(_req: Request, _reviewId: string): Promise<void> {}
   async onRegistryImagePulled(_req: Request, _userDn: string): Promise<void> {}

--- a/backend/src/connectors/audit/stdout.ts
+++ b/backend/src/connectors/audit/stdout.ts
@@ -439,8 +439,14 @@ export class StdoutAuditConnector extends BaseAuditConnector {
     req.log.info(event, req.audit.description)
   }
 
-  async onCreateDeploymentAssessment(req: Request, deploymentAssessment: DeploymentAssessmentDoc) {
+  async onCreateDeploymentAssessment(req: Request, deploymentAssessment: DeploymentAssessmentDoc): Promise<void> {
     this.checkEventType(AuditInfo.CreateDeploymentAssessment, req)
+    const event = this.generateEvent(req, { id: deploymentAssessment.id })
+    req.log.info(event, req.audit.description)
+  }
+
+  async onViewDeploymentAssessment(req: Request, deploymentAssessment: DeploymentAssessmentDoc): Promise<void> {
+    this.checkEventType(AuditInfo.ViewDeploymentAssessment, req)
     const event = this.generateEvent(req, { id: deploymentAssessment.id })
     req.log.info(event, req.audit.description)
   }

--- a/backend/src/connectors/audit/stroom.ts
+++ b/backend/src/connectors/audit/stroom.ts
@@ -501,6 +501,10 @@ export class StroomAuditConnector extends BaseAuditConnector {
     this.auditGenericEvent(req, deploymentAssessment.id)
   }
 
+  async onViewDeploymentAssessment(req: Request, deploymentAssessment: DeploymentAssessmentDoc): Promise<void> {
+    this.auditGenericEvent(req, deploymentAssessment.id)
+  }
+
   async onViewCurrentUserInformation(req: Request, userInformation: GetCurrentUserResponse): Promise<void> {
     this.auditGenericEvent(req, userInformation.user.dn)
   }

--- a/backend/src/connectors/authorisation/__mocks__/index.ts
+++ b/backend/src/connectors/authorisation/__mocks__/index.ts
@@ -16,6 +16,9 @@ const auth = {
   accessRequest: vi.fn(() => ({ success: true })),
   accessRequests: vi.fn(() => [{ success: true }]),
 
+  deploymentAssessment: vi.fn(() => ({ success: true })),
+  deploymentAssessments: vi.fn(() => [{ success: true }]),
+
   release: vi.fn(() => ({ success: true })),
   releases: vi.fn(() => [{ success: true }]),
 

--- a/backend/src/connectors/authorisation/actions.ts
+++ b/backend/src/connectors/authorisation/actions.ts
@@ -29,6 +29,15 @@ export const AccessRequestAction = {
 } as const
 export type AccessRequestActionKeys = (typeof AccessRequestAction)[keyof typeof AccessRequestAction]
 
+export const DeploymentAssessmentAction = {
+  Create: 'deployment_assessment:create',
+  View: 'deployment_assessment:view',
+  Update: 'deployment_assessment:update',
+  Delete: 'deployment_assessment:delete',
+} as const
+export type DeploymentAssessmentActionKeys =
+  (typeof DeploymentAssessmentAction)[keyof typeof DeploymentAssessmentAction]
+
 export const SchemaAction = {
   Create: 'schema:create',
   Delete: 'schema:delete',

--- a/backend/src/connectors/authorisation/base.ts
+++ b/backend/src/connectors/authorisation/base.ts
@@ -1,4 +1,5 @@
 import { AccessRequestDoc } from '../../models/AccessRequest.js'
+import { DeploymentAssessmentDoc } from '../../models/DeploymentAssessment.js'
 import { FileInterface } from '../../models/File.js'
 import { EntryKind, EntryVisibility, ModelDoc } from '../../models/Model.js'
 import { ReleaseDoc, ReleaseInterface } from '../../models/Release.js'
@@ -21,6 +22,8 @@ import {
   AccessRequestAction,
   AccessRequestActionKeys,
   ActionLookup,
+  DeploymentAssessmentAction,
+  DeploymentAssessmentActionKeys,
   FileAction,
   FileActionKeys,
   ImageAction,
@@ -94,6 +97,14 @@ export class BasicAuthorisationConnector {
     action: AccessRequestActionKeys,
   ) {
     return (await this.accessRequests(user, model, [accessRequest], action))[0]
+  }
+
+  async deploymentAssessment(
+    user: UserInterface,
+    deploymentAssessment: DeploymentAssessmentDoc,
+    action: DeploymentAssessmentActionKeys,
+  ) {
+    return (await this.deploymentAssessments(user, [deploymentAssessment], action))[0]
   }
 
   async response(user: UserInterface, response: ResponseDoc, action: ResponseActionKeys) {
@@ -313,6 +324,53 @@ export class BasicAuthorisationConnector {
 
         // Otherwise they either own the model, access request or this is a read-only action.
         return { success: true, id: request.id }
+      }),
+    )
+  }
+
+  async deploymentAssessments(
+    user: UserInterface,
+    deploymentAssessments: Array<DeploymentAssessmentDoc>,
+    action: DeploymentAssessmentActionKeys,
+  ): Promise<Array<Response>> {
+    return Promise.all(
+      deploymentAssessments.map(async (deploymentAssessment) => {
+        const isNamedUser = [deploymentAssessment.createdBy, deploymentAssessment.metadata.overview.riskOwner].includes(
+          user.dn,
+        )
+
+        let errorInfo: string | undefined
+        switch (action) {
+          case DeploymentAssessmentAction.View: {
+            // Only allow GET requests if the DA is not a draft, otherwise restrict to creator or risk owner
+            if (deploymentAssessment.draft && !isNamedUser) {
+              errorInfo = 'You do not have permission to view this Deployment Assessment'
+            }
+            break
+          }
+          case DeploymentAssessmentAction.Delete: {
+            if (!isNamedUser) {
+              errorInfo = 'You do not have permission to delete this Deployment Assessment'
+            }
+            break
+          }
+          case DeploymentAssessmentAction.Update: {
+            if (!isNamedUser) {
+              errorInfo = 'You do not have permission to update this Deployment Assessment'
+            }
+            break
+          }
+        }
+
+        if (errorInfo !== undefined) {
+          return {
+            success: false,
+            info: errorInfo,
+            id: deploymentAssessment.id,
+          }
+        }
+
+        return { success: true, id: deploymentAssessment.id }
       }),
     )
   }

--- a/backend/src/connectors/authorisation/base.ts
+++ b/backend/src/connectors/authorisation/base.ts
@@ -1,7 +1,6 @@
 import { AccessRequestDoc } from '../../models/AccessRequest.js'
 import { FileInterface } from '../../models/File.js'
-import { EntryVisibility, ModelDoc } from '../../models/Model.js'
-import { EntryKind } from '../../models/Model.js'
+import { EntryKind, EntryVisibility, ModelDoc } from '../../models/Model.js'
 import { ReleaseDoc, ReleaseInterface } from '../../models/Release.js'
 import { ResponseDoc } from '../../models/Response.js'
 import ReviewRoleModel from '../../models/ReviewRole.js'

--- a/backend/src/connectors/authorisation/base.ts
+++ b/backend/src/connectors/authorisation/base.ts
@@ -344,7 +344,8 @@ export class BasicAuthorisationConnector {
           case DeploymentAssessmentAction.View: {
             // Only allow GET requests if the DA is not a draft, otherwise restrict to creator or risk owner
             if (deploymentAssessment.draft && !isNamedUser) {
-              errorInfo = 'You are not the creator or the risk owner of this draft Deployment Assessment, so you do not have permission to view it.'
+              errorInfo =
+                'You are not the creator or the risk owner of this draft Deployment Assessment, so you do not have permission to view it.'
             }
             break
           }

--- a/backend/src/connectors/authorisation/base.ts
+++ b/backend/src/connectors/authorisation/base.ts
@@ -344,19 +344,19 @@ export class BasicAuthorisationConnector {
           case DeploymentAssessmentAction.View: {
             // Only allow GET requests if the DA is not a draft, otherwise restrict to creator or risk owner
             if (deploymentAssessment.draft && !isNamedUser) {
-              errorInfo = 'You do not have permission to view this Deployment Assessment'
+              errorInfo = 'You are not the creator or the risk owner of this draft Deployment Assessment, so you do not have permission to view it.'
             }
             break
           }
           case DeploymentAssessmentAction.Delete: {
             if (!isNamedUser) {
-              errorInfo = 'You do not have permission to delete this Deployment Assessment'
+              errorInfo = 'You do not have permission to delete this Deployment Assessment.'
             }
             break
           }
           case DeploymentAssessmentAction.Update: {
             if (!isNamedUser) {
-              errorInfo = 'You do not have permission to update this Deployment Assessment'
+              errorInfo = 'You do not have permission to update this Deployment Assessment.'
             }
             break
           }

--- a/backend/src/routes/v3/deploymentAssessment/getDeploymentAssessment.ts
+++ b/backend/src/routes/v3/deploymentAssessment/getDeploymentAssessment.ts
@@ -1,0 +1,54 @@
+import { Request, Response } from 'express'
+
+import { AuditInfo } from '../../../connectors/audit/Base.js'
+import audit from '../../../connectors/audit/index.js'
+import { z } from '../../../lib/zod.js'
+import { DeploymentAssessmentInterface } from '../../../models/DeploymentAssessment.js'
+import { getDeploymentAssessmentById } from '../../../services/deploymentAssessment.js'
+import { deploymentAssessmentInterfaceSchema, registerPath } from '../../../services/specification.js'
+import { parse } from '../../../utils/validate.js'
+
+export const getDeploymentAssessmentSchema = z.object({
+  params: z.object({
+    deploymentAssessmentId: z.string(),
+  }),
+})
+
+registerPath({
+  method: 'get',
+  path: '/api/v3/deployment-assessment/{deploymentAssessmentId}',
+  tags: ['deployment assessment'],
+  description: 'Get a deployment assessment.',
+  schema: getDeploymentAssessmentSchema,
+  responses: {
+    200: {
+      description: 'A deployment assessment.',
+      content: {
+        'application/json': {
+          schema: z.object({
+            deploymentAssessment: deploymentAssessmentInterfaceSchema,
+          }),
+        },
+      },
+    },
+  },
+})
+
+interface GetDeploymentAssessmentResponse {
+  deploymentAssessment: DeploymentAssessmentInterface
+}
+
+export const getDeploymentAssessment = [
+  async (req: Request, res: Response<GetDeploymentAssessmentResponse>): Promise<void> => {
+    req.audit = AuditInfo.ViewDeploymentAssessment
+    const { params } = parse(req, getDeploymentAssessmentSchema)
+
+    const deploymentAssessment = await getDeploymentAssessmentById(params.deploymentAssessmentId)
+
+    await audit.onViewDeploymentAssessment(req, deploymentAssessment)
+
+    res.json({
+      deploymentAssessment,
+    })
+  },
+]

--- a/backend/src/routes/v3/deploymentAssessment/getDeploymentAssessment.ts
+++ b/backend/src/routes/v3/deploymentAssessment/getDeploymentAssessment.ts
@@ -14,25 +14,28 @@ export const getDeploymentAssessmentSchema = z.object({
   }),
 })
 
-registerPath({
-  method: 'get',
-  path: '/api/v3/deployment-assessment/{deploymentAssessmentId}',
-  tags: ['deployment assessment'],
-  description: 'Get a deployment assessment.',
-  schema: getDeploymentAssessmentSchema,
-  responses: {
-    200: {
-      description: 'A deployment assessment.',
-      content: {
-        'application/json': {
-          schema: z.object({
-            deploymentAssessment: deploymentAssessmentInterfaceSchema,
-          }),
+registerPath(
+  {
+    method: 'get',
+    path: '/api/v3/deployment-assessments/{deploymentAssessmentId}',
+    tags: ['deployment assessments'],
+    description: 'Get a deployment assessment.',
+    schema: getDeploymentAssessmentSchema,
+    responses: {
+      200: {
+        description: 'A deployment assessment.',
+        content: {
+          'application/json': {
+            schema: z.object({
+              deploymentAssessment: deploymentAssessmentInterfaceSchema,
+            }),
+          },
         },
       },
     },
   },
-})
+  'v3',
+)
 
 interface GetDeploymentAssessmentResponse {
   deploymentAssessment: DeploymentAssessmentInterface
@@ -43,7 +46,7 @@ export const getDeploymentAssessment = [
     req.audit = AuditInfo.ViewDeploymentAssessment
     const { params } = parse(req, getDeploymentAssessmentSchema)
 
-    const deploymentAssessment = await getDeploymentAssessmentById(params.deploymentAssessmentId)
+    const deploymentAssessment = await getDeploymentAssessmentById(req.user, params.deploymentAssessmentId)
 
     await audit.onViewDeploymentAssessment(req, deploymentAssessment)
 

--- a/backend/src/routes/v3/deploymentAssessment/postDeploymentAssessment.ts
+++ b/backend/src/routes/v3/deploymentAssessment/postDeploymentAssessment.ts
@@ -5,52 +5,15 @@ import audit from '../../../connectors/audit/index.js'
 import { z } from '../../../lib/zod.js'
 import { DeploymentAssessmentInterface } from '../../../models/DeploymentAssessment.js'
 import { createDeploymentAssessment } from '../../../services/deploymentAssessment.js'
-import { registerPath } from '../../../services/specification.js'
+import { deploymentAssessmentInterfaceSchema, registerPath } from '../../../services/specification.js'
 import { parse } from '../../../utils/validate.js'
 
-const overview = z
-  .object({
-    name: z
-      .string()
-      .min(1, 'You must provide a deployment assessment name')
-      .openapi({ example: 'Just A Rather Very Intelligent System' }),
-    riskOwner: z.string().min(1, 'You must provide a risk owner').openapi({ example: 'user:tony' }).optional(),
-    justification: z
-      .string()
-      .min(1, 'You must provide a justification')
-      .openapi({ example: 'The risk owner is accountable for the deployed service.' })
-      .optional(),
-    modelIds: z
-      .array(z.string())
-      .openapi({ example: ['ironman-a1b2c3', 'hulkbuster-a1b2c3'] })
-      .optional(),
-  })
-  .passthrough()
-
-const metadata = z.object({ overview }).passthrough()
-
-const schemaId = z
-  .string()
-  .min(1, 'You must provide a schema ID')
-  .openapi({ example: 'stark-deployment-assessment-schema-v1' })
-const draft = z.boolean().openapi({ example: true })
-
-export const deploymentAssessmentInterfaceSchema = z.object({
-  id: z.string().openapi({ example: 'just-a-rather-very-intelligent-system-a1b2c3' }),
-  schemaId,
-  metadata,
-  draft,
-  createdBy: z.string().openapi({ example: 'tony' }),
-  createdAt: z.string().datetime().openapi({ example: new Date().toISOString() }),
-  updatedAt: z.string().datetime().openapi({ example: new Date().toISOString() }),
-})
-
 export const postDeploymentAssessmentSchema = z.object({
-  body: z
-    .object({
-      schemaId,
-      metadata,
-      draft: draft.optional().default(true),
+  body: deploymentAssessmentInterfaceSchema
+    .pick({
+      schemaId: true,
+      metadata: true,
+      draft: true,
     })
     .strict(),
 })
@@ -58,7 +21,7 @@ export const postDeploymentAssessmentSchema = z.object({
 registerPath(
   {
     method: 'post',
-    path: '/api/v3/deployment-assessments',
+    path: '/api/v3/deployment-assessment',
     tags: ['deployment assessments'],
     description: 'Create a deployment assessment',
     schema: postDeploymentAssessmentSchema,
@@ -88,6 +51,6 @@ export const postDeploymentAssessment = [
     const deploymentAssessment = await createDeploymentAssessment(req.user, body)
     await audit.onCreateDeploymentAssessment(req, deploymentAssessment)
 
-    res.location(`/api/v3/deployment-assessments/${deploymentAssessment.id}`).status(201).json({ deploymentAssessment })
+    res.location(`/api/v3/deployment-assessment/${deploymentAssessment.id}`).status(201).json({ deploymentAssessment })
   },
 ]

--- a/backend/src/routes/v3/deploymentAssessment/postDeploymentAssessment.ts
+++ b/backend/src/routes/v3/deploymentAssessment/postDeploymentAssessment.ts
@@ -21,7 +21,7 @@ export const postDeploymentAssessmentSchema = z.object({
 registerPath(
   {
     method: 'post',
-    path: '/api/v3/deployment-assessment',
+    path: '/api/v3/deployment-assessments',
     tags: ['deployment assessments'],
     description: 'Create a deployment assessment',
     schema: postDeploymentAssessmentSchema,
@@ -51,6 +51,6 @@ export const postDeploymentAssessment = [
     const deploymentAssessment = await createDeploymentAssessment(req.user, body)
     await audit.onCreateDeploymentAssessment(req, deploymentAssessment)
 
-    res.location(`/api/v3/deployment-assessment/${deploymentAssessment.id}`).status(201).json({ deploymentAssessment })
+    res.location(`/api/v3/deployment-assessments/${deploymentAssessment.id}`).status(201).json({ deploymentAssessment })
   },
 ]

--- a/backend/src/routes/v3/routes.ts
+++ b/backend/src/routes/v3/routes.ts
@@ -23,8 +23,8 @@ router.get('/api-docs/swagger.json', (req, res) => res.json(generateV3SwaggerSpe
 
 router.get('/model/:modelId/image/:name/:tag/:digest', ...getImageByDigest)
 
-router.post('/deployment-assessment', ...postDeploymentAssessment)
-router.get('/deployment-assessment/:deploymentAssessmentId', ...getDeploymentAssessment)
+router.post('/deployment-assessments', ...postDeploymentAssessment)
+router.get('/deployment-assessments/:deploymentAssessmentId', ...getDeploymentAssessment)
 
 router.get('/metrics/usage', ...getUsageMetrics)
 router.get('/metrics/compliance/no-releases', ...getNoReleasesComplianceMetrics)

--- a/backend/src/routes/v3/routes.ts
+++ b/backend/src/routes/v3/routes.ts
@@ -2,6 +2,7 @@ import { Router } from 'express'
 
 import { generateV3SwaggerSpec } from '../../services/specification.js'
 import { getImageByDigest } from '../v3/model/images/getImage.js'
+import { getDeploymentAssessment } from './deploymentAssessment/getDeploymentAssessment.js'
 import { postDeploymentAssessment } from './deploymentAssessment/postDeploymentAssessment.js'
 import { getCurrentUser } from './entities/getCurrentUser.js'
 import { getEntryVolume } from './metrics/getEntryVolume.js'
@@ -22,7 +23,8 @@ router.get('/api-docs/swagger.json', (req, res) => res.json(generateV3SwaggerSpe
 
 router.get('/model/:modelId/image/:name/:tag/:digest', ...getImageByDigest)
 
-router.post('/deployment-assessments', ...postDeploymentAssessment)
+router.post('/deployment-assessment', ...postDeploymentAssessment)
+router.get('/deployment-assessment/:deploymentAssessmentId', ...getDeploymentAssessment)
 
 router.get('/metrics/usage', ...getUsageMetrics)
 router.get('/metrics/compliance/no-releases', ...getNoReleasesComplianceMetrics)

--- a/backend/src/services/deploymentAssessment.ts
+++ b/backend/src/services/deploymentAssessment.ts
@@ -8,7 +8,7 @@ import { UserInterface } from '../models/User.js'
 import { SchemaKind } from '../types/enums.js'
 import config from '../utils/config.js'
 import { fromEntity } from '../utils/entity.js'
-import { BadReq, Conflict } from '../utils/error.js'
+import { BadReq, Conflict, NotFound } from '../utils/error.js'
 import { convertStringToId } from '../utils/id.js'
 import { isMongoServerError } from '../utils/mongo.js'
 import { getSchemaById, validateContentAgainstSchema } from './schema.js'
@@ -59,6 +59,15 @@ async function validateModels(modelIds: string[]) {
       },
     )
   }
+}
+
+export async function getDeploymentAssessmentById(deploymentAssessmentId: string) {
+  const deploymentAssessment = await DeploymentAssessmentModel.findOne({ id: deploymentAssessmentId })
+  if (!deploymentAssessment) {
+    throw NotFound('The requested deployment assessment was not found.', { deploymentAssessmentId })
+  }
+
+  return deploymentAssessment
 }
 
 export async function createDeploymentAssessment(user: UserInterface, params: CreateDeploymentAssessmentParams) {

--- a/backend/src/services/deploymentAssessment.ts
+++ b/backend/src/services/deploymentAssessment.ts
@@ -1,4 +1,6 @@
 import authentication from '../connectors/authentication/index.js'
+import { DeploymentAssessmentAction } from '../connectors/authorisation/actions.js'
+import authorisation from '../connectors/authorisation/index.js'
 import DeploymentAssessmentModel, {
   DeploymentAssessmentInterface,
   DeploymentAssessmentMetadata,
@@ -8,7 +10,7 @@ import { UserInterface } from '../models/User.js'
 import { SchemaKind } from '../types/enums.js'
 import config from '../utils/config.js'
 import { fromEntity } from '../utils/entity.js'
-import { BadReq, Conflict, NotFound } from '../utils/error.js'
+import { BadReq, Conflict, Forbidden, NotFound } from '../utils/error.js'
 import { convertStringToId } from '../utils/id.js'
 import { isMongoServerError } from '../utils/mongo.js'
 import { getSchemaById, validateContentAgainstSchema } from './schema.js'
@@ -61,10 +63,15 @@ async function validateModels(modelIds: string[]) {
   }
 }
 
-export async function getDeploymentAssessmentById(deploymentAssessmentId: string) {
+export async function getDeploymentAssessmentById(user: UserInterface, deploymentAssessmentId: string) {
   const deploymentAssessment = await DeploymentAssessmentModel.findOne({ id: deploymentAssessmentId })
   if (!deploymentAssessment) {
     throw NotFound('The requested deployment assessment was not found.', { deploymentAssessmentId })
+  }
+
+  const auth = await authorisation.deploymentAssessment(user, deploymentAssessment, DeploymentAssessmentAction.View)
+  if (!auth.success) {
+    throw Forbidden(auth.info, { userDn: user.dn, deploymentAssessmentId })
   }
 
   return deploymentAssessment
@@ -96,13 +103,19 @@ export async function createDeploymentAssessment(user: UserInterface, params: Cr
     await validateModels(modelIds)
   }
 
+  const deploymentAssessmentId = convertStringToId(name)
   const deploymentAssessment = new DeploymentAssessmentModel({
-    id: convertStringToId(name),
+    id: deploymentAssessmentId,
     schemaId: params.schemaId,
     metadata,
     draft: params.draft,
     createdBy: user.dn,
   })
+
+  const auth = await authorisation.deploymentAssessment(user, deploymentAssessment, DeploymentAssessmentAction.Create)
+  if (!auth.success) {
+    throw Forbidden(auth.info, { userDn: user.dn, deploymentAssessmentId })
+  }
 
   try {
     await deploymentAssessment.save()

--- a/backend/src/services/specification.ts
+++ b/backend/src/services/specification.ts
@@ -66,6 +66,9 @@ export const systemStatusSchema = z.object({
   }),
 })
 
+const schemaId = z.string().min(1, 'You must provide a schema ID')
+const draft = z.boolean().openapi({ example: true })
+
 export const modelTransferSchema = z.object({
   _id: z.string().openapi({ example: '65df1a0e8c2b7c0012f0abcd' }),
   modelId: z.string().openapi({ example: 'model-123456' }),
@@ -100,7 +103,7 @@ export const peersConfigStatusSchema = z.object({
 })
 
 export const modelCardInterfaceSchema = z.object({
-  schemaId: z.string().openapi({ example: 'minimal-general-v10-beta' }),
+  schemaId: schemaId.openapi({ example: 'minimal-general-v10-beta' }),
   version: z.number().openapi({ example: 5 }),
   createdBy: z.string().openapi({ example: 'user' }),
   metadata: z.object({
@@ -110,7 +113,7 @@ export const modelCardInterfaceSchema = z.object({
 
 export const modelCardRevisionInterfaceSchema = z.object({
   modelId: z.string().openapi({ example: 'yolo-v4-abcdef' }),
-  schemaId: z.string().openapi({ example: 'minimal-general-v10-beta' }),
+  schemaId: schemaId.openapi({ example: 'minimal-general-v10-beta' }),
 
   version: z.number().openapi({ example: 5 }),
   metadata: z.object({
@@ -282,7 +285,7 @@ export const releaseInterfaceSchema = z.object({
   notes: z.string().openapi({ example: 'An example release' }),
 
   minor: z.boolean().openapi({ example: false }),
-  draft: z.boolean().openapi({ example: false }),
+  draft,
 
   fileIds: z.array(z.string()).openapi({ example: ['507f1f77bcf86cd799439011'] }),
   images: z.array(z.string()).openapi({ example: ['/yolo-v4-abcdef/example:v1.0.0'] }),
@@ -338,7 +341,7 @@ export const accessRequestInterfaceSchema = z.object({
   id: z.string().openapi({ example: 'looking-at-pictures-zyxwvu' }),
   modelId: z.string().openapi({ example: 'yolo-v4-abcdef' }),
 
-  schemaId: z.string().openapi({ example: 'minimal-access-request-v1' }),
+  schemaId: schemaId.openapi({ example: 'minimal-access-request-v1' }),
   metadata: z.object({
     overview: z.object({
       name: z.string().openapi({ example: 'Looking at Pictures' }),
@@ -363,6 +366,35 @@ export const accessRequestInterfaceSchema = z.object({
   createdBy: z.string().openapi({ example: 'user' }),
   createdAt: z.string().openapi({ example: new Date().toISOString() }),
   updatedAt: z.string().openapi({ example: new Date().toISOString() }),
+})
+
+const deploymentAssessmentOverview = z
+  .object({
+    name: z
+      .string()
+      .min(1, 'You must provide a deployment assessment name')
+      .openapi({ example: 'Just A Rather Very Intelligent System' }),
+    riskOwner: z.string().min(1, 'You must provide a risk owner').openapi({ example: 'user:tony' }).optional(),
+    justification: z
+      .string()
+      .min(1, 'You must provide a justification')
+      .openapi({ example: 'The risk owner is accountable for the deployed service.' })
+      .optional(),
+    modelIds: z
+      .array(z.string())
+      .openapi({ example: ['ironman-a1b2c3', 'hulkbuster-a1b2c3'] })
+      .optional(),
+  })
+  .passthrough()
+
+export const deploymentAssessmentInterfaceSchema = z.object({
+  id: z.string().openapi({ example: 'just-a-rather-very-intelligent-system-a1b2c3' }),
+  schemaId: schemaId.openapi({ example: 'stark-deployment-assessment-schema-v1' }),
+  metadata: z.object({ overview: deploymentAssessmentOverview }).passthrough(),
+  draft: draft.optional().default(true).openapi({ example: true }),
+  createdBy: z.string().openapi({ example: 'tony' }),
+  createdAt: z.string().datetime().openapi({ example: new Date().toISOString() }),
+  updatedAt: z.string().datetime().openapi({ example: new Date().toISOString() }),
 })
 
 export const schemaInterfaceSchema = z.object({

--- a/backend/test/connectors/authorisation/base.spec.ts
+++ b/backend/test/connectors/authorisation/base.spec.ts
@@ -3,6 +3,7 @@ import { describe, expect, test, vi } from 'vitest'
 import { Roles } from '../../../src/connectors/authentication/constants.js'
 import {
   AccessRequestAction,
+  DeploymentAssessmentAction,
   FileAction,
   ModelAction,
   ReleaseAction,
@@ -1029,6 +1030,119 @@ describe('connectors > authorisation > base', () => {
       id: 'role1',
       success: false,
       info: 'You cannot upload or modify a review role if you are not an admin.',
+    })
+  })
+
+  describe('Deployment assessments', () => {
+    const connector = new BasicAuthorisationConnector()
+
+    const deploymentAssessment = {
+      id: 'da-1',
+      createdBy: 'creator',
+      draft: false,
+      metadata: { overview: { riskOwner: 'riskOwner' } },
+    } as any
+
+    test('view non-draft DA as non-named user', async () => {
+      const result = await connector.deploymentAssessment(
+        { dn: 'otherUser' } as UserInterface,
+        deploymentAssessment,
+        DeploymentAssessmentAction.View,
+      )
+
+      expect(result).toStrictEqual({ id: 'da-1', success: true })
+    })
+
+    test('view draft DA as creator', async () => {
+      const result = await connector.deploymentAssessment(
+        { dn: 'creator' } as UserInterface,
+        { ...deploymentAssessment, draft: true },
+        DeploymentAssessmentAction.View,
+      )
+
+      expect(result).toStrictEqual({ id: 'da-1', success: true })
+    })
+
+    test('view draft DA as risk owner', async () => {
+      const result = await connector.deploymentAssessment(
+        { dn: 'riskOwner' } as UserInterface,
+        { ...deploymentAssessment, draft: true },
+        DeploymentAssessmentAction.View,
+      )
+
+      expect(result).toStrictEqual({ id: 'da-1', success: true })
+    })
+
+    test('view draft DA as non-named user', async () => {
+      const result = await connector.deploymentAssessment(
+        { dn: 'otherUser' } as UserInterface,
+        { ...deploymentAssessment, draft: true },
+        DeploymentAssessmentAction.View,
+      )
+
+      expect(result).toStrictEqual({
+        id: 'da-1',
+        success: false,
+        info: 'You do not have permission to view this Deployment Assessment',
+      })
+    })
+
+    test('delete DA as creator', async () => {
+      const result = await connector.deploymentAssessment(
+        { dn: 'creator' } as UserInterface,
+        deploymentAssessment,
+        DeploymentAssessmentAction.Delete,
+      )
+
+      expect(result).toStrictEqual({ id: 'da-1', success: true })
+    })
+
+    test('delete DA as non-named user', async () => {
+      const result = await connector.deploymentAssessment(
+        { dn: 'otherUser' } as UserInterface,
+        deploymentAssessment,
+        DeploymentAssessmentAction.Delete,
+      )
+
+      expect(result).toStrictEqual({
+        id: 'da-1',
+        success: false,
+        info: 'You do not have permission to delete this Deployment Assessment',
+      })
+    })
+
+    test('update DA as risk owner', async () => {
+      const result = await connector.deploymentAssessment(
+        { dn: 'riskOwner' } as UserInterface,
+        deploymentAssessment,
+        DeploymentAssessmentAction.Update,
+      )
+
+      expect(result).toStrictEqual({ id: 'da-1', success: true })
+    })
+
+    test('update DA as non-named user', async () => {
+      const result = await connector.deploymentAssessment(
+        { dn: 'otherUser' } as UserInterface,
+        deploymentAssessment,
+        DeploymentAssessmentAction.Update,
+      )
+
+      expect(result).toStrictEqual({
+        id: 'da-1',
+        success: false,
+        info: 'You do not have permission to update this Deployment Assessment',
+      })
+    })
+
+    test('create DA as any user', async () => {
+      const result = await connector.deploymentAssessment(
+        { dn: 'anyUser' } as UserInterface,
+        deploymentAssessment,
+        DeploymentAssessmentAction.Create,
+      )
+
+      expect(result).toStrictEqual({ id: 'da-1', success: true })
     })
   })
 

--- a/backend/test/connectors/authorisation/base.spec.ts
+++ b/backend/test/connectors/authorisation/base.spec.ts
@@ -1083,7 +1083,7 @@ describe('connectors > authorisation > base', () => {
       expect(result).toStrictEqual({
         id: 'da-1',
         success: false,
-        info: 'You do not have permission to view this Deployment Assessment',
+        info: 'You are not the creator or the risk owner of this draft Deployment Assessment, so you do not have permission to view it.',
       })
     })
 
@@ -1107,7 +1107,7 @@ describe('connectors > authorisation > base', () => {
       expect(result).toStrictEqual({
         id: 'da-1',
         success: false,
-        info: 'You do not have permission to delete this Deployment Assessment',
+        info: 'You do not have permission to delete this Deployment Assessment.',
       })
     })
 
@@ -1131,7 +1131,7 @@ describe('connectors > authorisation > base', () => {
       expect(result).toStrictEqual({
         id: 'da-1',
         success: false,
-        info: 'You do not have permission to update this Deployment Assessment',
+        info: 'You do not have permission to update this Deployment Assessment.',
       })
     })
 

--- a/backend/test/routes/v3/deploymentAssessment/__snapshots__/getDeploymentAssessment.spec.ts.snap
+++ b/backend/test/routes/v3/deploymentAssessment/__snapshots__/getDeploymentAssessment.spec.ts.snap
@@ -1,0 +1,5 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`routes > v3 > deploymentAssessment > getDeploymentAssessment > 200 > ok 1`] = `{}`;
+
+exports[`routes > v3 > deploymentAssessment > getDeploymentAssessment > audit > expected call 1`] = `undefined`;

--- a/backend/test/routes/v3/deploymentAssessment/getDeploymentAssessment.spec.ts
+++ b/backend/test/routes/v3/deploymentAssessment/getDeploymentAssessment.spec.ts
@@ -1,0 +1,31 @@
+import { describe, expect, test, vi } from 'vitest'
+
+import audit from '../../../../src/connectors/audit/__mocks__/index.js'
+import { getDeploymentAssessmentSchema } from '../../../../src/routes/v3/deploymentAssessment/getDeploymentAssessment.js'
+import { createFixture, testGet } from '../../../testUtils/routes.js'
+
+vi.mock('../../../../src/connectors/audit/index.js')
+
+const serviceMock = vi.hoisted(() => ({
+  getDeploymentAssessmentById: vi.fn(),
+}))
+vi.mock('../../../../src/services/deploymentAssessment.js', () => serviceMock)
+
+describe('routes > v3 > deploymentAssessment > getDeploymentAssessment', () => {
+  test('200 > ok', async () => {
+    const fixture = createFixture(getDeploymentAssessmentSchema)
+    const res = await testGet(`/api/v3/deployment-assessment/${fixture.params.deploymentAssessmentId}`)
+
+    expect(res.statusCode).toBe(200)
+    expect(res.body).matchSnapshot()
+  })
+
+  test('audit > expected call', async () => {
+    const fixture = createFixture(getDeploymentAssessmentSchema)
+    const res = await testGet(`/api/v3/deployment-assessment/${fixture.params.deploymentAssessmentId}`)
+
+    expect(res.statusCode).toBe(200)
+    expect(audit.onViewDeploymentAssessment).toHaveBeenCalled()
+    expect(audit.onViewDeploymentAssessment.mock.calls.at(0)?.at(1)).toMatchSnapshot()
+  })
+})

--- a/backend/test/routes/v3/deploymentAssessment/getDeploymentAssessment.spec.ts
+++ b/backend/test/routes/v3/deploymentAssessment/getDeploymentAssessment.spec.ts
@@ -14,7 +14,7 @@ vi.mock('../../../../src/services/deploymentAssessment.js', () => serviceMock)
 describe('routes > v3 > deploymentAssessment > getDeploymentAssessment', () => {
   test('200 > ok', async () => {
     const fixture = createFixture(getDeploymentAssessmentSchema)
-    const res = await testGet(`/api/v3/deployment-assessment/${fixture.params.deploymentAssessmentId}`)
+    const res = await testGet(`/api/v3/deployment-assessments/${fixture.params.deploymentAssessmentId}`)
 
     expect(res.statusCode).toBe(200)
     expect(res.body).matchSnapshot()
@@ -22,7 +22,7 @@ describe('routes > v3 > deploymentAssessment > getDeploymentAssessment', () => {
 
   test('audit > expected call', async () => {
     const fixture = createFixture(getDeploymentAssessmentSchema)
-    const res = await testGet(`/api/v3/deployment-assessment/${fixture.params.deploymentAssessmentId}`)
+    const res = await testGet(`/api/v3/deployment-assessments/${fixture.params.deploymentAssessmentId}`)
 
     expect(res.statusCode).toBe(200)
     expect(audit.onViewDeploymentAssessment).toHaveBeenCalled()

--- a/backend/test/routes/v3/deploymentAssessment/postDeploymentAssessment.spec.ts
+++ b/backend/test/routes/v3/deploymentAssessment/postDeploymentAssessment.spec.ts
@@ -37,10 +37,10 @@ describe('routes > v3 > deploymentAssessment > postDeploymentAssessment', () => 
         draft: false,
       },
     }
-    const res = await testPost('/api/v3/deployment-assessment', fixture)
+    const res = await testPost('/api/v3/deployment-assessments', fixture)
 
     expect(res.statusCode).toBe(201)
-    expect(res.headers.location).toBe('/api/v3/deployment-assessment/assessment-abc123')
+    expect(res.headers.location).toBe('/api/v3/deployment-assessments/assessment-abc123')
     expect(res.body).toEqual({
       deploymentAssessment: {
         ...deploymentAssessment,
@@ -69,7 +69,7 @@ describe('routes > v3 > deploymentAssessment > postDeploymentAssessment', () => 
       draft: true,
     }
 
-    const res = await testPost('/api/v3/deployment-assessment', { body })
+    const res = await testPost('/api/v3/deployment-assessments', { body })
 
     expect(res.statusCode).toBe(201)
     expect(serviceMock.createDeploymentAssessment).toHaveBeenCalledWith(expect.anything(), body)
@@ -82,7 +82,7 @@ describe('routes > v3 > deploymentAssessment > postDeploymentAssessment', () => 
       metadata: { overview: { name: 'Assessment' } },
     }
 
-    const res = await testPost('/api/v3/deployment-assessment', { body })
+    const res = await testPost('/api/v3/deployment-assessments', { body })
 
     expect(res.statusCode).toBe(201)
     expect(serviceMock.createDeploymentAssessment).toHaveBeenCalledWith(expect.anything(), { ...body, draft: true })
@@ -104,7 +104,7 @@ describe('routes > v3 > deploymentAssessment > postDeploymentAssessment', () => 
       description: 'server-managed property',
     },
   ])('rejects malformed input: $description', async ({ body }) => {
-    const res = await testPost('/api/v3/deployment-assessment', { body })
+    const res = await testPost('/api/v3/deployment-assessments', { body })
 
     expect(res.statusCode).toBe(400)
     expect(serviceMock.createDeploymentAssessment).not.toHaveBeenCalled()

--- a/backend/test/routes/v3/deploymentAssessment/postDeploymentAssessment.spec.ts
+++ b/backend/test/routes/v3/deploymentAssessment/postDeploymentAssessment.spec.ts
@@ -27,7 +27,7 @@ const serviceMock = vi.hoisted(() => ({
 }))
 vi.mock('../../../../src/services/deploymentAssessment.js', () => serviceMock)
 
-describe('routes > deploymentAssessment > postDeploymentAssessment', () => {
+describe('routes > v3 > deploymentAssessment > postDeploymentAssessment', () => {
   test('creates a deployment assessment', async () => {
     serviceMock.createDeploymentAssessment.mockResolvedValueOnce(deploymentAssessment)
     const fixture = {
@@ -37,10 +37,10 @@ describe('routes > deploymentAssessment > postDeploymentAssessment', () => {
         draft: false,
       },
     }
-    const res = await testPost('/api/v3/deployment-assessments', fixture)
+    const res = await testPost('/api/v3/deployment-assessment', fixture)
 
     expect(res.statusCode).toBe(201)
-    expect(res.headers.location).toBe('/api/v3/deployment-assessments/assessment-abc123')
+    expect(res.headers.location).toBe('/api/v3/deployment-assessment/assessment-abc123')
     expect(res.body).toEqual({
       deploymentAssessment: {
         ...deploymentAssessment,
@@ -69,7 +69,7 @@ describe('routes > deploymentAssessment > postDeploymentAssessment', () => {
       draft: true,
     }
 
-    const res = await testPost('/api/v3/deployment-assessments', { body })
+    const res = await testPost('/api/v3/deployment-assessment', { body })
 
     expect(res.statusCode).toBe(201)
     expect(serviceMock.createDeploymentAssessment).toHaveBeenCalledWith(expect.anything(), body)
@@ -82,7 +82,7 @@ describe('routes > deploymentAssessment > postDeploymentAssessment', () => {
       metadata: { overview: { name: 'Assessment' } },
     }
 
-    const res = await testPost('/api/v3/deployment-assessments', { body })
+    const res = await testPost('/api/v3/deployment-assessment', { body })
 
     expect(res.statusCode).toBe(201)
     expect(serviceMock.createDeploymentAssessment).toHaveBeenCalledWith(expect.anything(), { ...body, draft: true })
@@ -104,7 +104,7 @@ describe('routes > deploymentAssessment > postDeploymentAssessment', () => {
       description: 'server-managed property',
     },
   ])('rejects malformed input: $description', async ({ body }) => {
-    const res = await testPost('/api/v3/deployment-assessments', { body })
+    const res = await testPost('/api/v3/deployment-assessment', { body })
 
     expect(res.statusCode).toBe(400)
     expect(serviceMock.createDeploymentAssessment).not.toHaveBeenCalled()

--- a/backend/test/services/deploymentAssessment.spec.ts
+++ b/backend/test/services/deploymentAssessment.spec.ts
@@ -2,6 +2,7 @@ import { MongoServerError } from 'mongodb'
 import { beforeEach, describe, expect, test, vi } from 'vitest'
 
 import authentication from '../../src/connectors/authentication/index.js'
+import authorisation from '../../src/connectors/authorisation/index.js'
 import { EntryKind, EntryVisibility } from '../../src/models/Model.js'
 import { createDeploymentAssessment, getDeploymentAssessmentById } from '../../src/services/deploymentAssessment.js'
 import { SchemaKind } from '../../src/types/enums.js'
@@ -10,6 +11,8 @@ import { getTypedModelMock } from '../testUtils/setupMongooseModelMocks.js'
 vi.mock('../../src/connectors/authentication/index.js', () => ({
   default: { getUserInformation: vi.fn() },
 }))
+
+vi.mock('../../src/connectors/authorisation/index.js')
 
 const idMocks = vi.hoisted(() => ({ convertStringToId: vi.fn(() => 'assessment-abc123') }))
 vi.mock('../../src/utils/id.js', () => idMocks)
@@ -54,19 +57,40 @@ describe('services > deploymentAssessment', () => {
 
   describe('getDeploymentAssessmentById', () => {
     test('gets an existing DA by its ID', async () => {
-      DeploymentAssessmentModelMock.findOne.mockResolvedValueOnce('mocked')
+      const mockDA = {
+        createdBy: 'creator',
+        metadata: { overview: { riskOwner: 'user' } },
+      }
+      DeploymentAssessmentModelMock.findOne.mockResolvedValueOnce(mockDA)
 
-      const result = await getDeploymentAssessmentById('da-id')
+      const result = await getDeploymentAssessmentById({ dn: 'creator' }, 'da-id')
 
       expect(DeploymentAssessmentModelMock.findOne).toHaveBeenCalled()
-      expect(result).toBe('mocked')
+      expect(result).toBe(mockDA)
     })
 
     test('no DA', async () => {
       DeploymentAssessmentModelMock.findOne.mockResolvedValueOnce(undefined)
 
-      await expect(() => getDeploymentAssessmentById('da-id')).rejects.toThrow(
+      await expect(() => getDeploymentAssessmentById({ dn: 'creator' }, 'da-id')).rejects.toThrow(
         /^The requested deployment assessment was not found/,
+      )
+    })
+
+    test('forbidden when authorisation fails', async () => {
+      const mockDA = {
+        createdBy: 'creator',
+        metadata: { overview: { riskOwner: 'user' } },
+      }
+      DeploymentAssessmentModelMock.findOne.mockResolvedValueOnce(mockDA)
+      vi.mocked(authorisation.deploymentAssessment).mockResolvedValueOnce({
+        success: false,
+        info: 'You do not have permission to view this Deployment Assessment',
+        id: 'da-id',
+      })
+
+      await expect(() => getDeploymentAssessmentById({ dn: 'otherUser' }, 'da-id')).rejects.toThrow(
+        /^You do not have permission to view this Deployment Assessment/,
       )
     })
   })
@@ -178,6 +202,19 @@ describe('services > deploymentAssessment', () => {
 
     await expect(createDeploymentAssessment({ dn: 'creator' }, { ...params, draft: true })).rejects.toThrow(message)
     expect(DeploymentAssessmentModelMock).not.toHaveBeenCalled()
+  })
+
+  test('rejects creation when authorisation fails', async () => {
+    vi.mocked(authorisation.deploymentAssessment).mockResolvedValueOnce({
+      success: false,
+      info: 'You do not have permission to create this Deployment Assessment',
+      id: 'assessment-abc123',
+    })
+
+    await expect(createDeploymentAssessment({ dn: 'creator' }, params)).rejects.toThrow(
+      /^You do not have permission to create this Deployment Assessment/,
+    )
+    expect(DeploymentAssessmentModelMock.save).not.toHaveBeenCalled()
   })
 
   test('returns a conflict when the generated ID already exists', async () => {

--- a/backend/test/services/deploymentAssessment.spec.ts
+++ b/backend/test/services/deploymentAssessment.spec.ts
@@ -3,7 +3,7 @@ import { beforeEach, describe, expect, test, vi } from 'vitest'
 
 import authentication from '../../src/connectors/authentication/index.js'
 import { EntryKind, EntryVisibility } from '../../src/models/Model.js'
-import { createDeploymentAssessment } from '../../src/services/deploymentAssessment.js'
+import { createDeploymentAssessment, getDeploymentAssessmentById } from '../../src/services/deploymentAssessment.js'
 import { SchemaKind } from '../../src/types/enums.js'
 import { getTypedModelMock } from '../testUtils/setupMongooseModelMocks.js'
 
@@ -50,6 +50,25 @@ describe('services > deploymentAssessment', () => {
     schemaMocks.getSchemaById.mockResolvedValue({ kind: SchemaKind.DeploymentAssessment, hidden: false })
     schemaMocks.validateContentAgainstSchema.mockResolvedValue({ valid: true, errors: [] })
     ModelModelMock.find.mockResolvedValue([liveModel])
+  })
+
+  describe('getDeploymentAssessmentById', () => {
+    test('gets an existing DA by its ID', async () => {
+      DeploymentAssessmentModelMock.findOne.mockResolvedValueOnce('mocked')
+
+      const result = await getDeploymentAssessmentById('da-id')
+
+      expect(DeploymentAssessmentModelMock.findOne).toHaveBeenCalled()
+      expect(result).toBe('mocked')
+    })
+
+    test('no DA', async () => {
+      DeploymentAssessmentModelMock.findOne.mockResolvedValueOnce(undefined)
+
+      await expect(() => getDeploymentAssessmentById('da-id')).rejects.toThrow(
+        /^The requested deployment assessment was not found/,
+      )
+    })
   })
 
   test('creates an assessment with a generated ID and authenticated creator', async () => {


### PR DESCRIPTION
- Add new `GET /api/v3/deployment-assessments/{deploymentAssessmentId}` endpoint
- ~~Change `POST /api/v3/deployment-assessments` (plural) to `POST /api/v3/deployment-assessment` (singular)~~ reverted
- Move some specification `const`s to relevant file
- Add new audit event
- Add new auth for DAs
- Update tests