### PR TITLE
Add search filter for deployment assessments

### DIFF
--- a/backend/src/connectors/audit/Base.ts
+++ b/backend/src/connectors/audit/Base.ts
@@ -434,6 +434,12 @@ export const AuditInfo = {
     auditKind: AuditKind.Create,
     resourceKind: ResourceKind.Review,
   },
+  SearchDeploymentAssessments: {
+    typeId: 'SearchDeploymentAssessments',
+    description: 'Deployment assessments searched',
+    auditKind: AuditKind.Search,
+    resourceKind: ResourceKind.DeploymentAssessment,
+  },
   CreateDeploymentAssessment: {
     typeId: 'CreateDeploymentAssessment',
     description: 'Deployment assessment created',
@@ -557,6 +563,7 @@ export abstract class BaseAuditConnector {
 
   abstract onCreateReview(req: Request, modelId: string): Promise<void>
   abstract onCreateDeploymentAssessment(req: Request, deploymentAssessment: DeploymentAssessmentDoc): Promise<void>
+  abstract onSearchDeploymentAssessments(req: Request, deploymentAssessments: DeploymentAssessmentDoc[]): Promise<void>
   abstract onViewCurrentUserInformation(req: Request, userInformation: GetCurrentUserResponse): Promise<void>
 
   abstract onNotifyReviewers(req: Request, reviewId: string): Promise<void>

--- a/backend/src/connectors/audit/__mocks__/index.ts
+++ b/backend/src/connectors/audit/__mocks__/index.ts
@@ -77,6 +77,7 @@ const audit = {
 
   onCreateReview: vi.fn(),
   onCreateDeploymentAssessment: vi.fn(),
+  onSearchDeploymentAssessments: vi.fn(),
 
   onViewCurrentUserInformation: vi.fn(),
 

--- a/backend/src/connectors/audit/silly.ts
+++ b/backend/src/connectors/audit/silly.ts
@@ -88,6 +88,7 @@ export class SillyAuditConnector extends BaseAuditConnector {
   async onViewMetric(_req: Request): Promise<void> {}
   async onCreateReview(_req: Request, _modelId: string) {}
   async onCreateDeploymentAssessment(_req: Request, _deploymentAssessment: DeploymentAssessmentDoc) {}
+  async onSearchDeploymentAssessments(_req: Request, _deploymentAssessments: DeploymentAssessmentDoc[]) {}
   async onViewCurrentUserInformation(_req: Request, _userInformation: GetCurrentUserResponse): Promise<void> {}
   async onNotifyReviewers(_req: Request, _reviewId: string): Promise<void> {}
   async onRegistryImagePulled(_req: Request, _userDn: string): Promise<void> {}

--- a/backend/src/connectors/audit/stdout.ts
+++ b/backend/src/connectors/audit/stdout.ts
@@ -445,6 +445,15 @@ export class StdoutAuditConnector extends BaseAuditConnector {
     req.log.info(event, req.audit.description)
   }
 
+  async onSearchDeploymentAssessments(req: Request, deploymentAssessments: DeploymentAssessmentDoc[]) {
+    this.checkEventType(AuditInfo.SearchDeploymentAssessments, req)
+    const event = this.generateEvent(req, {
+      url: req.originalUrl,
+      results: deploymentAssessments.map((deploymentAssessment) => deploymentAssessment.id),
+    })
+    req.log.info(event, req.audit.description)
+  }
+
   async onViewCurrentUserInformation(req: Request, userInformation: GetCurrentUserResponse): Promise<void> {
     this.checkEventType(AuditInfo.ViewCurrentUserInformation, req)
     const event = this.generateEvent(req, { userDn: userInformation.user.dn })

--- a/backend/src/connectors/audit/stroom.ts
+++ b/backend/src/connectors/audit/stroom.ts
@@ -501,6 +501,13 @@ export class StroomAuditConnector extends BaseAuditConnector {
     this.auditGenericEvent(req, deploymentAssessment.id)
   }
 
+  async onSearchDeploymentAssessments(req: Request, deploymentAssessments: DeploymentAssessmentDoc[]): Promise<void> {
+    this.auditSearchEvent(
+      req,
+      deploymentAssessments.map((deploymentAssessment) => ({ Id: deploymentAssessment.id })),
+    )
+  }
+
   async onViewCurrentUserInformation(req: Request, userInformation: GetCurrentUserResponse): Promise<void> {
     this.auditGenericEvent(req, userInformation.user.dn)
   }

--- a/backend/src/routes/v3/deploymentAssessment/getDeploymentAssessments.ts
+++ b/backend/src/routes/v3/deploymentAssessment/getDeploymentAssessments.ts
@@ -1,0 +1,87 @@
+import { Request, Response } from 'express'
+
+import { AuditInfo } from '../../../connectors/audit/Base.js'
+import audit from '../../../connectors/audit/index.js'
+import { z } from '../../../lib/zod.js'
+import { DeploymentAssessmentDoc } from '../../../models/DeploymentAssessment.js'
+import { searchDeploymentAssessments } from '../../../services/deploymentAssessment.js'
+import { deploymentAssessmentSummarySchema, registerPath } from '../../../services/specification.js'
+import { coerceArray, parse, strictCoerceBoolean } from '../../../utils/validate.js'
+
+export const getDeploymentAssessmentsSchema = z.object({
+  query: z
+    .object({
+      schemaId: z.string().min(1).optional(),
+      modelIds: coerceArray(z.array(z.string().min(1)).optional()),
+      riskOwner: z.string().min(1).optional(),
+      createdBy: z.string().min(1).optional(),
+      createdAfter: z.string().date().optional(),
+      createdBefore: z.string().date().optional(),
+      draft: strictCoerceBoolean(z.boolean().optional()),
+      search: z.string().min(1).optional(),
+    })
+    .strict()
+    .refine(
+      ({ createdAfter, createdBefore }) =>
+        !createdAfter || !createdBefore || new Date(createdAfter) <= new Date(createdBefore),
+      {
+        message: 'createdAfter must be before or equal to createdBefore',
+        path: ['createdBefore'],
+      },
+    ),
+})
+
+export type DeploymentAssessmentSummary = z.infer<typeof deploymentAssessmentSummarySchema>
+
+function toDeploymentAssessmentSummary(deploymentAssessment: DeploymentAssessmentDoc): DeploymentAssessmentSummary {
+  const { name, riskOwner, modelIds, justification } = deploymentAssessment.metadata.overview
+
+  return {
+    id: deploymentAssessment.id,
+    schemaId: deploymentAssessment.schemaId,
+    name,
+    ...(riskOwner && { owner: riskOwner }),
+    ...(modelIds && { models: modelIds }),
+    ...(justification && { justification }),
+    draft: deploymentAssessment.draft,
+    createdBy: deploymentAssessment.createdBy,
+    createdAt: deploymentAssessment.createdAt.toISOString(),
+  }
+}
+
+registerPath(
+  {
+    method: 'get',
+    path: '/api/v3/deployment-assessments',
+    tags: ['deployment assessments'],
+    description: 'Search deployment assessments',
+    schema: getDeploymentAssessmentsSchema,
+    responses: {
+      200: {
+        description: 'Deployment assessments matching the supplied filters.',
+        content: {
+          'application/json': {
+            schema: z.object({ deploymentAssessments: z.array(deploymentAssessmentSummarySchema) }),
+          },
+        },
+      },
+    },
+  },
+  'v3',
+)
+
+interface GetDeploymentAssessmentsResponse {
+  deploymentAssessments: DeploymentAssessmentSummary[]
+}
+
+export const getDeploymentAssessments = [
+  async (req: Request, res: Response<GetDeploymentAssessmentsResponse>): Promise<void> => {
+    req.audit = AuditInfo.SearchDeploymentAssessments
+    const { query } = parse(req, getDeploymentAssessmentsSchema)
+
+    const deploymentAssessments = await searchDeploymentAssessments(req.user, query)
+    await audit.onSearchDeploymentAssessments(req, deploymentAssessments)
+
+    res.json({ deploymentAssessments: deploymentAssessments.map(toDeploymentAssessmentSummary) })
+  },
+]

--- a/backend/src/routes/v3/deploymentAssessment/postDeploymentAssessment.ts
+++ b/backend/src/routes/v3/deploymentAssessment/postDeploymentAssessment.ts
@@ -5,52 +5,21 @@ import audit from '../../../connectors/audit/index.js'
 import { z } from '../../../lib/zod.js'
 import { DeploymentAssessmentInterface } from '../../../models/DeploymentAssessment.js'
 import { createDeploymentAssessment } from '../../../services/deploymentAssessment.js'
-import { registerPath } from '../../../services/specification.js'
+import {
+  deploymentAssessmentDraftSchema,
+  deploymentAssessmentInterfaceSchema,
+  deploymentAssessmentMetadataSchema,
+  deploymentAssessmentSchemaIdSchema,
+  registerPath,
+} from '../../../services/specification.js'
 import { parse } from '../../../utils/validate.js'
-
-const overview = z
-  .object({
-    name: z
-      .string()
-      .min(1, 'You must provide a deployment assessment name')
-      .openapi({ example: 'Just A Rather Very Intelligent System' }),
-    riskOwner: z.string().min(1, 'You must provide a risk owner').openapi({ example: 'user:tony' }).optional(),
-    justification: z
-      .string()
-      .min(1, 'You must provide a justification')
-      .openapi({ example: 'The risk owner is accountable for the deployed service.' })
-      .optional(),
-    modelIds: z
-      .array(z.string())
-      .openapi({ example: ['ironman-a1b2c3', 'hulkbuster-a1b2c3'] })
-      .optional(),
-  })
-  .passthrough()
-
-const metadata = z.object({ overview }).passthrough()
-
-const schemaId = z
-  .string()
-  .min(1, 'You must provide a schema ID')
-  .openapi({ example: 'stark-deployment-assessment-schema-v1' })
-const draft = z.boolean().openapi({ example: true })
-
-export const deploymentAssessmentInterfaceSchema = z.object({
-  id: z.string().openapi({ example: 'just-a-rather-very-intelligent-system-a1b2c3' }),
-  schemaId,
-  metadata,
-  draft,
-  createdBy: z.string().openapi({ example: 'tony' }),
-  createdAt: z.string().datetime().openapi({ example: new Date().toISOString() }),
-  updatedAt: z.string().datetime().openapi({ example: new Date().toISOString() }),
-})
 
 export const postDeploymentAssessmentSchema = z.object({
   body: z
     .object({
-      schemaId,
-      metadata,
-      draft: draft.optional().default(true),
+      schemaId: deploymentAssessmentSchemaIdSchema,
+      metadata: deploymentAssessmentMetadataSchema,
+      draft: deploymentAssessmentDraftSchema.optional().default(true),
     })
     .strict(),
 })

--- a/backend/src/routes/v3/routes.ts
+++ b/backend/src/routes/v3/routes.ts
@@ -2,6 +2,7 @@ import { Router } from 'express'
 
 import { generateV3SwaggerSpec } from '../../services/specification.js'
 import { getImageByDigest } from '../v3/model/images/getImage.js'
+import { getDeploymentAssessments } from './deploymentAssessment/getDeploymentAssessments.js'
 import { postDeploymentAssessment } from './deploymentAssessment/postDeploymentAssessment.js'
 import { getCurrentUser } from './entities/getCurrentUser.js'
 import { getEntryVolume } from './metrics/getEntryVolume.js'
@@ -22,6 +23,7 @@ router.get('/api-docs/swagger.json', (req, res) => res.json(generateV3SwaggerSpe
 
 router.get('/model/:modelId/image/:name/:tag/:digest', ...getImageByDigest)
 
+router.get('/deployment-assessments', ...getDeploymentAssessments)
 router.post('/deployment-assessments', ...postDeploymentAssessment)
 
 router.get('/metrics/usage', ...getUsageMetrics)

--- a/backend/src/services/deploymentAssessment.ts
+++ b/backend/src/services/deploymentAssessment.ts
@@ -1,3 +1,5 @@
+import { escapeRegExp } from 'lodash-es'
+
 import authentication from '../connectors/authentication/index.js'
 import DeploymentAssessmentModel, {
   DeploymentAssessmentInterface,
@@ -12,6 +14,17 @@ import { BadReq, Conflict } from '../utils/error.js'
 import { convertStringToId } from '../utils/id.js'
 import { isMongoServerError } from '../utils/mongo.js'
 import { getSchemaById, validateContentAgainstSchema } from './schema.js'
+
+export interface SearchDeploymentAssessmentsParams {
+  schemaId?: string
+  modelIds?: string[]
+  riskOwner?: string
+  createdBy?: string
+  createdAfter?: string
+  createdBefore?: string
+  draft?: boolean
+  search?: string
+}
 
 export type CreateDeploymentAssessmentParams = Pick<DeploymentAssessmentInterface, 'schemaId' | 'draft'> & {
   metadata: unknown
@@ -107,4 +120,40 @@ export async function createDeploymentAssessment(user: UserInterface, params: Cr
   }
 
   return deploymentAssessment
+}
+
+export async function searchDeploymentAssessments(user: UserInterface, params: SearchDeploymentAssessmentsParams) {
+  const query: Record<string, unknown> = {
+    $and: [{ $or: [{ draft: false }, { draft: true, createdBy: user.dn }] }],
+  }
+
+  if (params.schemaId) {
+    query.schemaId = params.schemaId
+  }
+  if (params.modelIds?.length) {
+    query['metadata.overview.modelIds'] = { $all: params.modelIds }
+  }
+  if (params.riskOwner) {
+    query['metadata.overview.riskOwner'] = params.riskOwner
+  }
+  if (params.createdBy) {
+    query.createdBy = params.createdBy
+  }
+  if (params.createdAfter || params.createdBefore) {
+    const beforeDate = params.createdBefore ? new Date(params.createdBefore) : undefined
+    beforeDate?.setUTCDate(beforeDate.getUTCDate() + 1)
+
+    query.createdAt = {
+      ...(params.createdAfter && { $gte: new Date(params.createdAfter) }),
+      ...(beforeDate && { $lt: beforeDate }),
+    }
+  }
+  if (params.draft !== undefined) {
+    query.draft = params.draft
+  }
+  if (params.search) {
+    query['metadata.overview.name'] = { $regex: escapeRegExp(params.search), $options: 'i' }
+  }
+
+  return DeploymentAssessmentModel.find(query).sort({ draft: -1, updatedAt: -1 })
 }

--- a/backend/src/services/deploymentAssessment.ts
+++ b/backend/src/services/deploymentAssessment.ts
@@ -1,4 +1,5 @@
 import { escapeRegExp } from 'lodash-es'
+import { QueryFilter } from 'mongoose'
 
 import authentication from '../connectors/authentication/index.js'
 import { DeploymentAssessmentAction } from '../connectors/authorisation/actions.js'
@@ -145,9 +146,7 @@ export async function createDeploymentAssessment(user: UserInterface, params: Cr
 }
 
 export async function searchDeploymentAssessments(user: UserInterface, params: SearchDeploymentAssessmentsParams) {
-  const query: Record<string, unknown> = {
-    $and: [{ $or: [{ draft: false }, { draft: true, createdBy: user.dn }] }],
-  }
+  const query: QueryFilter<DeploymentAssessmentInterface> = {}
 
   if (params.schemaId) {
     query.schemaId = params.schemaId
@@ -174,8 +173,12 @@ export async function searchDeploymentAssessments(user: UserInterface, params: S
     query.draft = params.draft
   }
   if (params.search) {
-    query['metadata.overview.name'] = { $regex: escapeRegExp(params.search), $options: 'i' }
+    const search = { $regex: escapeRegExp(params.search), $options: 'i' }
+    query.$and = [{ $or: [{ 'metadata.overview.name': search }, { 'metadata.overview.justification': search }] }]
   }
 
-  return DeploymentAssessmentModel.find(query).sort({ draft: -1, updatedAt: -1 })
+  const deploymentAssessments = await DeploymentAssessmentModel.find(query).sort({ draft: -1, updatedAt: -1 })
+  const auths = await authorisation.deploymentAssessments(user, deploymentAssessments, DeploymentAssessmentAction.View)
+
+  return deploymentAssessments.filter((_, i) => auths[i].success)
 }

--- a/backend/src/services/specification.ts
+++ b/backend/src/services/specification.ts
@@ -57,6 +57,63 @@ export const errorSchemaContent = {
   },
 }
 
+const deploymentAssessmentIdSchema = z.string().openapi({ example: 'just-a-rather-very-intelligent-system-a1b2c3' })
+export const deploymentAssessmentSchemaIdSchema = z
+  .string()
+  .min(1, 'You must provide a schema ID')
+  .openapi({ example: 'stark-deployment-assessment-schema-v1' })
+const deploymentAssessmentNameSchema = z
+  .string()
+  .min(1, 'You must provide a deployment assessment name')
+  .openapi({ example: 'Just A Rather Very Intelligent System' })
+const deploymentAssessmentRiskOwnerSchema = z
+  .string()
+  .min(1, 'You must provide a risk owner')
+  .openapi({ example: 'user:tony' })
+const deploymentAssessmentJustificationSchema = z
+  .string()
+  .min(1, 'You must provide a risk owner justification')
+  .openapi({ example: 'Tony Stark is Iron Man.' })
+const deploymentAssessmentModelIdsSchema = z
+  .array(z.string())
+  .openapi({ example: ['ironman-a1b2c3', 'hulkbuster-a1b2c3'] })
+export const deploymentAssessmentDraftSchema = z.boolean().openapi({ example: true })
+
+export const deploymentAssessmentMetadataSchema = z
+  .object({
+    overview: z
+      .object({
+        name: deploymentAssessmentNameSchema,
+        riskOwner: deploymentAssessmentRiskOwnerSchema.optional(),
+        justification: deploymentAssessmentJustificationSchema.optional(),
+        modelIds: deploymentAssessmentModelIdsSchema.optional(),
+      })
+      .passthrough(),
+  })
+  .passthrough()
+
+export const deploymentAssessmentInterfaceSchema = z.object({
+  id: deploymentAssessmentIdSchema,
+  schemaId: deploymentAssessmentSchemaIdSchema,
+  metadata: deploymentAssessmentMetadataSchema,
+  draft: deploymentAssessmentDraftSchema,
+  createdBy: z.string().openapi({ example: 'tony' }),
+  createdAt: z.string().datetime().openapi({ example: new Date().toISOString() }),
+  updatedAt: z.string().datetime().openapi({ example: new Date().toISOString() }),
+})
+
+export const deploymentAssessmentSummarySchema = z.object({
+  id: deploymentAssessmentIdSchema,
+  schemaId: deploymentAssessmentSchemaIdSchema,
+  name: deploymentAssessmentNameSchema,
+  owner: deploymentAssessmentRiskOwnerSchema.optional(),
+  models: deploymentAssessmentModelIdsSchema.optional(),
+  justification: deploymentAssessmentJustificationSchema.optional(),
+  draft: deploymentAssessmentDraftSchema,
+  createdBy: z.string().openapi({ example: 'tony' }),
+  createdAt: z.string().datetime().openapi({ example: new Date().toISOString() }),
+})
+
 export const systemStatusSchema = z.object({
   code: z.number().openapi({ example: 200 }),
   ping: z.string().openapi({ example: 'pong' }),

--- a/backend/src/services/specification.ts
+++ b/backend/src/services/specification.ts
@@ -92,16 +92,6 @@ export const deploymentAssessmentMetadataSchema = z
   })
   .passthrough()
 
-export const deploymentAssessmentInterfaceSchema = z.object({
-  id: deploymentAssessmentIdSchema,
-  schemaId: deploymentAssessmentSchemaIdSchema,
-  metadata: deploymentAssessmentMetadataSchema,
-  draft: deploymentAssessmentDraftSchema,
-  createdBy: z.string().openapi({ example: 'tony' }),
-  createdAt: z.string().datetime().openapi({ example: new Date().toISOString() }),
-  updatedAt: z.string().datetime().openapi({ example: new Date().toISOString() }),
-})
-
 export const deploymentAssessmentSummarySchema = z.object({
   id: deploymentAssessmentIdSchema,
   schemaId: deploymentAssessmentSchemaIdSchema,

--- a/backend/test/routes/v3/deploymentAssessment/getDeploymentAssessments.spec.ts
+++ b/backend/test/routes/v3/deploymentAssessment/getDeploymentAssessments.spec.ts
@@ -1,0 +1,114 @@
+import { describe, expect, test, vi } from 'vitest'
+
+import audit from '../../../../src/connectors/audit/__mocks__/index.js'
+import { testGet } from '../../../testUtils/routes.js'
+
+vi.mock('../../../../src/connectors/audit/index.js')
+
+const deploymentAssessment = {
+  _id: 'mongo-object-id',
+  __v: 1,
+  id: 'assessment-abc123',
+  schemaId: 'deployment-assessment-schema',
+  metadata: {
+    overview: {
+      name: 'Assessment',
+      riskOwner: 'user:risk-owner',
+      justification: 'Owns the deployment risk.',
+      modelIds: ['model-one', 'model-two'],
+    },
+    deletedInformation: 'must not be returned',
+  },
+  draft: false,
+  createdBy: 'creator',
+  createdAt: new Date('2026-01-01T00:00:00.000Z'),
+  updatedAt: new Date('2026-01-02T00:00:00.000Z'),
+  deletedAt: new Date('2026-01-03T00:00:00.000Z'),
+}
+
+const serviceMock = vi.hoisted(() => ({
+  searchDeploymentAssessments: vi.fn(),
+}))
+vi.mock('../../../../src/services/deploymentAssessment.js', () => serviceMock)
+
+describe('routes > deploymentAssessment > getDeploymentAssessments', () => {
+  test('searches deployment assessments using all filters', async () => {
+    serviceMock.searchDeploymentAssessments.mockResolvedValueOnce([deploymentAssessment])
+
+    const res = await testGet(
+      '/api/v3/deployment-assessments?schemaId=deployment-assessment-schema&modelIds=model-one&modelIds=model-two&riskOwner=user%3Arisk-owner&createdBy=creator&createdAfter=2026-01-01&createdBefore=2026-01-31&draft=false&search=deployment%20justification',
+    )
+
+    expect(res.statusCode).toBe(200)
+    expect(serviceMock.searchDeploymentAssessments).toHaveBeenCalledWith(expect.anything(), {
+      schemaId: 'deployment-assessment-schema',
+      modelIds: ['model-one', 'model-two'],
+      riskOwner: 'user:risk-owner',
+      createdBy: 'creator',
+      createdAfter: '2026-01-01',
+      createdBefore: '2026-01-31',
+      draft: false,
+      search: 'deployment justification',
+    })
+    expect(res.body).toEqual({
+      deploymentAssessments: [
+        {
+          id: 'assessment-abc123',
+          schemaId: 'deployment-assessment-schema',
+          name: 'Assessment',
+          owner: 'user:risk-owner',
+          models: ['model-one', 'model-two'],
+          justification: 'Owns the deployment risk.',
+          draft: false,
+          createdBy: 'creator',
+          createdAt: '2026-01-01T00:00:00.000Z',
+        },
+      ],
+    })
+    expect(audit.onSearchDeploymentAssessments).toHaveBeenCalledWith(expect.anything(), [deploymentAssessment])
+  })
+
+  test('supports a single model filter', async () => {
+    serviceMock.searchDeploymentAssessments.mockResolvedValueOnce([])
+
+    const res = await testGet('/api/v3/deployment-assessments?modelIds=model-one')
+
+    expect(res.statusCode).toBe(200)
+    expect(serviceMock.searchDeploymentAssessments).toHaveBeenCalledWith(expect.anything(), { modelIds: ['model-one'] })
+  })
+
+  test.each([
+    ['createdAfter', '2026-01-01', { createdAfter: '2026-01-01' }],
+    ['createdBefore', '2026-01-31', { createdBefore: '2026-01-31' }],
+  ])('supports a creation window with only %s', async (parameter, value, expectedQuery) => {
+    serviceMock.searchDeploymentAssessments.mockResolvedValueOnce([])
+
+    const res = await testGet(`/api/v3/deployment-assessments?${parameter}=${value}`)
+
+    expect(res.statusCode).toBe(200)
+    expect(serviceMock.searchDeploymentAssessments).toHaveBeenCalledWith(expect.anything(), expectedQuery)
+  })
+
+  test('rejects a reversed creation window', async () => {
+    const res = await testGet('/api/v3/deployment-assessments?createdAfter=2026-02-01&createdBefore=2026-01-01')
+
+    expect(res.statusCode).toBe(400)
+    expect(serviceMock.searchDeploymentAssessments).not.toHaveBeenCalled()
+  })
+
+  test.each([
+    'schemaId=',
+    'riskOwner=',
+    'createdBy=',
+    'createdAfter=invalid',
+    'createdBefore=2026-01-01T00%3A00%3A00.000Z',
+    'draft=invalid',
+    'search=',
+    'unknown=value',
+  ])('rejects the malformed query %s', async (query) => {
+    const res = await testGet(`/api/v3/deployment-assessments?${query}`)
+
+    expect(res.statusCode).toBe(400)
+    expect(serviceMock.searchDeploymentAssessments).not.toHaveBeenCalled()
+  })
+})

--- a/backend/test/services/deploymentAssessment.spec.ts
+++ b/backend/test/services/deploymentAssessment.spec.ts
@@ -245,7 +245,7 @@ describe('services > deploymentAssessment', () => {
         deploymentAssessments,
         'deployment_assessment:view',
       )
-      expect(result).toBe(deploymentAssessments)
+      expect(result).toStrictEqual(deploymentAssessments)
     })
 
     test('combines model, risk owner, creator, creation window, and name filters', async () => {

--- a/backend/test/services/deploymentAssessment.spec.ts
+++ b/backend/test/services/deploymentAssessment.spec.ts
@@ -304,15 +304,16 @@ describe('services > deploymentAssessment', () => {
         createdAt: expectedCreatedAt,
       })
     })
-  test('rejects a non-draft assessment without a risk owner', async () => {
-    const metadata = {
-      overview: {
-        name: 'Submitted assessment',
-      },
-    }
+    test('rejects a non-draft assessment without a risk owner', async () => {
+      const metadata = {
+        overview: {
+          name: 'Submitted assessment',
+        },
+      }
 
-    await expect(createDeploymentAssessment({ dn: 'creator' }, { ...params, draft: false, metadata })).rejects.toThrow(
-      'Deployment risk owner is required',
-    )
+      await expect(
+        createDeploymentAssessment({ dn: 'creator' }, { ...params, draft: false, metadata }),
+      ).rejects.toThrow('Deployment risk owner is required')
+    })
   })
 })

--- a/backend/test/services/deploymentAssessment.spec.ts
+++ b/backend/test/services/deploymentAssessment.spec.ts
@@ -234,19 +234,24 @@ describe('services > deploymentAssessment', () => {
       const deploymentAssessments = [{ id: 'assessment-one' }]
       const sort = vi.fn().mockResolvedValue(deploymentAssessments)
       DeploymentAssessmentModelMock.find.mockReturnValueOnce({ sort })
+      vi.mocked(authorisation.deploymentAssessments).mockResolvedValueOnce([{ success: true, id: 'assessment-one' }])
 
       const result = await searchDeploymentAssessments({ dn: 'creator' }, {})
 
-      expect(DeploymentAssessmentModelMock.find).toHaveBeenCalledWith({
-        $and: [{ $or: [{ draft: false }, { draft: true, createdBy: 'creator' }] }],
-      })
+      expect(DeploymentAssessmentModelMock.find).toHaveBeenCalledWith({})
       expect(sort).toHaveBeenCalledWith({ draft: -1, updatedAt: -1 })
+      expect(authorisation.deploymentAssessments).toHaveBeenCalledWith(
+        { dn: 'creator' },
+        deploymentAssessments,
+        'deployment_assessment:view',
+      )
       expect(result).toBe(deploymentAssessments)
     })
 
     test('combines model, risk owner, creator, creation window, and name filters', async () => {
       const sort = vi.fn().mockResolvedValue([])
       DeploymentAssessmentModelMock.find.mockReturnValueOnce({ sort })
+      vi.mocked(authorisation.deploymentAssessments).mockResolvedValueOnce([])
 
       await searchDeploymentAssessments(
         { dn: 'creator' },
@@ -263,7 +268,6 @@ describe('services > deploymentAssessment', () => {
       )
 
       expect(DeploymentAssessmentModelMock.find).toHaveBeenCalledWith({
-        $and: [{ $or: [{ draft: false }, { draft: true, createdBy: 'creator' }] }],
         schemaId: 'deployment-assessment-schema',
         'metadata.overview.modelIds': { $all: ['model-one', 'model-two'] },
         'metadata.overview.riskOwner': 'user:risk-owner',
@@ -273,7 +277,14 @@ describe('services > deploymentAssessment', () => {
           $lt: new Date('2026-02-01T00:00:00.000Z'),
         },
         draft: true,
-        'metadata.overview.name': { $regex: 'Assessment\\.\\*', $options: 'i' },
+        $and: [
+          {
+            $or: [
+              { 'metadata.overview.name': { $regex: 'Assessment\\.\\*', $options: 'i' } },
+              { 'metadata.overview.justification': { $regex: 'Assessment\\.\\*', $options: 'i' } },
+            ],
+          },
+        ],
       })
       expect(sort).toHaveBeenCalledWith({ draft: -1, updatedAt: -1 })
     })
@@ -284,11 +295,11 @@ describe('services > deploymentAssessment', () => {
     ])('supports a creation window with only a %s boundary', async (_boundary, params, expectedCreatedAt) => {
       const sort = vi.fn().mockResolvedValue([])
       DeploymentAssessmentModelMock.find.mockReturnValueOnce({ sort })
+      vi.mocked(authorisation.deploymentAssessments).mockResolvedValueOnce([])
 
       await searchDeploymentAssessments({ dn: 'creator' }, params)
 
       expect(DeploymentAssessmentModelMock.find).toHaveBeenCalledWith({
-        $and: [{ $or: [{ draft: false }, { draft: true, createdBy: 'creator' }] }],
         createdAt: expectedCreatedAt,
       })
     })

--- a/backend/test/services/deploymentAssessment.spec.ts
+++ b/backend/test/services/deploymentAssessment.spec.ts
@@ -3,7 +3,7 @@ import { beforeEach, describe, expect, test, vi } from 'vitest'
 
 import authentication from '../../src/connectors/authentication/index.js'
 import { EntryKind, EntryVisibility } from '../../src/models/Model.js'
-import { createDeploymentAssessment } from '../../src/services/deploymentAssessment.js'
+import { createDeploymentAssessment, searchDeploymentAssessments } from '../../src/services/deploymentAssessment.js'
 import { SchemaKind } from '../../src/types/enums.js'
 import { getTypedModelMock } from '../testUtils/setupMongooseModelMocks.js'
 
@@ -167,5 +167,70 @@ describe('services > deploymentAssessment', () => {
     DeploymentAssessmentModelMock.save.mockRejectedValueOnce(mongoError)
 
     await expect(createDeploymentAssessment({ dn: 'creator' }, params)).rejects.toMatchObject({ code: 409 })
+  })
+
+  describe('searchDeploymentAssessments', () => {
+    test('returns visible deployment assessments ordered by draft status and most recently updated', async () => {
+      const deploymentAssessments = [{ id: 'assessment-one' }]
+      const sort = vi.fn().mockResolvedValue(deploymentAssessments)
+      DeploymentAssessmentModelMock.find.mockReturnValueOnce({ sort })
+
+      const result = await searchDeploymentAssessments({ dn: 'creator' }, {})
+
+      expect(DeploymentAssessmentModelMock.find).toHaveBeenCalledWith({
+        $and: [{ $or: [{ draft: false }, { draft: true, createdBy: 'creator' }] }],
+      })
+      expect(sort).toHaveBeenCalledWith({ draft: -1, updatedAt: -1 })
+      expect(result).toBe(deploymentAssessments)
+    })
+
+    test('combines model, risk owner, creator, creation window, and name filters', async () => {
+      const sort = vi.fn().mockResolvedValue([])
+      DeploymentAssessmentModelMock.find.mockReturnValueOnce({ sort })
+
+      await searchDeploymentAssessments(
+        { dn: 'creator' },
+        {
+          schemaId: 'deployment-assessment-schema',
+          modelIds: ['model-one', 'model-two'],
+          riskOwner: 'user:risk-owner',
+          createdBy: 'creator',
+          createdAfter: '2026-01-01',
+          createdBefore: '2026-01-31',
+          draft: true,
+          search: 'Assessment.*',
+        },
+      )
+
+      expect(DeploymentAssessmentModelMock.find).toHaveBeenCalledWith({
+        $and: [{ $or: [{ draft: false }, { draft: true, createdBy: 'creator' }] }],
+        schemaId: 'deployment-assessment-schema',
+        'metadata.overview.modelIds': { $all: ['model-one', 'model-two'] },
+        'metadata.overview.riskOwner': 'user:risk-owner',
+        createdBy: 'creator',
+        createdAt: {
+          $gte: new Date('2026-01-01T00:00:00.000Z'),
+          $lt: new Date('2026-02-01T00:00:00.000Z'),
+        },
+        draft: true,
+        'metadata.overview.name': { $regex: 'Assessment\\.\\*', $options: 'i' },
+      })
+      expect(sort).toHaveBeenCalledWith({ draft: -1, updatedAt: -1 })
+    })
+
+    test.each([
+      ['after', { createdAfter: '2026-01-01' }, { $gte: new Date('2026-01-01T00:00:00.000Z') }],
+      ['before', { createdBefore: '2026-01-31' }, { $lt: new Date('2026-02-01T00:00:00.000Z') }],
+    ])('supports a creation window with only a %s boundary', async (_boundary, params, expectedCreatedAt) => {
+      const sort = vi.fn().mockResolvedValue([])
+      DeploymentAssessmentModelMock.find.mockReturnValueOnce({ sort })
+
+      await searchDeploymentAssessments({ dn: 'creator' }, params)
+
+      expect(DeploymentAssessmentModelMock.find).toHaveBeenCalledWith({
+        $and: [{ $or: [{ draft: false }, { draft: true, createdBy: 'creator' }] }],
+        createdAt: expectedCreatedAt,
+      })
+    })
   })
 })


### PR DESCRIPTION
Add a search filter for deployment assessments. 

This includes filters on:
- Schemas
- Models
- DROs
- Authors
- When the DA was created
- Drafts
- Partial case insensitive matches on the name

*Drafts are not searchable to non-authors, to encourage accurate documentation of deployments*