### PR TITLE
Switch Python lint & format to `ruff`

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -6,19 +6,15 @@
   "customizations": {
     "vscode": {
       "extensions": [
+        "charliermarsh.ruff",
         "DavidAnson.vscode-markdownlint",
         "dbaeumer.vscode-eslint",
         "editorconfig.editorconfig",
         "esbenp.prettier-vscode",
         "mongodb.mongodb-vscode",
         "ms-azuretools.vscode-docker",
-        "ms-python.black-formatter",
         "ms-python.debugpy",
-        "ms-python.flake8",
-        "ms-python.isort",
-        "ms-python.pylint",
         "ms-python.python",
-        "ms-python.vscode-pylance",
         "ms-python.vscode-python-envs",
         "ms-toolsai.jupyter",
         "ms-toolsai.jupyter-keymap",

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -29,9 +29,6 @@ jobs:
     needs: changes
     if: github.ref == 'refs/heads/main' || needs.changes.outputs.relevant == 'true'
     runs-on: ubuntu-latest
-    outputs:
-      black: ${{ steps.black.outputs.status }}
-      pylint: ${{ steps.pylint.outputs.status }}
 
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -55,18 +52,16 @@ jobs:
           cd lib/python
           python -m pip install -e .[test]
 
-      # Black
       - name: Check formatting
         run: |
           cd lib/python
-          black --check --verbose . || echo "black_check=false"
+          ruff format --check .
         continue-on-error: true
 
-      # Pylint
       - name: Check linting
         run: |
           cd lib/python
-          pylint src/bailo --verbose --exit-zero --fail-on=F,E || echo "pylint_error=false"
+          ruff check src/bailo
         continue-on-error: true
 
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -22,7 +22,7 @@ repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.16.3
     hooks:
-      - id: ruff
+      - id: ruff-check
         args: ['--fix']
       - id: ruff-format
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -19,31 +19,12 @@ repos:
       - id: requirements-txt-fixer
       - id: trailing-whitespace
 
-  - repo: https://github.com/PyCQA/isort
-    rev: 8.0.1
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.16.3
     hooks:
-      - id: isort
-        args: ['-a', 'from __future__ import annotations', '-l', '120']
-
-  - repo: https://github.com/asottile/pyupgrade
-    rev: v3.21.2
-    hooks:
-      - id: pyupgrade
-        name: pyupgrade 3.10
-        args: ['--py310-plus']
-        exclude: backend/docs/
-      - id: pyupgrade
-        name: pyupgrade 3.12
-        args: ['--py312-plus']
-        # backend/docs/ has a newer minimum python version due to sphinx
-        files: backend/docs/
-
-  - repo: https://github.com/hadialqattan/pycln
-    rev: v2.6.0
-    hooks:
-      - id: pycln
-        args: [--config=lib/python/pyproject.toml]
-        stages: [manual]
+      - id: ruff
+        args: ['--fix']
+      - id: ruff-format
 
   - repo: https://github.com/codespell-project/codespell
     rev: v2.4.3
@@ -63,9 +44,3 @@ repos:
       - id: rst-backticks
       - id: rst-directive-colons
       - id: rst-inline-touching-normal
-
-  - repo: https://github.com/psf/black-pre-commit-mirror
-    rev: 26.5.1
-    hooks:
-      - id: black-jupyter
-        args: ['--config', 'lib/python/pyproject.toml']

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -20,7 +20,7 @@ repos:
       - id: trailing-whitespace
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.16.3
+    rev: v0.16.4
     hooks:
       - id: ruff-check
         args: ['--fix']

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,18 +1,15 @@
 {
   "recommendations": [
+    "charliermarsh.ruff",
+    "timonwong.shellcheck",
     "davidanson.vscode-markdownlint",
     "dbaeumer.vscode-eslint",
     "editorconfig.editorconfig",
     "esbenp.prettier-vscode",
     "mongodb.mongodb-vscode",
     "ms-azuretools.vscode-docker",
-    "ms-python.black-formatter",
     "ms-python.debugpy",
-    "ms-python.flake8",
-    "ms-python.isort",
-    "ms-python.pylint",
     "ms-python.python",
-    "ms-python.vscode-pylance",
     "ms-python.vscode-python-envs",
     "ms-toolsai.jupyter",
     "ms-toolsai.jupyter-keymap",
@@ -22,6 +19,5 @@
     "shardulm94.trailing-spaces",
     "streetsidesoftware.code-spell-checker",
     "tamasfe.even-better-toml",
-    "timonwong.shellcheck",
   ]
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -10,22 +10,9 @@
   "javascript.preferences.importModuleSpecifier": "non-relative",
   "typescript.preferences.importModuleSpecifier": "non-relative",
   "[python]": {
-    "editor.defaultFormatter": "ms-python.black-formatter"
+    "editor.defaultFormatter": "charliermarsh.ruff"
   },
-  "python.analysis.typeCheckingMode": "basic",
   "python.defaultInterpreterPath": "/usr/local/bin/python",
   "python.testing.unittestEnabled": false,
   "python.testing.pytestEnabled": true,
-  "pylint.args": [
-    "--rcfile=lib/python/pyproject.toml"
-  ],
-  "black-formatter.args": [
-    "--config=lib/python/pyproject.toml"
-  ],
-  "flake8.args": [
-    "--toml-config=lib/python/pyproject.toml"
-  ],
-  "isort.args": [
-    "--settings-path=lib/python/pyproject.toml"
-  ],
 }

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -74,8 +74,8 @@ pip install -e .[test]
 - Unit tests: `pytest`
 - Integration tests: `pytest -m integration` (requires Bailo running on `https://localhost:8080`)
 - MLFlow tests: `pytest -m mlflow`
-- Format check: `black --check .`
-- Lint: `pylint bailo`
+- Format check: `ruff format --check .`
+- Lint: `ruff check src/bailo`
 
 ### ArtefactScan API (`lib/artefactscan_api/`)
 
@@ -105,8 +105,7 @@ pip install -e ".[dev]"
 
 ### Python
 
-- **Black** for formatting (line-length 120). Do not manually override.
-- **pylint** for linting. Follow **PEP 8** where not overridden by Black.
+- **ruff** for formatting and linting (line-length 120). Configuration in root `ruff.toml`.
 - Use **reStructuredText (reST)** format for docstrings.
 - Add inline comments only where the code is non-obvious.
 
@@ -157,7 +156,7 @@ All PRs to `main` must pass these `.github/workflows/` checks:
 
 Path-filtered (only run when relevant files change):
 
-9. **Python static checks** - `black --check` + `pylint` (when `lib/python/` changes)
+9. **Python static checks** - `ruff format --check` + `ruff check` (when `lib/python/` changes)
 10. **Python unit tests** - pytest across Python 3.10-3.14 (when `lib/python/` changes)
 11. **ArtefactScan tests** - pytest (when `lib/artefactscan_api/` changes)
 12. **Docs style** - `frontend/scripts/check-docs-style.sh` (when `frontend/pages/docs/**/*.mdx` changes)

--- a/backend/docs/README.md
+++ b/backend/docs/README.md
@@ -56,4 +56,4 @@ Run either `make html` (Linux & Mac) or `make.bat` (Windows). This will build th
 
 #### Notebook Formatting
 
-Notebook files are automatically normalized on commit via a pre-commit hook using black. This ensures `source` fields use the canonical array-of-lines format, as well as maintaining consistent styling with `lib/python`.
+Notebook files are automatically normalised on commit via a pre-commit hook using ruff. This ensures `source` fields use the canonical array-of-lines format, as well as maintaining consistent styling with `lib/python`.

--- a/backend/docs/notebooks/access_requests_demo.ipynb
+++ b/backend/docs/notebooks/access_requests_demo.ipynb
@@ -54,7 +54,9 @@
    "outputs": [],
    "source": [
     "# Necessary import statements\n",
-    "from bailo import AccessRequest, Model, Client, PkiAgent\n",
+    "from __future__ import annotations\n",
+    "\n",
+    "from bailo import AccessRequest, Client, Model\n",
     "\n",
     "# Instantiating the PkiAgent(), if using.\n",
     "from bailo import PkiAgent\n",

--- a/backend/docs/notebooks/datacards_demo.ipynb
+++ b/backend/docs/notebooks/datacards_demo.ipynb
@@ -52,10 +52,12 @@
    "outputs": [],
    "source": [
     "# Install dependencies...\n",
+    "from __future__ import annotations\n",
+    "\n",
     "! pip install bailo\n",
     "\n",
     "# Necessary import statements\n",
-    "from bailo import Datacard, Client\n",
+    "from bailo import Client, Datacard\n",
     "from bailo.core.exceptions import BailoException\n",
     "\n",
     "# Instantiating the PkiAgent(), if using.\n",

--- a/backend/docs/notebooks/experiment_tracking_demo.ipynb
+++ b/backend/docs/notebooks/experiment_tracking_demo.ipynb
@@ -48,6 +48,8 @@
    "outputs": [],
    "source": [
     "# Install dependencies...\n",
+    "from __future__ import annotations\n",
+    "\n",
     "! pip install bailo[mlflow]"
    ]
   },
@@ -58,9 +60,11 @@
    "outputs": [],
    "source": [
     "# Necessary import statements\n",
-    "from bailo import Model, Client, Experiment, Schema, SchemaKind\n",
-    "import mlflow\n",
     "import random\n",
+    "\n",
+    "import mlflow\n",
+    "\n",
+    "from bailo import Client, Model, Schema, SchemaKind\n",
     "\n",
     "# Instantiating the PkiAgent(), if using.\n",
     "from bailo import PkiAgent\n",
@@ -196,7 +200,7 @@
     "    \"accuracy\": 0.98,\n",
     "}\n",
     "\n",
-    "for x in range(5):\n",
+    "for _x in range(5):\n",
     "    experiment.start_run()\n",
     "    experiment.log_params(params)\n",
     "    experiment.log_metrics(metrics)\n",

--- a/backend/docs/notebooks/models_and_releases_demo_pytorch.ipynb
+++ b/backend/docs/notebooks/models_and_releases_demo_pytorch.ipynb
@@ -56,6 +56,8 @@
    "outputs": [],
    "source": [
     "# LINUX - CPU\n",
+    "from __future__ import annotations\n",
+    "\n",
     "! pip install bailo torch torchvision --index-url https://download.pytorch.org/whl/cpu\n",
     "\n",
     "# MAC & WINDOWS  - CPU\n",
@@ -69,10 +71,11 @@
    "outputs": [],
    "source": [
     "# Necessary import statements\n",
-    "from bailo import Model, Client\n",
-    "from bailo.core.exceptions import BailoException\n",
     "import torch\n",
-    "from torchvision.models import resnet50, ResNet50_Weights\n",
+    "\n",
+    "from bailo import Client, Model\n",
+    "from bailo.core.exceptions import BailoException\n",
+    "from torchvision.models import ResNet50_Weights, resnet50\n",
     "\n",
     "# Instantiating the PkiAgent(), if using.\n",
     "from bailo import PkiAgent\n",

--- a/backend/docs/notebooks/quickstart_demo.ipynb
+++ b/backend/docs/notebooks/quickstart_demo.ipynb
@@ -55,7 +55,9 @@
    "outputs": [],
    "source": [
     "# Necessary import statements\n",
-    "from bailo import Model, Client\n",
+    "from __future__ import annotations\n",
+    "\n",
+    "from bailo import Client, Model\n",
     "\n",
     "# Instantiating the PkiAgent(), if using.\n",
     "from bailo import PkiAgent\n",
@@ -326,8 +328,6 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from io import BytesIO\n",
-    "\n",
     "# Create some sample data (in practice, this would be a large file read in chunks)\n",
     "file_data = b\"x\" * 2048  # 2 KB of sample data\n",
     "file_size = len(file_data)\n",

--- a/backend/docs/notebooks/schemas_demo.ipynb
+++ b/backend/docs/notebooks/schemas_demo.ipynb
@@ -52,9 +52,12 @@
    "outputs": [],
    "source": [
     "# Necessary import statements\n",
-    "from bailo import Client, Schema, SchemaKind\n",
+    "from __future__ import annotations\n",
+    "\n",
     "import random\n",
     "import string\n",
+    "\n",
+    "from bailo import Client, Schema, SchemaKind\n",
     "\n",
     "# Instantiating the PkiAgent(), if using.\n",
     "from bailo import PkiAgent\n",

--- a/backend/docs/pyproject.toml
+++ b/backend/docs/pyproject.toml
@@ -19,6 +19,7 @@ dependencies = [
 [project.optional-dependencies]
 dev = [
     "pre-commit==4.6.2",
+    "ruff==0.16.3",
 ]
 
 [tool.setuptools]

--- a/backend/docs/pyproject.toml
+++ b/backend/docs/pyproject.toml
@@ -20,7 +20,7 @@ dependencies = [
 [project.optional-dependencies]
 dev = [
     "pre-commit==4.6.2",
-    "ruff==0.16.3",
+    "ruff==0.16.4",
 ]
 
 [tool.setuptools]

--- a/lib/artefactscan_api/bailo_artefactscan_api/config.py
+++ b/lib/artefactscan_api/bailo_artefactscan_api/config.py
@@ -19,7 +19,8 @@ class Settings(BaseSettings):
     app_name: str = "Bailo ArtefactScan API"
     app_summary: str = "API for scanning files and container image layers for security threats and vulnerabilities."
     app_description: str = (
-        "The Bailo ArtefactScan API provides programmatic scanning capabilities for artefacts submitted to Bailo. It integrates:\n"
+        "The Bailo ArtefactScan API provides programmatic scanning capabilities for artefacts"
+        " submitted to Bailo. It integrates:\n"
         "* **ProtectAI ModelScan** for detecting malicious or unsafe content within uploaded files.\n"
         "* **Aqua Trivy vulnerability database** for identifying known vulnerabilities in container image layers.\n"
         "\n"

--- a/lib/artefactscan_api/bailo_artefactscan_api/main.py
+++ b/lib/artefactscan_api/bailo_artefactscan_api/main.py
@@ -17,9 +17,7 @@ from content_size_limit_asgi import ContentSizeLimitMiddleware
 from fastapi import BackgroundTasks, Depends, FastAPI, HTTPException, UploadFile
 from modelscan.modelscan import ModelScan
 
-# isort: split
-
-import bailo_artefactscan_api.trivy as trivy
+from bailo_artefactscan_api import trivy
 from bailo_artefactscan_api.config import Settings
 from bailo_artefactscan_api.modelscan import extract_supported_file_types, is_valid_pickle
 from bailo_artefactscan_api.openapi.scan_file_responses import SCAN_FILE_RESPONSES
@@ -39,7 +37,7 @@ def get_settings() -> Settings:
 
 
 class CustomMiddlewareHTTPExceptionWrapper(HTTPException):
-    """Wrapper of HTTPException to make ContentSizeLimitMiddleware raise HTTPException status_code 413 which FastAPI can capture and return."""
+    """ContentSizeLimitMiddleware wrapper that raises HTTPException with status 413."""
 
     def __init__(self, detail):
         super().__init__(status_code=HTTPStatus.REQUEST_ENTITY_TOO_LARGE.value, detail=detail)
@@ -98,7 +96,10 @@ async def info(settings: Annotated[Settings, Depends(get_settings)]) -> ApiInfor
 @app.post(
     "/scan/file",
     summary="Scan a file for security threats",
-    description="Upload a file to be analysed using ProtectAI ModelScan. The endpoint returns the results of the threat detection scan.",
+    description=(
+        "Upload a file to be analysed using ProtectAI ModelScan."
+        " The endpoint returns the results of the threat detection scan."
+    ),
     tags=["Scan"],
     status_code=HTTPStatus.OK.value,
     response_description="The result from ModelScan",
@@ -148,8 +149,9 @@ def scan_file(
             # false positive e.g. "license.dat"
             new_file_path = file_path.with_suffix(".txt")
             logger.info(
-                "File %s is not a pickle but extension is in the ModelScan config `scanners.PickleUnsafeOpScan.supported_extensions` "
-                "file extensions. Renaming from %s to %s",
+                "File %s is not a pickle but extension is in the ModelScan config"
+                " `scanners.PickleUnsafeOpScan.supported_extensions`."
+                " Renaming from %s to %s",
                 in_file.filename,
                 file_path,
                 new_file_path,
@@ -190,7 +192,10 @@ def scan_file(
 @app.post(
     "/scan/image",
     summary="Scan a container image layer for vulnerabilities",
-    description="Upload a container image layer to be scanned against the Trivy vulnerability database. The endpoint returns detected vulnerabilities and metadata.",
+    description=(
+        "Upload a container image layer to be scanned against the Trivy vulnerability database."
+        " The endpoint returns detected vulnerabilities and metadata."
+    ),
     tags=["Scan"],
     status_code=HTTPStatus.OK.value,
     response_description="The result from Trivy",

--- a/lib/artefactscan_api/bailo_artefactscan_api/modelscan.py
+++ b/lib/artefactscan_api/bailo_artefactscan_api/modelscan.py
@@ -68,8 +68,6 @@ def is_valid_pickle(file_path: Path, max_bytes: int = 2 * 1024 * 1024) -> bool:
     try:
         # Attempt to iterate through all opcodes
         ops = list(genops(BytesIO(data)))
-        if not ops:
-            return False
-        return True
+        return bool(ops)
     except (ValueError, UnpicklingError):
         return False

--- a/lib/artefactscan_api/bailo_artefactscan_api/trivy.py
+++ b/lib/artefactscan_api/bailo_artefactscan_api/trivy.py
@@ -300,7 +300,8 @@ def download_database():
         _login_to_database_registry(client, settings)
 
         # Fetch the OCI manifest to get layer digests for SHA-256 verification.
-        # Call `get_manifest` + `download_blob` instead of `client.pull()` to verify each layer's hash against the manifest before extracting
+        # Use get_manifest + download_blob instead of client.pull() to verify
+        # each layer's hash against the manifest before extracting.
         container = oras.container.Container(settings.DB_IMAGE)
         manifest = client.get_manifest(container)
         layers = manifest.get("layers", [])
@@ -360,7 +361,7 @@ def scan(upload_file: UploadFile, background_tasks: BackgroundTasks, block_size:
     blob_digest = blob_hash.hexdigest()
 
     if blob_digest != filename:
-        logger.exception("Calculated digest %s does not match expected digest %s", blob_digest, filename)
+        logger.error("Calculated digest %s does not match expected digest %s", blob_digest, filename)
         raise HTTPException(
             status_code=HTTPStatus.BAD_REQUEST.value,
             detail=f"Uploaded blob {filename} did not match expected digest",
@@ -393,7 +394,8 @@ def scan(upload_file: UploadFile, background_tasks: BackgroundTasks, block_size:
             blob_digest,
         )
 
-    # Check if the DB needs refreshing. `_DB_LOCK` is held only for the metadata read so concurrent scans aren't blocked.
+    # Check if the DB needs refreshing. _DB_LOCK is held only for the
+    # metadata read so concurrent scans aren't blocked.
     with _DB_LOCK:
         next_update = _read_next_update()
     if next_update is not None and next_update < datetime.datetime.now(datetime.timezone.utc):

--- a/lib/artefactscan_api/pyproject.toml
+++ b/lib/artefactscan_api/pyproject.toml
@@ -20,11 +20,11 @@ dependencies = [
 
 [project.optional-dependencies]
 dev = [
-    "black==26.5.1",
     "pre-commit==4.6.2",
     "pytest==9.1.1",
     "pytest-github-actions-annotate-failures==0.4.2",
     "pytest-mock==3.15.1",
+    "ruff==0.16.3",
 ]
 
 [tool.flit.module]

--- a/lib/artefactscan_api/pyproject.toml
+++ b/lib/artefactscan_api/pyproject.toml
@@ -24,7 +24,7 @@ dev = [
     "pytest==9.1.1",
     "pytest-github-actions-annotate-failures==0.4.2",
     "pytest-mock==3.15.1",
-    "ruff==0.16.3",
+    "ruff==0.16.4",
 ]
 
 [tool.flit.module]

--- a/lib/artefactscan_api/tests/test_integration.py
+++ b/lib/artefactscan_api/tests/test_integration.py
@@ -12,14 +12,11 @@ from unittest.mock import ANY
 
 import modelscan
 import pytest
+from bailo_artefactscan_api import trivy
+from bailo_artefactscan_api.config import Settings
+from bailo_artefactscan_api.main import CustomMiddlewareHTTPExceptionWrapper, app
 from content_size_limit_asgi import ContentSizeLimitMiddleware
 from fastapi.testclient import TestClient
-
-# isort: split
-
-import bailo_artefactscan_api.trivy as trivy
-from bailo_artefactscan_api.config import Settings
-from bailo_artefactscan_api.main import CustomMiddlewareHTTPExceptionWrapper, app, get_settings
 
 MAXIMUM_FILESIZE_OVERRIDE = 20_000
 

--- a/lib/artefactscan_api/tests/test_main.py
+++ b/lib/artefactscan_api/tests/test_main.py
@@ -11,13 +11,10 @@ from unittest.mock import Mock, patch
 
 import modelscan
 import pytest
-from fastapi import FastAPI
-from fastapi.testclient import TestClient
-
-# isort: split
-
 from bailo_artefactscan_api.config import Settings
 from bailo_artefactscan_api.main import app, get_settings
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
 
 
 @pytest.fixture(scope="module")
@@ -56,9 +53,8 @@ def test_shutdown_waits_for_db_lock(mocker):
     lock = mocker.patch("bailo_artefactscan_api.trivy._DB_LOCK")
     rm = mocker.patch("shutil.rmtree")
 
-    with pytest.warns():
-        with TestClient(app):
-            pass
+    with pytest.warns(), TestClient(app):
+        pass
 
     lock.__enter__.assert_called()
     rm.assert_called()

--- a/lib/artefactscan_api/tests/test_modelscan.py
+++ b/lib/artefactscan_api/tests/test_modelscan.py
@@ -3,9 +3,6 @@ from __future__ import annotations
 import pickle
 from pathlib import Path
 
-# isort: split
-
-from bailo_artefactscan_api.config import Settings
 from bailo_artefactscan_api.modelscan import extract_supported_file_types, is_valid_pickle
 
 

--- a/lib/artefactscan_api/tests/test_trivy.py
+++ b/lib/artefactscan_api/tests/test_trivy.py
@@ -11,11 +11,8 @@ from subprocess import CalledProcessError
 from unittest.mock import Mock, patch
 
 import pytest
+from bailo_artefactscan_api import trivy
 from fastapi import BackgroundTasks, HTTPException, UploadFile
-
-# isort: split
-
-import bailo_artefactscan_api.trivy as trivy
 
 EMPTY_CONTENTS = b""
 EMPTY_DIGEST = hashlib.sha256(EMPTY_CONTENTS).hexdigest()
@@ -140,9 +137,11 @@ def test_download_database_rejects_bad_digest(mock_client_cls: Mock, tmp_path: P
 
     settings = trivy.Settings(DB_DIR=str(tmp_path / "db"))
 
-    with patch.object(trivy, "get_settings", return_value=settings):
-        with pytest.raises(RuntimeError, match="SHA-256 mismatch"):
-            trivy.download_database()
+    with (
+        patch.object(trivy, "get_settings", return_value=settings),
+        pytest.raises(RuntimeError, match="SHA-256 mismatch"),
+    ):
+        trivy.download_database()
 
     assert not os.path.exists(str(tmp_path / "db")), "DB_DIR should not be created on failure"
 
@@ -154,9 +153,11 @@ def test_download_database_rejects_empty_manifest(mock_client_cls: Mock, tmp_pat
 
     settings = trivy.Settings(DB_DIR=str(tmp_path / "db"))
 
-    with patch.object(trivy, "get_settings", return_value=settings):
-        with pytest.raises(RuntimeError, match="contains no layers"):
-            trivy.download_database()
+    with (
+        patch.object(trivy, "get_settings", return_value=settings),
+        pytest.raises(RuntimeError, match="contains no layers"),
+    ):
+        trivy.download_database()
 
 
 @patch("bailo_artefactscan_api.trivy.oras.client.OrasClient")
@@ -197,8 +198,7 @@ def test_download_database_atomic_on_failure(mock_client_cls: Mock, tmp_path: Pa
     with patch.object(trivy, "get_settings", return_value=settings), patch("tarfile.open") as mock_tar:
         mock_tar.return_value.__enter__ = Mock()
         mock_tar.return_value.__exit__ = Mock(return_value=False)
-        with patch.object(trivy, "safe_extract"):
-            with pytest.raises(RuntimeError, match="SHA-256 mismatch"):
-                trivy.download_database()
+        with patch.object(trivy, "safe_extract"), pytest.raises(RuntimeError, match="SHA-256 mismatch"):
+            trivy.download_database()
 
     assert sentinel.read_text() == "original", "Original DB should be preserved on failure"

--- a/lib/python/README.md
+++ b/lib/python/README.md
@@ -62,20 +62,13 @@ from bailo import Client, Model
 client = Client("http://localhost:8080")
 
 # Create a model
-yolo = Model.create(
-    client=client,
-    name="YoloV4",
-    description="You only look once!"
-)
+yolo = Model.create(client=client, name="YoloV4", description="You only look once!")
 
 # Populate datacard using a predefined schema
 yolo.card_from_schema("minimal-general-v10")
 
 # Create a new release
-my_release = yolo.create_release(
-    version="0.1.0",
-    notes="Beta"
-)
+my_release = yolo.create_release(version="0.1.0", notes="Beta")
 
 # Upload a binary file to the release
 with open("yolo.onnx") as f:

--- a/lib/python/pyproject.toml
+++ b/lib/python/pyproject.toml
@@ -40,7 +40,7 @@ test = [
     "pytest==9.1.1",
     "pytest-github-actions-annotate-failures==0.4.2",
     "requests_mock==1.12.1",
-    "ruff==0.16.3",
+    "ruff==0.16.4",
     "shellcheck-py==0.11.0.1",
     "bailo[mlflow]"
 ]

--- a/lib/python/pyproject.toml
+++ b/lib/python/pyproject.toml
@@ -32,17 +32,15 @@ mlflow = [
     "mlflow-skinny[mlserver]==3.15.1"
 ]
 test = [
-    "black==26.5.1",
     "check-manifest==0.51",
     "pre-commit==4.6.2",
-    "pylint==4.0.7",
-    "pylint_junit==0.3.5",
     "pytest-cov==7.1.0",
     "pytest-mock==3.15.1",
     "pytest-runner==6.0.1",
     "pytest==9.1.1",
     "pytest-github-actions-annotate-failures==0.4.2",
     "requests_mock==1.12.1",
+    "ruff==0.16.3",
     "shellcheck-py==0.11.0.1",
     "bailo[mlflow]"
 ]
@@ -55,10 +53,6 @@ Changelog = "https://github.com/gchq/Bailo/blob/main/lib/python/CHANGELOG.md"
 
 [tool.flit.module]
 name = "bailo"
-
-[tool.black]
-line-length = 120
-fast = true
 
 [tool.coverage.run]
 branch = true
@@ -94,150 +88,4 @@ junit_family = "xunit2"
 markers = [
     "integration: marks as integration test",
     "mlflow: marks as mlflow integration test",
-]
-
-[tool.pylint]
-extension-pkg-whitelist= [
-    "numpy",
-    "torch",
-    "cv2",
-    "pyodbc",
-    "pydantic",
-    "ciso8601",
-    "netcdf4",
-    "scipy"
-]
-ignore="CVS"
-ignore-patterns="test.*?py,conftest.py"
-init-hook='import sys; sys.setrecursionlimit(8 * sys.getrecursionlimit())'
-jobs=0
-limit-inference-results=100
-persistent="yes"
-unsafe-load-any-extension="no"
-
-[tool.pylint.'MESSAGES CONTROL']
-enable="c-extension-no-member"
-disable="W0238"
-
-[tool.pylint.'REPORTS']
-evaluation="10.0 - ((float(5 * error + warning + refactor + convention) / statement) * 10)"
-output-format="text"
-reports="no"
-score="yes"
-
-[tool.pylint.'REFACTORING']
-max-nested-blocks=5
-never-returning-functions="sys.exit"
-
-[tool.pylint.'BASIC']
-argument-naming-style="snake_case"
-attr-naming-style="snake_case"
-bad-names= [
-    "foo",
-    "bar"
-]
-class-attribute-naming-style="any"
-class-naming-style="PascalCase"
-const-naming-style="UPPER_CASE"
-docstring-min-length=-1
-function-naming-style="snake_case"
-good-names= [
-    "i",
-    "j",
-    "k",
-    "ex",
-    "Run",
-    "_"
-]
-include-naming-hint="yes"
-inlinevar-naming-style="any"
-method-naming-style="snake_case"
-module-naming-style="any"
-no-docstring-rgx="^_"
-property-classes="abc.abstractproperty"
-variable-naming-style="snake_case"
-
-[tool.pylint.'FORMAT']
-ignore-long-lines="^\\s*(# )?.*['\"]?<?https?://\\S+>?"
-indent-after-paren=4
-indent-string='    '
-max-line-length=120
-max-module-lines=1000
-single-line-class-stmt="no"
-single-line-if-stmt="no"
-
-[tool.pylint.'LOGGING']
-logging-format-style="old"
-logging-modules="logging"
-
-[tool.pylint.'MISCELLANEOUS']
-notes= [
-    "FIXME",
-    "XXX",
-    "TODO"
-]
-
-[tool.pylint.'SIMILARITIES']
-ignore-comments="yes"
-ignore-docstrings="yes"
-ignore-imports="yes"
-min-similarity-lines=7
-
-[tool.pylint.'SPELLING']
-max-spelling-suggestions=4
-spelling-store-unknown-words="no"
-
-[tool.pylint.'STRING']
-check-str-concat-over-line-jumps="no"
-
-[tool.pylint.'VARIABLES']
-additional-builtins="dbutils"
-allow-global-unused-variables="yes"
-callbacks= [
-    "cb_",
-    "_cb"
-]
-dummy-variables-rgx="_+$|(_[a-zA-Z0-9_]*[a-zA-Z0-9]+?$)|dummy|^ignored_|^unused_"
-ignored-argument-names="_.*|^ignored_|^unused_"
-init-import="no"
-redefining-builtins-modules="six.moves,past.builtins,future.builtins,builtins,io"
-
-[tool.pylint.'CLASSES']
-defining-attr-methods= [
-    "__init__",
-    "__new__",
-    "setUp",
-    "__post_init__"
-]
-exclude-protected= [
-    "_asdict",
-    "_fields",
-    "_replace",
-    "_source",
-    "_make"
-]
-valid-classmethod-first-arg="cls"
-valid-metaclass-classmethod-first-arg="cls"
-
-[tool.pylint.'DESIGN']
-max-args=5
-max-attributes=7
-max-bool-expr=5
-max-branches=12
-max-locals=15
-max-parents=7
-max-public-methods=20
-max-returns=6
-max-statements=50
-min-public-methods=2
-
-[tool.pylint.'IMPORTS']
-allow-wildcard-with-all="no"
-analyse-fallback-blocks="no"
-deprecated-modules=["optparse","tkinter.tix"]
-
-[tool.pylint.'EXCEPTIONS']
-overgeneral-exceptions= [
-    "builtins.BaseException",
-    "builtins.Exception"
 ]

--- a/lib/python/src/bailo/core/agent.py
+++ b/lib/python/src/bailo/core/agent.py
@@ -3,12 +3,11 @@ from __future__ import annotations
 import getpass
 import logging
 import os
+from http import HTTPStatus
 from json import JSONDecodeError
 
 import requests
 from requests.auth import HTTPBasicAuth
-
-# isort: split
 
 from bailo.core.exceptions import BailoException, ResponseException
 
@@ -50,7 +49,7 @@ class Agent:
         res = self.session.request(method, *args, **kwargs)
 
         # Check response for a valid range
-        if res.status_code < 400:
+        if res.status_code < HTTPStatus.BAD_REQUEST:
             return res
 
         try:

--- a/lib/python/src/bailo/core/client.py
+++ b/lib/python/src/bailo/core/client.py
@@ -6,8 +6,6 @@ from typing import Any
 
 import requests
 
-# isort: split
-
 from bailo.core.agent import Agent, TokenAgent
 from bailo.core.enums import CollaboratorEntry, EntryKind, ModelVisibility, SchemaKind
 from bailo.core.exceptions import BailoException, ResponseException
@@ -607,10 +605,7 @@ class Client:
         :param data: File chunk as BytesIO or bytes
         :return: JSON response object containing the ETag for this part
         """
-        if isinstance(data, BytesIO):
-            content_length = data.getbuffer().nbytes
-        else:
-            content_length = len(data)
+        content_length = data.getbuffer().nbytes if isinstance(data, BytesIO) else len(data)
 
         return self._parse_json(
             self.agent.post(

--- a/lib/python/src/bailo/helper/__init__.py
+++ b/lib/python/src/bailo/helper/__init__.py
@@ -5,7 +5,7 @@ This module allows interaction of Models, Releases, Access Requests and Schemas.
 
 >>> from bailo import Model, Client
 >>>
->>> client = Client("https://bailo.com") # URL of Bailo
+>>> client = Client("https://bailo.com")  # URL of Bailo
 
 To import a resource from Bailo:
 

--- a/lib/python/src/bailo/helper/access_request.py
+++ b/lib/python/src/bailo/helper/access_request.py
@@ -153,3 +153,6 @@ class AccessRequest:
         if not isinstance(other, self.__class__):
             return NotImplemented
         return self.access_request_id == other.access_request_id
+
+    def __hash__(self):
+        return hash(self.access_request_id)

--- a/lib/python/src/bailo/helper/entry.py
+++ b/lib/python/src/bailo/helper/entry.py
@@ -116,7 +116,8 @@ class Entry:
             logger.info("Latest card for ID %s successfully retrieved.", self.id)
         else:
             warnings.warn(
-                f"ID {self.id} does not have any associated cards. If needed, create a card with the .card_from_schema() method."
+                f"ID {self.id} does not have any associated cards. If needed, create a card with the .card_from_schema() method.",
+                stacklevel=2,
             )
 
     def get_card_revision(self, version: str) -> None:

--- a/lib/python/src/bailo/helper/mirroredModel.py
+++ b/lib/python/src/bailo/helper/mirroredModel.py
@@ -6,8 +6,6 @@ from typing import Any
 
 from semantic_version import Version
 
-# isort: split
-
 from bailo.core.client import Client
 from bailo.core.enums import CollaboratorEntry, EntryKind, ModelVisibility
 from bailo.core.exceptions import BailoException
@@ -324,11 +322,11 @@ class MirroredModel(Entry):
             self._unpack_card(res["model"]["card"])
             logger.info("Latest card for ID %s successfully retrieved.", self.id)
         else:
-            warnings.warn(f"ID {self.id} does not have any associated model card.")
+            warnings.warn(f"ID {self.id} does not have any associated model card.", stacklevel=2)
         if "mirroredCard" in res["model"]:
             self._unpack_card(res["model"]["mirroredCard"], True)
         else:
-            warnings.warn(f"ID {self.id} does not have any associated additional information.")
+            warnings.warn(f"ID {self.id} does not have any associated additional information.", stacklevel=2)
 
     def _unpack_card(self, res, mirrored=False) -> None:
         if mirrored:

--- a/lib/python/src/bailo/helper/model.py
+++ b/lib/python/src/bailo/helper/model.py
@@ -9,8 +9,6 @@ from typing import Any
 
 from semantic_version import Version
 
-# isort: split
-
 from bailo.core.client import Client
 from bailo.core.enums import CollaboratorEntry, EntryKind, MinimalSchema, ModelVisibility
 from bailo.core.exceptions import BailoException
@@ -611,7 +609,8 @@ class Experiment:
             )
         else:
             warnings.warn(
-                f"MLFlow experiment {experiment_id} does not have any runs and publishing requires at least one valid run. Are you sure the ID is correct?"
+                f"MLFlow experiment {experiment_id} does not have any runs and publishing requires at least one valid run. Are you sure the ID is correct?",
+                stacklevel=2,
             )
 
         for run in runs:
@@ -649,7 +648,7 @@ class Experiment:
 
         logger.info("Successfully imported MLFlow experiment %s.", experiment_id)
 
-    def publish(
+    def publish(  # noqa: PLR0912
         self,
         mc_loc: str,
         semver: str = "0.1.0",
@@ -715,7 +714,7 @@ class Experiment:
             try:
                 release_latest_version = self.model.get_latest_release().version
                 release_new_version = release_latest_version.next_minor()
-            except:
+            except Exception:
                 release_new_version = semver
 
             run_id = sel_run["run"]
@@ -744,7 +743,7 @@ class Experiment:
     def __select_run(self, select_by: str) -> dict:
         # Parse target and order from select_by string
         select_by_split = select_by.split(" ")
-        if len(select_by_split) != 2:
+        if len(select_by_split) != 2:  # noqa: PLR2004
             raise BailoException("Invalid select_by string. Expected format is 'metric_name MIN|MAX'.")
         order_str = select_by_split[1].upper()
         order_opt = {"MIN": 0, "MAX": -1}

--- a/lib/python/src/bailo/helper/release.py
+++ b/lib/python/src/bailo/helper/release.py
@@ -11,8 +11,6 @@ from semantic_version import Version
 from tqdm import tqdm
 from tqdm.utils import CallbackIOWrapper
 
-# isort: split
-
 from bailo.core.client import Client
 from bailo.core.exceptions import BailoException
 from bailo.core.utils import NO_COLOR
@@ -184,23 +182,22 @@ class Release:
                 path = filename
             total_size = int(res.headers.get("content-length", 0))
 
-            if NO_COLOR:
-                colour = "white"
-            else:
-                colour = "green"
+            colour = "white" if NO_COLOR else "green"
 
-            with tqdm(
-                total=total_size,
-                unit="B",
-                unit_scale=True,
-                unit_divisor=BLOCK_SIZE,
-                postfix=f"downloading {filename} as {path}",
-                colour=colour,
-            ) as t:
-                with open(path, "wb") as f:
-                    for data in res.iter_content(BLOCK_SIZE):
-                        t.update(len(data))
-                        f.write(data)
+            with (
+                tqdm(
+                    total=total_size,
+                    unit="B",
+                    unit_scale=True,
+                    unit_divisor=BLOCK_SIZE,
+                    postfix=f"downloading {filename} as {path}",
+                    colour=colour,
+                ) as t,
+                open(path, "wb") as f,
+            ):
+                for data in res.iter_content(BLOCK_SIZE):
+                    t.update(len(data))
+                    f.write(data)
 
             logger.info("File written to %s", path)
 
@@ -290,7 +287,7 @@ class Release:
                 path = f"{name}.zip"
                 name = path
 
-            data: BytesIO = open(path, "rb")  # type: ignore[reportAssignmentType]
+            data: BytesIO = open(path, "rb")  # noqa: SIM115  # type: ignore[reportAssignmentType]
             to_close = True
 
             if zip_required:
@@ -302,10 +299,7 @@ class Release:
         size = data.tell()
         data.seek(old_file_position, os.SEEK_SET)
 
-        if NO_COLOR:
-            colour = "white"
-        else:
-            colour = "blue"
+        colour = "white" if NO_COLOR else "blue"
 
         with tqdm(
             total=size,

--- a/lib/python/tests/conftest.py
+++ b/lib/python/tests/conftest.py
@@ -1,7 +1,3 @@
-#   ---------------------------------------------------------------------------------
-#   Copyright (c) Microsoft Corporation. All rights reserved.
-#   Licensed under the MIT License. See LICENSE in project root for information.
-#   ---------------------------------------------------------------------------------
 """
 This is a configuration file for pytest containing customizations and fixtures.
 
@@ -14,17 +10,14 @@ import random
 
 import mlflow
 import pytest
-from example_schemas import METRICS_JSON_SCHEMA
-from mlflow.tracking import MlflowClient
-
-# isort: split
-
 from bailo.core.client import Client
 from bailo.core.enums import ModelVisibility, SchemaKind
 from bailo.helper.datacard import Datacard
 from bailo.helper.mirroredModel import MirroredModel
 from bailo.helper.model import Model
 from bailo.helper.schema import Schema
+from example_schemas import METRICS_JSON_SCHEMA
+from mlflow.tracking import MlflowClient
 
 BAILO_URL = "http://localhost:8080"
 
@@ -124,7 +117,6 @@ def test_path(tmpdir_factory):
 
 @pytest.fixture(scope="session")
 def test_path_large(tmpdir_factory):
-    weights = "Test"
     fn = tmpdir_factory.mktemp("data").join("test.pth")
 
     f = open(str(fn), "wb")

--- a/lib/python/tests/test_access_request.py
+++ b/lib/python/tests/test_access_request.py
@@ -86,7 +86,7 @@ def test_access_request_eq():
         for i in range(2)
     ]
 
-    assert not (access_requests[0] == access_requests[1])
+    assert access_requests[0] != access_requests[1]
 
 
 def test_access_request_eq_not_implemented():
@@ -102,7 +102,7 @@ def test_access_request_eq_not_implemented():
     )
 
     # NotImplemented evaluates to false
-    assert not (access_request == {})
+    assert access_request != {}
 
 
 @pytest.mark.integration

--- a/lib/python/tests/test_api_coverage.py
+++ b/lib/python/tests/test_api_coverage.py
@@ -255,7 +255,7 @@ def test_all_client_methods_discoverable():
         if not _find_captured_request(agent):
             failures.append(f"{method_name}: no HTTP call made")
 
-    assert not failures, f"Client methods that could not be auto-discovered:\n" + "\n".join(failures)
+    assert not failures, "Client methods that could not be auto-discovered:\n" + "\n".join(failures)
 
 
 def test_discovered_routes_have_api_prefix():
@@ -269,7 +269,7 @@ def test_discovered_routes_have_api_prefix():
         if not path.startswith("/api/v2/")
     ]
 
-    assert not wrong_prefix, f"Client methods with unexpected URL prefix:\n" + "\n".join(wrong_prefix)
+    assert not wrong_prefix, "Client methods with unexpected URL prefix:\n" + "\n".join(wrong_prefix)
 
 
 # ---------------------------------------------------------------------------
@@ -297,7 +297,7 @@ def test_client_routes_exist_in_swagger():
         elif (http_method, matched_spec_path) not in live_routes:
             mismatches.append(f"{method_name}: spec has path {matched_spec_path} but not for method {http_method}")
 
-    assert not mismatches, f"Client methods targeting non-existent backend routes:\n" + "\n".join(mismatches)
+    assert not mismatches, "Client methods targeting non-existent backend routes:\n" + "\n".join(mismatches)
 
 
 @pytest.mark.integration
@@ -394,4 +394,4 @@ def test_swagger_spec_params_match_client():
         if missing_body:
             mismatches.append(f"{method_name}: missing required body fields {missing_body}")
 
-    assert not mismatches, f"Parameter mismatches:\n" + "\n".join(mismatches)
+    assert not mismatches, "Parameter mismatches:\n" + "\n".join(mismatches)

--- a/lib/python/tests/test_client.py
+++ b/lib/python/tests/test_client.py
@@ -4,9 +4,6 @@ import json
 import random
 
 import pytest
-
-# isort: split
-
 from bailo import Client, ModelVisibility, SchemaKind
 from bailo.core.enums import CollaboratorEntry, EntryKind, Role
 from bailo.core.exceptions import BailoException, ResponseException

--- a/lib/python/tests/test_datacard.py
+++ b/lib/python/tests/test_datacard.py
@@ -1,9 +1,6 @@
 from __future__ import annotations
 
 import pytest
-
-# isort: split
-
 from bailo import Client, Datacard, Model, ModelVisibility
 from bailo.core.enums import CollaboratorEntry, Role
 from bailo.core.exceptions import BailoException
@@ -108,4 +105,4 @@ def test_get_model_as_datacard(integration_client):
     )
 
     with pytest.raises(BailoException):
-        datacard = Datacard.from_id(client=integration_client, datacard_id=model.model_id)
+        Datacard.from_id(client=integration_client, datacard_id=model.model_id)

--- a/lib/python/tests/test_exceptions.py
+++ b/lib/python/tests/test_exceptions.py
@@ -74,7 +74,7 @@ def test_documentation_url_excluded_from_context_display():
     result = str(exc)
     assert "Context:" in result
     assert "'modelId': 'abc'" in result
-    assert "documentationUrl" not in result.split("Context:")[1].split("\n")[0]
+    assert "documentationUrl" not in result.split("Context:")[1].split("\n", maxsplit=1)[0]
     assert "Documentation: https://docs.example.com" in result
 
 

--- a/lib/python/tests/test_files.py
+++ b/lib/python/tests/test_files.py
@@ -5,10 +5,6 @@ from io import BytesIO
 from pathlib import Path
 
 import pytest
-
-# isort: split
-
-from bailo.core.client import Client
 from bailo.core.exceptions import BailoException
 from bailo.helper.model import Model
 

--- a/lib/python/tests/test_mirrored_model.py
+++ b/lib/python/tests/test_mirrored_model.py
@@ -1,13 +1,9 @@
 from __future__ import annotations
 
 import pytest
-from bailo.core.enums import CollaboratorEntry, EntryKind, MinimalSchema, Role
-
-# isort: split
-
-from bailo import Client, Datacard, Experiment, MirroredModel, ModelVisibility
+from bailo import Client, MirroredModel, ModelVisibility
+from bailo.core.enums import CollaboratorEntry, EntryKind, Role
 from bailo.core.exceptions import BailoException
-from bailo.core.utils import NestedDict
 
 
 def test_model_card_defaults(local_mirrored_model):
@@ -116,9 +112,25 @@ def test_mirrored_model(local_mirrored_model):
 
 @pytest.mark.integration
 @pytest.mark.parametrize(
-    ("name", "description", "sourceModelId", "organisation", "tags", "visibility", "collaborators"),
+    (
+        "name",
+        "description",
+        "sourceModelId",
+        "organisation",
+        "tags",
+        "visibility",
+        "collaborators",
+    ),
     [
-        ("test-mirrored-model", "test", "test-1234", None, None, ModelVisibility.PUBLIC, None),
+        (
+            "test-mirrored-model",
+            "test",
+            "test-1234",
+            None,
+            None,
+            ModelVisibility.PUBLIC,
+            None,
+        ),
         (
             "test-mirrored-model",
             "test",
@@ -263,7 +275,7 @@ def test_get_releases(integration_client):
         visibility=ModelVisibility.PUBLIC,
     )
 
-    releases = model.get_releases()
+    model.get_releases()
 
     with pytest.raises(BailoException):
         model.get_latest_release()

--- a/lib/python/tests/test_model.py
+++ b/lib/python/tests/test_model.py
@@ -3,12 +3,8 @@ from __future__ import annotations
 from typing import Any
 
 import pytest
-from bailo.core.enums import CollaboratorEntry, MinimalSchema, Role
-
-# isort: split
-
 from bailo import Client, Datacard, Experiment, Model, ModelVisibility
-from bailo.core.enums import EntryKind
+from bailo.core.enums import CollaboratorEntry, EntryKind, MinimalSchema, Role
 from bailo.core.exceptions import BailoException
 from bailo.core.utils import NestedDict
 
@@ -270,7 +266,7 @@ def test_get_datacard_as_model(integration_client):
     )
 
     with pytest.raises(BailoException):
-        model = Model.from_id(client=integration_client, model_id=datacard.datacard_id)
+        Model.from_id(client=integration_client, model_id=datacard.datacard_id)
 
 
 @pytest.mark.integration
@@ -324,7 +320,7 @@ def test_import_model_from_mlflow(integration_client, mlflow_model, request):
 @pytest.mark.mlflow
 def test_import_nonexistent_model_from_mlflow(integration_client, request):
     with pytest.raises(BailoException):
-        model = Model.from_mlflow(
+        Model.from_mlflow(
             client=integration_client,
             mlflow_uri=request.config.mlflow_uri,
             schema_id="minimal-general-v10",
@@ -335,7 +331,7 @@ def test_import_nonexistent_model_from_mlflow(integration_client, request):
 @pytest.mark.mlflow
 def test_import_model_files_no_run(integration_client, mlflow_model_no_run, request):
     with pytest.raises(BailoException):
-        model = Model.from_mlflow(
+        Model.from_mlflow(
             client=integration_client,
             mlflow_uri=request.config.mlflow_uri,
             schema_id="minimal-general-v10",

--- a/lib/python/tests/test_release.py
+++ b/lib/python/tests/test_release.py
@@ -104,7 +104,7 @@ def test_create_get_from_version_update_and_delete_release(
 @pytest.mark.integration
 def test_nonexistent_file_ids(integration_client, example_model):
     with pytest.raises(BailoException):
-        release = Release.create(
+        Release.create(
             client=integration_client,
             model_id=example_model.model_id,
             version="1.0.2",
@@ -119,7 +119,7 @@ def test_nonexistent_file_ids(integration_client, example_model):
 @pytest.mark.integration
 def test_incorrect_format_file_ids(integration_client, example_model):
     with pytest.raises(BailoException):
-        release = Release.create(
+        Release.create(
             client=integration_client,
             model_id=example_model.model_id,
             version="1.0.2",

--- a/lib/python/tests/test_schema.py
+++ b/lib/python/tests/test_schema.py
@@ -4,9 +4,6 @@ import random
 import string
 
 import pytest
-
-# isort: split
-
 from bailo import Client, Schema, SchemaKind
 from example_schemas import MINIMAL_JSON_SCHEMA
 

--- a/ruff.toml
+++ b/ruff.toml
@@ -17,15 +17,32 @@ select = [
     "PLR",    # pylint refactor
     "PLW",    # pylint warning
 ]
+# ruff format handles code line length; E501 only fires on strings/comments
+# which are often intentionally long (URLs, docstrings, log messages)
+ignore = ["E501"]
 
 [lint.per-file-ignores]
 "backend/docs/**" = ["UP"]
+# Demo notebooks intentionally interleave imports with code for readability
+"backend/docs/notebooks/**" = ["E402", "F821", "I001", "N803"]
+# Generated OpenAPI response examples
+"lib/artefactscan_api/bailo_artefactscan_api/openapi/**" = ["E501"]
+# Pydantic model fields use camelCase to match the REST API contract
+"lib/artefactscan_api/bailo_artefactscan_api/schemas.py" = ["N815"]
+# Public API re-exports
+"lib/python/src/bailo/__init__.py" = ["F401"]
+"lib/python/src/bailo/helper/__init__.py" = ["F401"]
+# API parameters use camelCase to match the REST API field names;
+# exception class names are part of the published API (can't rename)
+"lib/python/src/bailo/**" = ["N803", "N818", "N999"]
+# Tests: magic values (status codes), naming conventions, variable reuse, and file handling
+"**/tests/**" = ["PLR2004", "SIM115", "N802", "N803", "N806", "PLR1704"]
 
 [lint.isort]
 required-imports = ["from __future__ import annotations"]
 
 [lint.pylint]
-max-args = 5
+max-args = 12
 max-returns = 6
 max-branches = 12
 max-locals = 15
@@ -33,6 +50,7 @@ max-statements = 50
 max-nested-blocks = 5
 max-bool-expr = 5
 max-public-methods = 20
+max-positional-args = 12
 
 [format]
 docstring-code-format = true

--- a/ruff.toml
+++ b/ruff.toml
@@ -1,0 +1,38 @@
+target-version = "py310"
+line-length = 120
+
+[lint]
+select = [
+    "E",      # pycodestyle errors
+    "F",      # pyflakes
+    "W",      # pycodestyle warnings
+    "I",      # isort
+    "UP",     # pyupgrade
+    "N",      # pep8-naming
+    "B",      # flake8-bugbear
+    "SIM",    # flake8-simplify
+    "LOG",    # flake8-logging
+    "PLC",    # pylint convention
+    "PLE",    # pylint error
+    "PLR",    # pylint refactor
+    "PLW",    # pylint warning
+]
+
+[lint.per-file-ignores]
+"backend/docs/**" = ["UP"]
+
+[lint.isort]
+required-imports = ["from __future__ import annotations"]
+
+[lint.pylint]
+max-args = 5
+max-returns = 6
+max-branches = 12
+max-locals = 15
+max-statements = 50
+max-nested-blocks = 5
+max-bool-expr = 5
+max-public-methods = 20
+
+[format]
+docstring-code-format = true


### PR DESCRIPTION
Contributes towards #4080

Replace multiple python lint & formatters with single package `ruff` to standardise styling across multiple packages in monorepo. Run `ruff` over all Python code.