### PR TITLE
Add Deployment Assessment update endpoint

### DIFF
--- a/backend/src/connectors/audit/Base.ts
+++ b/backend/src/connectors/audit/Base.ts
@@ -446,6 +446,12 @@ export const AuditInfo = {
     auditKind: AuditKind.Create,
     resourceKind: ResourceKind.DeploymentAssessment,
   },
+  UpdateDeploymentAssessment: {
+    typeId: 'UpdateDeploymentAssessment',
+    description: 'Deployment assessment updated',
+    auditKind: AuditKind.Update,
+    resourceKind: ResourceKind.DeploymentAssessment,
+  },
   ViewDeploymentAssessment: {
     typeId: 'ViewDeploymentAssessment',
     description: 'Deployment assessment viewed',
@@ -570,6 +576,7 @@ export abstract class BaseAuditConnector {
   abstract onCreateReview(req: Request, modelId: string): Promise<void>
 
   abstract onCreateDeploymentAssessment(req: Request, deploymentAssessment: DeploymentAssessmentDoc): Promise<void>
+  abstract onUpdateDeploymentAssessment(req: Request, deploymentAssessment: DeploymentAssessmentDoc): Promise<void>
   abstract onSearchDeploymentAssessments(req: Request, deploymentAssessments: DeploymentAssessmentDoc[]): Promise<void>
   abstract onViewDeploymentAssessment(req: Request, deploymentAssessment: DeploymentAssessmentDoc): Promise<void>
 

--- a/backend/src/connectors/audit/__mocks__/index.ts
+++ b/backend/src/connectors/audit/__mocks__/index.ts
@@ -78,6 +78,7 @@ const audit = {
   onCreateReview: vi.fn(),
 
   onCreateDeploymentAssessment: vi.fn(),
+  onUpdateDeploymentAssessment: vi.fn(),
   onSearchDeploymentAssessments: vi.fn(),
   onViewDeploymentAssessment: vi.fn(),
 

--- a/backend/src/connectors/audit/silly.ts
+++ b/backend/src/connectors/audit/silly.ts
@@ -88,6 +88,7 @@ export class SillyAuditConnector extends BaseAuditConnector {
   async onViewMetric(_req: Request): Promise<void> {}
   async onCreateReview(_req: Request, _modelId: string) {}
   async onCreateDeploymentAssessment(_req: Request, _deploymentAssessment: DeploymentAssessmentDoc) {}
+  async onUpdateDeploymentAssessment(_req: Request, _deploymentAssessment: DeploymentAssessmentDoc) {}
   async onSearchDeploymentAssessments(_req: Request, _deploymentAssessments: DeploymentAssessmentDoc[]) {}
   async onViewDeploymentAssessment(_req: Request, _deploymentAssessment: DeploymentAssessmentDoc): Promise<void> {}
   async onViewCurrentUserInformation(_req: Request, _userInformation: GetCurrentUserResponse): Promise<void> {}

--- a/backend/src/connectors/audit/stdout.ts
+++ b/backend/src/connectors/audit/stdout.ts
@@ -445,6 +445,12 @@ export class StdoutAuditConnector extends BaseAuditConnector {
     req.log.info(event, req.audit.description)
   }
 
+  async onUpdateDeploymentAssessment(req: Request, deploymentAssessment: DeploymentAssessmentDoc): Promise<void> {
+    this.checkEventType(AuditInfo.UpdateDeploymentAssessment, req)
+    const event = this.generateEvent(req, { id: deploymentAssessment.id })
+    req.log.info(event, req.audit.description)
+  }
+
   async onSearchDeploymentAssessments(req: Request, deploymentAssessments: DeploymentAssessmentDoc[]) {
     this.checkEventType(AuditInfo.SearchDeploymentAssessments, req)
     const event = this.generateEvent(req, {

--- a/backend/src/connectors/audit/stroom.ts
+++ b/backend/src/connectors/audit/stroom.ts
@@ -501,6 +501,10 @@ export class StroomAuditConnector extends BaseAuditConnector {
     this.auditGenericEvent(req, deploymentAssessment.id)
   }
 
+  async onUpdateDeploymentAssessment(req: Request, deploymentAssessment: DeploymentAssessmentDoc): Promise<void> {
+    this.auditGenericEvent(req, deploymentAssessment.id)
+  }
+
   async onSearchDeploymentAssessments(req: Request, deploymentAssessments: DeploymentAssessmentDoc[]): Promise<void> {
     this.auditSearchEvent(
       req,

--- a/backend/src/routes/v3/deploymentAssessment/patchDeploymentAssessment.ts
+++ b/backend/src/routes/v3/deploymentAssessment/patchDeploymentAssessment.ts
@@ -1,0 +1,80 @@
+import { Request, Response } from 'express'
+
+import { AuditInfo } from '../../../connectors/audit/Base.js'
+import audit from '../../../connectors/audit/index.js'
+import { z } from '../../../lib/zod.js'
+import { DeploymentAssessmentInterface } from '../../../models/DeploymentAssessment.js'
+import { updateDeploymentAssessment } from '../../../services/deploymentAssessment.js'
+import {
+  deploymentAssessmentDraftSchema,
+  deploymentAssessmentInterfaceSchema,
+  deploymentAssessmentMetadataSchema,
+  registerPath,
+} from '../../../services/specification.js'
+import { parse } from '../../../utils/validate.js'
+
+export const patchDeploymentAssessmentSchema = z.object({
+  body: z
+    .object({
+      metadata: deploymentAssessmentMetadataSchema.optional(),
+      draft: deploymentAssessmentDraftSchema.optional(),
+    })
+    .refine(
+      (obj) => {
+        for (const val of Object.values(obj)) {
+          if (val !== undefined) {
+            return true
+          }
+        }
+        return false
+      },
+      {
+        message: 'Body must have at least one property defined.',
+      },
+    ),
+  params: z.object({
+    deploymentAssessmentId: z.string(),
+  }),
+})
+
+registerPath(
+  {
+    method: 'patch',
+    path: '/api/v3/deployment-assessments/{deploymentAssessmentId}',
+    tags: ['deployment assessments'],
+    description: 'Get a deployment assessment.',
+    schema: patchDeploymentAssessmentSchema,
+    responses: {
+      200: {
+        description: 'A deployment assessment.',
+        content: {
+          'application/json': {
+            schema: z.object({
+              deploymentAssessment: deploymentAssessmentInterfaceSchema,
+            }),
+          },
+        },
+      },
+    },
+  },
+  'v3',
+)
+
+interface GetDeploymentAssessmentResponse {
+  deploymentAssessment: DeploymentAssessmentInterface
+}
+
+export const patchDeploymentAssessment = [
+  async (req: Request, res: Response<GetDeploymentAssessmentResponse>): Promise<void> => {
+    req.audit = AuditInfo.UpdateDeploymentAssessment
+    const { body, params } = parse(req, patchDeploymentAssessmentSchema)
+
+    const deploymentAssessment = await updateDeploymentAssessment(req.user, params.deploymentAssessmentId, body)
+
+    await audit.onUpdateDeploymentAssessment(req, deploymentAssessment)
+
+    res.json({
+      deploymentAssessment,
+    })
+  },
+]

--- a/backend/src/routes/v3/deploymentAssessment/patchDeploymentAssessment.ts
+++ b/backend/src/routes/v3/deploymentAssessment/patchDeploymentAssessment.ts
@@ -42,7 +42,7 @@ registerPath(
     method: 'patch',
     path: '/api/v3/deployment-assessments/{deploymentAssessmentId}',
     tags: ['deployment assessments'],
-    description: 'Get a deployment assessment.',
+    description: 'Patch the values of a deployment assessment.',
     schema: patchDeploymentAssessmentSchema,
     responses: {
       200: {

--- a/backend/src/routes/v3/deploymentAssessment/patchDeploymentAssessment.ts
+++ b/backend/src/routes/v3/deploymentAssessment/patchDeploymentAssessment.ts
@@ -19,7 +19,9 @@ export const patchDeploymentAssessmentSchema = z.object({
       metadata: deploymentAssessmentMetadataSchema.optional(),
       draft: deploymentAssessmentDraftSchema.optional(),
     })
+    .strict()
     .refine(
+      // prevent no-op request
       (obj) => {
         for (const val of Object.values(obj)) {
           if (val !== undefined) {

--- a/backend/src/routes/v3/routes.ts
+++ b/backend/src/routes/v3/routes.ts
@@ -4,6 +4,7 @@ import { generateV3SwaggerSpec } from '../../services/specification.js'
 import { getImageByDigest } from '../v3/model/images/getImage.js'
 import { getDeploymentAssessment } from './deploymentAssessment/getDeploymentAssessment.js'
 import { getDeploymentAssessments } from './deploymentAssessment/getDeploymentAssessments.js'
+import { patchDeploymentAssessment } from './deploymentAssessment/patchDeploymentAssessment.js'
 import { postDeploymentAssessment } from './deploymentAssessment/postDeploymentAssessment.js'
 import { getCurrentUser } from './entities/getCurrentUser.js'
 import { getEntryVolume } from './metrics/getEntryVolume.js'
@@ -27,6 +28,7 @@ router.get('/model/:modelId/image/:name/:tag/:digest', ...getImageByDigest)
 router.get('/deployment-assessments', ...getDeploymentAssessments)
 router.post('/deployment-assessments', ...postDeploymentAssessment)
 router.get('/deployment-assessments/:deploymentAssessmentId', ...getDeploymentAssessment)
+router.patch('/deployment-assessments/:deploymentAssessmentId', ...patchDeploymentAssessment)
 
 router.get('/metrics/usage', ...getUsageMetrics)
 router.get('/metrics/compliance/no-releases', ...getNoReleasesComplianceMetrics)

--- a/backend/src/services/deploymentAssessment.ts
+++ b/backend/src/services/deploymentAssessment.ts
@@ -31,9 +31,7 @@ export interface SearchDeploymentAssessmentsParams {
   search?: string
 }
 
-export type CreateDeploymentAssessmentParams = Pick<DeploymentAssessmentInterface, 'schemaId' | 'draft'> & {
-  metadata: unknown
-}
+export type CreateDeploymentAssessmentParams = Pick<DeploymentAssessmentInterface, 'schemaId' | 'draft' | 'metadata'>
 export type UpdateDeploymentAssessmentParams = Pick<DeploymentAssessmentInterface, 'metadata' | 'draft'>
 
 async function validateRiskOwner(riskOwner: string) {
@@ -80,42 +78,9 @@ async function validateModels(modelIds: string[]) {
   }
 }
 
-/** Returns the first metadata property that does not match `DeploymentAssessmentMetadata`, or undefined when it does. */
-function findInvalidMetadataProperty(metadata: unknown): string | undefined {
-  if (typeof metadata !== 'object' || metadata === null) {
-    return 'metadata'
-  }
-
-  const { overview } = metadata as { overview?: unknown }
-  if (typeof overview !== 'object' || overview === null) {
-    return 'overview'
-  }
-
-  const { name, riskOwner, justification, modelIds } = overview as Record<string, unknown>
-  if (typeof name !== 'string') {
-    return 'overview.name'
-  }
-  if (riskOwner !== undefined && typeof riskOwner !== 'string') {
-    return 'overview.riskOwner'
-  }
-  if (justification !== undefined && typeof justification !== 'string') {
-    return 'overview.justification'
-  }
-  if (modelIds !== undefined && (!Array.isArray(modelIds) || modelIds.some((id) => typeof id !== 'string'))) {
-    return 'overview.modelIds'
-  }
-
-  return undefined
-}
-
-function isDeploymentAssessmentMetadata(metadata: unknown): metadata is DeploymentAssessmentMetadata {
-  return findInvalidMetadataProperty(metadata) === undefined
-}
-
-/** Validates metadata against its schema, returning it narrowed to `DeploymentAssessmentMetadata`. */
 async function validateDeploymentAssessment(
   schemaId: DeploymentAssessmentInterface['schemaId'],
-  metadata: unknown,
+  metadata: DeploymentAssessmentInterface['metadata'],
   draft: DeploymentAssessmentInterface['draft'],
 ): Promise<DeploymentAssessmentMetadata> {
   const schema = await getSchemaById(schemaId)
@@ -126,19 +91,9 @@ async function validateDeploymentAssessment(
     throw BadReq('Deployment assessments must use a deployment assessment schema.', { schemaId })
   }
 
-  const { valid, errors } = await validateContentAgainstSchema(schemaId, metadata, {
-    draft,
-  })
+  const { valid, errors } = await validateContentAgainstSchema(schemaId, metadata, { draft })
   if (!valid) {
     throw BadReq('Deployment assessment metadata could not be validated against the schema.', { errors })
-  }
-
-  // The schema check above cannot narrow the type, so guard the properties this service relies on.
-  if (!isDeploymentAssessmentMetadata(metadata)) {
-    throw BadReq('Deployment assessment metadata has an invalid overview.', {
-      schemaId,
-      property: findInvalidMetadataProperty(metadata),
-    })
   }
 
   const { riskOwner, modelIds } = metadata.overview
@@ -224,13 +179,13 @@ export async function getDeploymentAssessmentById(user: UserInterface, deploymen
 }
 
 export async function createDeploymentAssessment(user: UserInterface, params: CreateDeploymentAssessmentParams) {
-  const metadata = await validateDeploymentAssessment(params.schemaId, params.metadata, params.draft)
+  await validateDeploymentAssessment(params.schemaId, params.metadata, params.draft)
 
-  const deploymentAssessmentId = convertStringToId(metadata.overview.name)
+  const deploymentAssessmentId = convertStringToId(params.metadata.overview.name)
   const deploymentAssessment = new DeploymentAssessmentModel({
     id: deploymentAssessmentId,
     schemaId: params.schemaId,
-    metadata,
+    metadata: params.metadata,
     draft: params.draft,
     createdBy: user.dn,
   })
@@ -251,10 +206,10 @@ export async function createDeploymentAssessment(user: UserInterface, params: Cr
     throw error
   }
 
-  if (!params.draft && metadata.overview.riskOwner) {
+  if (!params.draft && params.metadata.overview.riskOwner) {
     await notifyDeploymentStakeholders(
-      metadata.overview.riskOwner,
-      metadata.overview.modelIds ?? [],
+      params.metadata.overview.riskOwner,
+      params.metadata.overview.modelIds ?? [],
       deploymentAssessment,
     )
   }
@@ -286,7 +241,7 @@ export async function updateDeploymentAssessment(
   }
   if (diff.draft !== undefined) {
     if (!deploymentAssessment.draft && diff.draft) {
-      throw BadReq('Cannot convert a released deployment assessment back to a draft.')
+      throw BadReq('Cannot convert a submitted deployment assessment back to a draft.')
     }
     deploymentAssessment.draft = diff.draft
     deploymentAssessment.markModified('draft')

--- a/backend/src/services/deploymentAssessment.ts
+++ b/backend/src/services/deploymentAssessment.ts
@@ -34,6 +34,7 @@ export interface SearchDeploymentAssessmentsParams {
 export type CreateDeploymentAssessmentParams = Pick<DeploymentAssessmentInterface, 'schemaId' | 'draft'> & {
   metadata: unknown
 }
+export type UpdateDeploymentAssessmentParams = Pick<DeploymentAssessmentInterface, 'metadata' | 'draft'>
 
 async function validateRiskOwner(riskOwner: string) {
   const { kind, value } = fromEntity(riskOwner)
@@ -77,6 +78,83 @@ async function validateModels(modelIds: string[]) {
       },
     )
   }
+}
+
+/** Returns the first metadata property that does not match `DeploymentAssessmentMetadata`, or undefined when it does. */
+function findInvalidMetadataProperty(metadata: unknown): string | undefined {
+  if (typeof metadata !== 'object' || metadata === null) {
+    return 'metadata'
+  }
+
+  const { overview } = metadata as { overview?: unknown }
+  if (typeof overview !== 'object' || overview === null) {
+    return 'overview'
+  }
+
+  const { name, riskOwner, justification, modelIds } = overview as Record<string, unknown>
+  if (typeof name !== 'string') {
+    return 'overview.name'
+  }
+  if (riskOwner !== undefined && typeof riskOwner !== 'string') {
+    return 'overview.riskOwner'
+  }
+  if (justification !== undefined && typeof justification !== 'string') {
+    return 'overview.justification'
+  }
+  if (modelIds !== undefined && (!Array.isArray(modelIds) || modelIds.some((id) => typeof id !== 'string'))) {
+    return 'overview.modelIds'
+  }
+
+  return undefined
+}
+
+function isDeploymentAssessmentMetadata(metadata: unknown): metadata is DeploymentAssessmentMetadata {
+  return findInvalidMetadataProperty(metadata) === undefined
+}
+
+/** Validates metadata against its schema, returning it narrowed to `DeploymentAssessmentMetadata`. */
+async function validateDeploymentAssessment(
+  schemaId: DeploymentAssessmentInterface['schemaId'],
+  metadata: unknown,
+  draft: DeploymentAssessmentInterface['draft'],
+): Promise<DeploymentAssessmentMetadata> {
+  const schema = await getSchemaById(schemaId)
+  if (schema.hidden) {
+    throw BadReq('Cannot create a deployment assessment using a hidden schema.', { schemaId })
+  }
+  if (schema.kind !== SchemaKind.DeploymentAssessment) {
+    throw BadReq('Deployment assessments must use a deployment assessment schema.', { schemaId })
+  }
+
+  const { valid, errors } = await validateContentAgainstSchema(schemaId, metadata, {
+    draft,
+  })
+  if (!valid) {
+    throw BadReq('Deployment assessment metadata could not be validated against the schema.', { errors })
+  }
+
+  // The schema check above cannot narrow the type, so guard the properties this service relies on.
+  if (!isDeploymentAssessmentMetadata(metadata)) {
+    throw BadReq('Deployment assessment metadata has an invalid overview.', {
+      schemaId,
+      property: findInvalidMetadataProperty(metadata),
+    })
+  }
+
+  const { riskOwner, modelIds } = metadata.overview
+
+  if (!draft && !riskOwner) {
+    throw BadReq('Deployment risk owner is required')
+  }
+
+  if (riskOwner) {
+    await validateRiskOwner(riskOwner)
+  }
+  if (modelIds?.length) {
+    await validateModels(modelIds)
+  }
+
+  return metadata
 }
 
 async function notifyDeploymentStakeholders(
@@ -146,36 +224,9 @@ export async function getDeploymentAssessmentById(user: UserInterface, deploymen
 }
 
 export async function createDeploymentAssessment(user: UserInterface, params: CreateDeploymentAssessmentParams) {
-  const schema = await getSchemaById(params.schemaId)
-  if (schema.hidden) {
-    throw BadReq('Cannot create a deployment assessment using a hidden schema.', { schemaId: params.schemaId })
-  }
-  if (schema.kind !== SchemaKind.DeploymentAssessment) {
-    throw BadReq('Deployment assessments must use a deployment assessment schema.', { schemaId: params.schemaId })
-  }
+  const metadata = await validateDeploymentAssessment(params.schemaId, params.metadata, params.draft)
 
-  const { valid, errors } = await validateContentAgainstSchema(params.schemaId, params.metadata, {
-    draft: params.draft,
-  })
-  if (!valid) {
-    throw BadReq('Deployment assessment metadata could not be validated against the schema.', { errors })
-  }
-
-  const metadata = params.metadata as DeploymentAssessmentMetadata
-  const { name, riskOwner, modelIds } = metadata.overview
-
-  if (!params.draft && !riskOwner) {
-    throw BadReq('Deployment risk owner is required')
-  }
-
-  if (riskOwner) {
-    await validateRiskOwner(riskOwner)
-  }
-  if (modelIds?.length) {
-    await validateModels(modelIds)
-  }
-
-  const deploymentAssessmentId = convertStringToId(name)
+  const deploymentAssessmentId = convertStringToId(metadata.overview.name)
   const deploymentAssessment = new DeploymentAssessmentModel({
     id: deploymentAssessmentId,
     schemaId: params.schemaId,
@@ -200,9 +251,48 @@ export async function createDeploymentAssessment(user: UserInterface, params: Cr
     throw error
   }
 
-  if (!params.draft && riskOwner) {
-    await notifyDeploymentStakeholders(riskOwner, modelIds ?? [], deploymentAssessment)
+  if (!params.draft && metadata.overview.riskOwner) {
+    await notifyDeploymentStakeholders(
+      metadata.overview.riskOwner,
+      metadata.overview.modelIds ?? [],
+      deploymentAssessment,
+    )
   }
+
+  return deploymentAssessment
+}
+
+export async function updateDeploymentAssessment(
+  user: UserInterface,
+  deploymentAssessmentId: string,
+  diff: Partial<UpdateDeploymentAssessmentParams>,
+) {
+  const deploymentAssessment = await getDeploymentAssessmentById(user, deploymentAssessmentId)
+
+  const auth = await authorisation.deploymentAssessment(user, deploymentAssessment, DeploymentAssessmentAction.Update)
+  if (!auth.success) {
+    throw Forbidden(auth.info, { userDn: user.dn, deploymentAssessmentId })
+  }
+
+  const metadata = await validateDeploymentAssessment(
+    deploymentAssessment.schemaId,
+    diff.metadata ?? deploymentAssessment.metadata,
+    diff.draft ?? deploymentAssessment.draft,
+  )
+
+  if (diff.metadata !== undefined) {
+    deploymentAssessment.metadata = metadata
+    deploymentAssessment.markModified('metadata')
+  }
+  if (diff.draft !== undefined) {
+    if (!deploymentAssessment.draft && diff.draft) {
+      throw BadReq('Cannot convert a released deployment assessment back to a draft.')
+    }
+    deploymentAssessment.draft = diff.draft
+    deploymentAssessment.markModified('draft')
+  }
+
+  await deploymentAssessment.save()
 
   return deploymentAssessment
 }

--- a/backend/src/services/deploymentAssessment.ts
+++ b/backend/src/services/deploymentAssessment.ts
@@ -83,14 +83,6 @@ async function validateDeploymentAssessment(
   metadata: DeploymentAssessmentInterface['metadata'],
   draft: DeploymentAssessmentInterface['draft'],
 ): Promise<DeploymentAssessmentMetadata> {
-  const schema = await getSchemaById(schemaId)
-  if (schema.hidden) {
-    throw BadReq('Cannot create a deployment assessment using a hidden schema.', { schemaId })
-  }
-  if (schema.kind !== SchemaKind.DeploymentAssessment) {
-    throw BadReq('Deployment assessments must use a deployment assessment schema.', { schemaId })
-  }
-
   const { valid, errors } = await validateContentAgainstSchema(schemaId, metadata, { draft })
   if (!valid) {
     throw BadReq('Deployment assessment metadata could not be validated against the schema.', { errors })
@@ -179,6 +171,15 @@ export async function getDeploymentAssessmentById(user: UserInterface, deploymen
 }
 
 export async function createDeploymentAssessment(user: UserInterface, params: CreateDeploymentAssessmentParams) {
+  // only validate schema on creation as it cannot be edited
+  const schema = await getSchemaById(params.schemaId)
+  if (schema.hidden) {
+    throw BadReq('Cannot create a deployment assessment using a hidden schema.', { schemaId: params.schemaId })
+  }
+  if (schema.kind !== SchemaKind.DeploymentAssessment) {
+    throw BadReq('Deployment assessments must use a deployment assessment schema.', { schemaId: params.schemaId })
+  }
+
   await validateDeploymentAssessment(params.schemaId, params.metadata, params.draft)
 
   const deploymentAssessmentId = convertStringToId(params.metadata.overview.name)

--- a/backend/test/routes/v3/deploymentAssessment/__snapshots__/patchDeploymentAssessment.spec.ts.snap
+++ b/backend/test/routes/v3/deploymentAssessment/__snapshots__/patchDeploymentAssessment.spec.ts.snap
@@ -4,47 +4,21 @@ exports[`routes > v3 > deploymentAssessment > patchDeploymentAssessment > 200 > 
 
 exports[`routes > v3 > deploymentAssessment > patchDeploymentAssessment > 200 > ok 1`] = `{}`;
 
-exports[`routes > v3 > deploymentAssessment > patchDeploymentAssessment > 400 > no draft 1`] = `
+exports[`routes > v3 > deploymentAssessment > patchDeploymentAssessment > 400 > empty body 1`] = `
 {
   "error": {
     "context": {
       "errors": [
         {
-          "code": "invalid_type",
-          "expected": "boolean",
-          "message": "Required",
+          "code": "custom",
+          "message": "Body must have at least one property defined.",
           "path": [
             "body",
-            "draft",
           ],
-          "received": "undefined",
         },
       ],
     },
-    "message": "Path: body.draft - Message: Required",
-    "name": "Bailo Error",
-  },
-}
-`;
-
-exports[`routes > v3 > deploymentAssessment > patchDeploymentAssessment > 400 > no name 1`] = `
-{
-  "error": {
-    "context": {
-      "errors": [
-        {
-          "code": "invalid_type",
-          "expected": "boolean",
-          "message": "Required",
-          "path": [
-            "body",
-            "draft",
-          ],
-          "received": "undefined",
-        },
-      ],
-    },
-    "message": "Path: body.draft - Message: Required",
+    "message": "Path: body - Message: Body must have at least one property defined.",
     "name": "Bailo Error",
   },
 }

--- a/backend/test/routes/v3/deploymentAssessment/__snapshots__/patchDeploymentAssessment.spec.ts.snap
+++ b/backend/test/routes/v3/deploymentAssessment/__snapshots__/patchDeploymentAssessment.spec.ts.snap
@@ -1,0 +1,53 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`routes > v3 > deploymentAssessment > patchDeploymentAssessment > 200 > no draft 1`] = `{}`;
+
+exports[`routes > v3 > deploymentAssessment > patchDeploymentAssessment > 200 > ok 1`] = `{}`;
+
+exports[`routes > v3 > deploymentAssessment > patchDeploymentAssessment > 400 > no draft 1`] = `
+{
+  "error": {
+    "context": {
+      "errors": [
+        {
+          "code": "invalid_type",
+          "expected": "boolean",
+          "message": "Required",
+          "path": [
+            "body",
+            "draft",
+          ],
+          "received": "undefined",
+        },
+      ],
+    },
+    "message": "Path: body.draft - Message: Required",
+    "name": "Bailo Error",
+  },
+}
+`;
+
+exports[`routes > v3 > deploymentAssessment > patchDeploymentAssessment > 400 > no name 1`] = `
+{
+  "error": {
+    "context": {
+      "errors": [
+        {
+          "code": "invalid_type",
+          "expected": "boolean",
+          "message": "Required",
+          "path": [
+            "body",
+            "draft",
+          ],
+          "received": "undefined",
+        },
+      ],
+    },
+    "message": "Path: body.draft - Message: Required",
+    "name": "Bailo Error",
+  },
+}
+`;
+
+exports[`routes > v3 > deploymentAssessment > patchDeploymentAssessment > audit > expected call 1`] = `undefined`;

--- a/backend/test/routes/v3/deploymentAssessment/patchDeploymentAssessment.spec.ts
+++ b/backend/test/routes/v3/deploymentAssessment/patchDeploymentAssessment.spec.ts
@@ -38,4 +38,15 @@ describe('routes > v3 > deploymentAssessment > patchDeploymentAssessment', () =>
     expect(res.statusCode).toEqual(200)
     expect(res.body).matchSnapshot()
   })
+
+  test('400 > empty body', async () => {
+    const fixture = createFixture(patchDeploymentAssessmentSchema) as any
+
+    delete fixture.body.draft
+    delete fixture.body.metadata
+    const res = await testPatch(`/api/v3/deployment-assessments/${fixture.params.deploymentAssessmentId}`, fixture)
+
+    expect(res.statusCode).toEqual(400)
+    expect(res.body).matchSnapshot()
+  })
 })

--- a/backend/test/routes/v3/deploymentAssessment/patchDeploymentAssessment.spec.ts
+++ b/backend/test/routes/v3/deploymentAssessment/patchDeploymentAssessment.spec.ts
@@ -1,0 +1,41 @@
+import { describe, expect, test, vi } from 'vitest'
+
+import audit from '../../../../src/connectors/audit/__mocks__/index.js'
+import { patchDeploymentAssessmentSchema } from '../../../../src/routes/v3/deploymentAssessment/patchDeploymentAssessment.js'
+import { createFixture, testPatch } from '../../../testUtils/routes.js'
+
+vi.mock('../../../../src/connectors/audit/index.js')
+
+const serviceMock = vi.hoisted(() => ({
+  updateDeploymentAssessment: vi.fn(),
+}))
+vi.mock('../../../../src/services/deploymentAssessment.js', () => serviceMock)
+
+describe('routes > v3 > deploymentAssessment > patchDeploymentAssessment', () => {
+  test('200 > ok', async () => {
+    const fixture = createFixture(patchDeploymentAssessmentSchema)
+    const res = await testPatch(`/api/v3/deployment-assessments/${fixture.params.deploymentAssessmentId}`, fixture)
+
+    expect(res.statusCode).toBe(200)
+    expect(res.body).matchSnapshot()
+  })
+
+  test('audit > expected call', async () => {
+    const fixture = createFixture(patchDeploymentAssessmentSchema)
+    const res = await testPatch(`/api/v3/deployment-assessments/${fixture.params.deploymentAssessmentId}`, fixture)
+
+    expect(res.statusCode).toBe(200)
+    expect(audit.onUpdateDeploymentAssessment).toHaveBeenCalled()
+    expect(audit.onUpdateDeploymentAssessment.mock.calls.at(0)?.at(1)).toMatchSnapshot()
+  })
+
+  test('200 > no draft', async () => {
+    const fixture = createFixture(patchDeploymentAssessmentSchema) as any
+
+    delete fixture.body.draft
+    const res = await testPatch(`/api/v3/deployment-assessments/${fixture.params.deploymentAssessmentId}`, fixture)
+
+    expect(res.statusCode).toEqual(200)
+    expect(res.body).matchSnapshot()
+  })
+})

--- a/backend/test/services/deploymentAssessment.spec.ts
+++ b/backend/test/services/deploymentAssessment.spec.ts
@@ -318,7 +318,7 @@ describe('services > deploymentAssessment', () => {
       DeploymentAssessmentModelMock.findOne.mockResolvedValueOnce(deploymentAssessment)
 
       await expect(updateDeploymentAssessment({ dn: 'creator' }, 'da-id', { draft: true })).rejects.toThrow(
-        'Cannot convert a released submitted assessment back to a draft.',
+        'Cannot convert a submitted deployment assessment back to a draft.',
       )
       expect(deploymentAssessment.save).not.toHaveBeenCalled()
     })

--- a/backend/test/services/deploymentAssessment.spec.ts
+++ b/backend/test/services/deploymentAssessment.spec.ts
@@ -8,6 +8,8 @@ import {
   createDeploymentAssessment,
   getDeploymentAssessmentById,
   searchDeploymentAssessments,
+  updateDeploymentAssessment,
+  UpdateDeploymentAssessmentParams,
 } from '../../src/services/deploymentAssessment.js'
 import { SchemaKind } from '../../src/types/enums.js'
 import { getTypedModelMock } from '../testUtils/setupMongooseModelMocks.js'
@@ -199,6 +201,37 @@ describe('services > deploymentAssessment', () => {
   })
 
   test.each([
+    ['null metadata', null],
+    ['a non-object', 'not-an-object'],
+    ['a missing overview', { assessment: { summary: 'Summary' } }],
+    ['a non-object overview', { overview: 'Assessment' }],
+    ['a null overview', { overview: null }],
+    ['a missing name', { overview: { riskOwner: 'user:risk-owner' } }],
+    ['a non-string name', { overview: { name: 42 } }],
+    ['a non-string risk owner', { overview: { name: 'Assessment', riskOwner: 42 } }],
+    ['a non-string justification', { overview: { name: 'Assessment', justification: 42 } }],
+    ['non-array model IDs', { overview: { name: 'Assessment', modelIds: 'model-one' } }],
+    ['non-string model IDs', { overview: { name: 'Assessment', modelIds: ['model-one', 42] } }],
+  ])('rejects schema-valid metadata with %s', async (_description, metadata) => {
+    await expect(createDeploymentAssessment({ dn: 'creator' }, { ...params, draft: true, metadata })).rejects.toThrow(
+      'Deployment assessment metadata has an invalid overview.',
+    )
+    expect(authentication.getUserInformation).not.toHaveBeenCalled()
+    expect(ModelModelMock.find).not.toHaveBeenCalled()
+    expect(DeploymentAssessmentModelMock).not.toHaveBeenCalled()
+  })
+
+  test.each([
+    ['only a name', { overview: { name: 'Assessment' } }],
+    ['an empty model ID list', { overview: { name: 'Assessment', modelIds: [] } }],
+    ['unknown extra properties', { overview: { name: 'Assessment', extra: { nested: true } }, extra: 'value' }],
+  ])('accepts metadata with %s', async (_description, metadata) => {
+    await createDeploymentAssessment({ dn: 'creator' }, { ...params, draft: true, metadata })
+
+    expect(DeploymentAssessmentModelMock).toHaveBeenCalledWith(expect.objectContaining({ metadata }))
+  })
+
+  test.each([
     [{ ...liveModel, kind: EntryKind.DataCard }, 'One or more models could not be found.'],
     [{ ...liveModel, visibility: EntryVisibility.Private }, 'Deployment assessments can only use public models.'],
     [{ ...liveModel, state: 'Review' }, 'Deployment assessments can only use models with a production state.'],
@@ -228,6 +261,101 @@ describe('services > deploymentAssessment', () => {
     DeploymentAssessmentModelMock.save.mockRejectedValueOnce(mongoError)
 
     await expect(createDeploymentAssessment({ dn: 'creator' }, params)).rejects.toMatchObject({ code: 409 })
+  })
+
+  describe('updateDeploymentAssessment', () => {
+    const existingDeploymentAssessment = () => ({
+      id: 'da-id',
+      schemaId: params.schemaId,
+      metadata: params.metadata,
+      draft: true,
+      createdBy: 'creator',
+      markModified: vi.fn(),
+      save: vi.fn(),
+    })
+
+    test('stores the validated metadata', async () => {
+      const deploymentAssessment = existingDeploymentAssessment()
+      DeploymentAssessmentModelMock.findOne.mockResolvedValueOnce(deploymentAssessment)
+      const metadata = { overview: { name: 'Updated assessment', riskOwner: 'user:risk-owner' } }
+
+      const result = await updateDeploymentAssessment({ dn: 'creator' }, 'da-id', { metadata, draft: false })
+
+      expect(schemaMocks.validateContentAgainstSchema).toHaveBeenCalledWith(params.schemaId, metadata, { draft: false })
+      expect(result.metadata).toStrictEqual(metadata)
+      expect(result.draft).toBe(false)
+      expect(deploymentAssessment.markModified).toHaveBeenCalledWith('metadata')
+      expect(deploymentAssessment.markModified).toHaveBeenCalledWith('draft')
+      expect(deploymentAssessment.save).toHaveBeenCalled()
+    })
+
+    test('leaves the draft status unchanged when the diff omits it', async () => {
+      const deploymentAssessment = existingDeploymentAssessment()
+      DeploymentAssessmentModelMock.findOne.mockResolvedValueOnce(deploymentAssessment)
+
+      const result = await updateDeploymentAssessment({ dn: 'creator' }, 'da-id', {
+        metadata: params.metadata,
+      })
+
+      expect(schemaMocks.validateContentAgainstSchema).toHaveBeenCalledWith(params.schemaId, params.metadata, {
+        draft: true,
+      })
+      expect(result.draft).toBe(true)
+      expect(deploymentAssessment.markModified).not.toHaveBeenCalledWith('draft')
+    })
+
+    test('rejects an update when authorisation fails', async () => {
+      const deploymentAssessment = existingDeploymentAssessment()
+      DeploymentAssessmentModelMock.findOne.mockResolvedValueOnce(deploymentAssessment)
+      vi.mocked(authorisation.deploymentAssessment)
+        .mockResolvedValueOnce({ success: true, id: 'da-id' })
+        .mockResolvedValueOnce({
+          success: false,
+          info: 'You do not have permission to update this Deployment Assessment',
+          id: 'da-id',
+        })
+
+      await expect(updateDeploymentAssessment({ dn: 'creator' }, 'da-id', { draft: false })).rejects.toThrow(
+        /^You do not have permission to update this Deployment Assessment/,
+      )
+      expect(schemaMocks.validateContentAgainstSchema).not.toHaveBeenCalled()
+      expect(deploymentAssessment.save).not.toHaveBeenCalled()
+    })
+
+    test('validates the existing metadata when the diff omits it', async () => {
+      const deploymentAssessment = existingDeploymentAssessment()
+      DeploymentAssessmentModelMock.findOne.mockResolvedValueOnce(deploymentAssessment)
+
+      await updateDeploymentAssessment({ dn: 'creator' }, 'da-id', { draft: false })
+
+      expect(schemaMocks.validateContentAgainstSchema).toHaveBeenCalledWith(params.schemaId, params.metadata, {
+        draft: false,
+      })
+      expect(deploymentAssessment.markModified).not.toHaveBeenCalledWith('metadata')
+    })
+
+    test('rejects schema-valid metadata with an unusable overview', async () => {
+      const deploymentAssessment = existingDeploymentAssessment()
+      DeploymentAssessmentModelMock.findOne.mockResolvedValueOnce(deploymentAssessment)
+
+      await expect(
+        updateDeploymentAssessment({ dn: 'creator' }, 'da-id', {
+          metadata: { overview: { name: 42 } } as unknown as UpdateDeploymentAssessmentParams['metadata'],
+        }),
+      ).rejects.toThrow('Deployment assessment metadata has an invalid overview.')
+      expect(deploymentAssessment.save).not.toHaveBeenCalled()
+    })
+
+    test('rejects switching released DA back to a draft', async () => {
+      const deploymentAssessment = existingDeploymentAssessment()
+      deploymentAssessment.draft = false
+      DeploymentAssessmentModelMock.findOne.mockResolvedValueOnce(deploymentAssessment)
+
+      await expect(updateDeploymentAssessment({ dn: 'creator' }, 'da-id', { draft: true })).rejects.toThrow(
+        'Cannot convert a released deployment assessment back to a draft.',
+      )
+      expect(deploymentAssessment.save).not.toHaveBeenCalled()
+    })
   })
 
   describe('searchDeploymentAssessments', () => {

--- a/backend/test/services/deploymentAssessment.spec.ts
+++ b/backend/test/services/deploymentAssessment.spec.ts
@@ -9,7 +9,6 @@ import {
   getDeploymentAssessmentById,
   searchDeploymentAssessments,
   updateDeploymentAssessment,
-  UpdateDeploymentAssessmentParams,
 } from '../../src/services/deploymentAssessment.js'
 import { SchemaKind } from '../../src/types/enums.js'
 import { getTypedModelMock } from '../testUtils/setupMongooseModelMocks.js'
@@ -201,27 +200,6 @@ describe('services > deploymentAssessment', () => {
   })
 
   test.each([
-    ['null metadata', null],
-    ['a non-object', 'not-an-object'],
-    ['a missing overview', { assessment: { summary: 'Summary' } }],
-    ['a non-object overview', { overview: 'Assessment' }],
-    ['a null overview', { overview: null }],
-    ['a missing name', { overview: { riskOwner: 'user:risk-owner' } }],
-    ['a non-string name', { overview: { name: 42 } }],
-    ['a non-string risk owner', { overview: { name: 'Assessment', riskOwner: 42 } }],
-    ['a non-string justification', { overview: { name: 'Assessment', justification: 42 } }],
-    ['non-array model IDs', { overview: { name: 'Assessment', modelIds: 'model-one' } }],
-    ['non-string model IDs', { overview: { name: 'Assessment', modelIds: ['model-one', 42] } }],
-  ])('rejects schema-valid metadata with %s', async (_description, metadata) => {
-    await expect(createDeploymentAssessment({ dn: 'creator' }, { ...params, draft: true, metadata })).rejects.toThrow(
-      'Deployment assessment metadata has an invalid overview.',
-    )
-    expect(authentication.getUserInformation).not.toHaveBeenCalled()
-    expect(ModelModelMock.find).not.toHaveBeenCalled()
-    expect(DeploymentAssessmentModelMock).not.toHaveBeenCalled()
-  })
-
-  test.each([
     ['only a name', { overview: { name: 'Assessment' } }],
     ['an empty model ID list', { overview: { name: 'Assessment', modelIds: [] } }],
     ['unknown extra properties', { overview: { name: 'Assessment', extra: { nested: true } }, extra: 'value' }],
@@ -334,25 +312,13 @@ describe('services > deploymentAssessment', () => {
       expect(deploymentAssessment.markModified).not.toHaveBeenCalledWith('metadata')
     })
 
-    test('rejects schema-valid metadata with an unusable overview', async () => {
-      const deploymentAssessment = existingDeploymentAssessment()
-      DeploymentAssessmentModelMock.findOne.mockResolvedValueOnce(deploymentAssessment)
-
-      await expect(
-        updateDeploymentAssessment({ dn: 'creator' }, 'da-id', {
-          metadata: { overview: { name: 42 } } as unknown as UpdateDeploymentAssessmentParams['metadata'],
-        }),
-      ).rejects.toThrow('Deployment assessment metadata has an invalid overview.')
-      expect(deploymentAssessment.save).not.toHaveBeenCalled()
-    })
-
     test('rejects switching released DA back to a draft', async () => {
       const deploymentAssessment = existingDeploymentAssessment()
       deploymentAssessment.draft = false
       DeploymentAssessmentModelMock.findOne.mockResolvedValueOnce(deploymentAssessment)
 
       await expect(updateDeploymentAssessment({ dn: 'creator' }, 'da-id', { draft: true })).rejects.toThrow(
-        'Cannot convert a released deployment assessment back to a draft.',
+        'Cannot convert a released submitted assessment back to a draft.',
       )
       expect(deploymentAssessment.save).not.toHaveBeenCalled()
     })

--- a/backend/test/services/deploymentAssessment.spec.ts
+++ b/backend/test/services/deploymentAssessment.spec.ts
@@ -202,11 +202,16 @@ describe('services > deploymentAssessment', () => {
   test.each([
     ['only a name', { overview: { name: 'Assessment' } }],
     ['an empty model ID list', { overview: { name: 'Assessment', modelIds: [] } }],
-    ['unknown extra properties', { overview: { name: 'Assessment', extra: { nested: true } }, extra: 'value' }],
+    ['an empty justification', { overview: { name: 'Assessment', justification: '' } }],
+    ['a risk owner but no models', { overview: { name: 'Assessment', riskOwner: 'user:risk-owner' } }],
+    ['models but no risk owner', { overview: { name: 'Assessment', modelIds: ['model-one'] } }],
+    ['repeated model IDs', { overview: { name: 'Assessment', modelIds: ['model-one', 'model-one'] } }],
   ])('accepts metadata with %s', async (_description, metadata) => {
-    await createDeploymentAssessment({ dn: 'creator' }, { ...params, draft: true, metadata })
+    const result = await createDeploymentAssessment({ dn: 'creator' }, { ...params, draft: true, metadata })
 
     expect(DeploymentAssessmentModelMock).toHaveBeenCalledWith(expect.objectContaining({ metadata }))
+    expect(idMocks.convertStringToId).toHaveBeenCalledWith('Assessment')
+    expect(result.save).toHaveBeenCalled()
   })
 
   test.each([
@@ -310,6 +315,25 @@ describe('services > deploymentAssessment', () => {
         draft: false,
       })
       expect(deploymentAssessment.markModified).not.toHaveBeenCalledWith('metadata')
+    })
+
+    test.each([
+      ['only a name', { overview: { name: 'Assessment' } }],
+      ['an empty model ID list', { overview: { name: 'Assessment', modelIds: [] } }],
+      ['an empty justification', { overview: { name: 'Assessment', justification: '' } }],
+      ['a risk owner but no models', { overview: { name: 'Assessment', riskOwner: 'user:risk-owner' } }],
+      ['models but no risk owner', { overview: { name: 'Assessment', modelIds: ['model-one'] } }],
+      ['repeated model IDs', { overview: { name: 'Assessment', modelIds: ['model-one', 'model-one'] } }],
+    ])('accepts a draft update with metadata with %s', async (_description, metadata) => {
+      const deploymentAssessment = existingDeploymentAssessment()
+      DeploymentAssessmentModelMock.findOne.mockResolvedValueOnce(deploymentAssessment)
+
+      const result = await updateDeploymentAssessment({ dn: 'creator' }, 'da-id', { metadata })
+
+      expect(schemaMocks.validateContentAgainstSchema).toHaveBeenCalledWith(params.schemaId, metadata, { draft: true })
+      expect(result.metadata).toStrictEqual(metadata)
+      expect(deploymentAssessment.markModified).toHaveBeenCalledWith('metadata')
+      expect(deploymentAssessment.save).toHaveBeenCalled()
     })
 
     test('rejects switching released DA back to a draft', async () => {


### PR DESCRIPTION
As a Deployment Assessment's `riskOwner` or `createdBy` user, I want to update an existing Deployment Assessment so that Deployment Assessment editing can be supported.

- Add a new `PATCH /api/v3/deployment-assessment/{deploymentAssessmentId}` endpoint
- If the DA is a draft then allow saving with missing fields but do not allow saving invalid/extra fields
- If the DA is not a draft (including updating the current state to no longer be a draft) then all required/mandatory fields must be populated
- Only authorised users can update the DA