### PR TITLE
feat: add scan completion webhook notifications

### DIFF
--- a/backend/src/models/Webhook.ts
+++ b/backend/src/models/Webhook.ts
@@ -8,6 +8,7 @@ export const WebhookEvent = {
   CreateReviewResponse: 'createReviewResponse',
   CreateAccessRequest: 'createAccessRequest',
   ImportModel: 'importModel',
+  ScanComplete: 'scanComplete',
 } as const
 export type WebhookEventKeys = (typeof WebhookEvent)[keyof typeof WebhookEvent]
 

--- a/backend/src/services/scan.ts
+++ b/backend/src/services/scan.ts
@@ -8,6 +8,7 @@ import { FileInterface } from '../models/File.js'
 import { ImageRef } from '../models/Release.js'
 import ScanModel, { ArtefactKind, ArtefactKindKeys } from '../models/Scan.js'
 import { UserInterface } from '../models/User.js'
+import { WebhookEvent } from '../models/Webhook.js'
 import { issueAccessToken } from '../routes/v1/registryAuth.js'
 import { dedupeByKey } from '../utils/array.js'
 import config from '../utils/config.js'
@@ -18,6 +19,7 @@ import { getFileById } from './file.js'
 import { getImageLayers } from './images/getImageLayers.js'
 import log from './log.js'
 import { getModelById } from './model.js'
+import { dispatchWebhooks, ScanWebhookResult } from './webhook.js'
 
 type ArtefactScanIdentifier =
   | {
@@ -69,10 +71,23 @@ export async function updateArtefactScanWithResults(
 }
 
 type RunScansParams = { file: FileInterface; layerRef?: never } | { file?: never; layerRef: LayerRefInterface }
+
+function toWebhookScanResult(result: ArtefactScanResult, layerDigest?: string): ScanWebhookResult {
+  return {
+    toolName: result.toolName,
+    scannerVersion: result.scannerVersion,
+    state: result.state,
+    summary: result.summary,
+    lastRunAt: result.lastRunAt,
+    artefactKind: result.artefactKind,
+    ...(layerDigest ? { layerDigest } : {}),
+  }
+}
+
 /**
  * Only await if you want to wait for the scans to complete.
  */
-export async function runScans({ file, layerRef }: RunScansParams) {
+export async function runScans({ file, layerRef }: RunScansParams): Promise<ArtefactScanResult[]> {
   const requiredScannerType: ArtefactKindKeys = file ? ArtefactKind.FILE : ArtefactKind.IMAGE
   const scannersInfo = scanners.scannersInfo()
   const activeScanners = scannersInfo.filter((scannerInfo) => scannerInfo.artefactKind === requiredScannerType)
@@ -89,7 +104,7 @@ export async function runScans({ file, layerRef }: RunScansParams) {
     }
   }
 
-  await useTransaction([
+  const [scanResults] = await useTransaction([
     async (session) => {
       try {
         const resultsInprogress: ArtefactScanResult[] = activeScanners.map((scannerInfo) => ({
@@ -102,6 +117,7 @@ export async function runScans({ file, layerRef }: RunScansParams) {
 
         const resultsArray = await scanners.startScans({ ...(file ? { file } : { layerRef }) })
         await updateArtefactScanWithResults(scanIdentifier, resultsArray, session)
+        return resultsArray
       } catch (error) {
         log.warn({ scannersInfo, scanIdentifier, error }, 'Unable to run scans. Attempting to set failure state.')
         const failedResults = activeScanners.map((scannerInfo) => ({
@@ -112,9 +128,23 @@ export async function runScans({ file, layerRef }: RunScansParams) {
 
         // This will always release the lock by setting results to no longer be in progress
         await updateArtefactScanWithResults(scanIdentifier, failedResults, session)
+        return failedResults
       }
     },
   ])
+
+  if (file) {
+    dispatchWebhooks(file.modelId, WebhookEvent.ScanComplete, `Scan completed for file ${file.name}`, {
+      scan: {
+        modelId: file.modelId,
+        artefactKind: ArtefactKind.FILE,
+        artefact: { id: file._id.toString(), name: file.name },
+        results: scanResults.map((result) => toWebhookScanResult(result)),
+      },
+    })
+  }
+
+  return scanResults
 }
 
 async function artefactScanDelay(scanIdentifier: ArtefactScanIdentifier): Promise<number> {
@@ -229,15 +259,27 @@ export async function rerunImageScanNoAuth(image: ImageRef, repositoryToken: str
     throw BadReq(`Please wait ${plural(minutesBeforeRescanning, 'minute')} before attempting a rescan ${imageName}`)
   }
 
-  for (const imageLayer of imageLayers) {
-    const layerIdentifier = { artefactKind: ArtefactKind.IMAGE, layerDigest: imageLayer.digest }
-    // Do not await so that the endpoint can return early (fire-and-forget)
-    runScans({ layerRef: { ...image, layerDigest: imageLayer.digest } }).catch((error) => {
-      log.error(
-        { scanIdentifier: layerIdentifier, image, imageName, error },
-        'Unable to set failure state after failing to run image scans. Safely aborted.',
-      )
+  // Do not await so that the endpoint can return early (fire-and-forget).
+  // The completion webhook is sent only after all image layers have finished scanning.
+  Promise.all(
+    imageLayers.map(async (imageLayer) => {
+      const results = await runScans({ layerRef: { ...image, layerDigest: imageLayer.digest } })
+      return results.map((result) => toWebhookScanResult(result, imageLayer.digest))
+    }),
+  )
+    .then((layerResults) => {
+      dispatchWebhooks(image.repository, WebhookEvent.ScanComplete, `Scan completed for image ${imageName}`, {
+        scan: {
+          modelId: image.repository,
+          artefactKind: ArtefactKind.IMAGE,
+          artefact: image,
+          results: layerResults.flat(),
+        },
+      })
     })
-  }
+    .catch((error) => {
+      log.error({ image, imageName, error }, 'Unable to run image scans. Safely aborted.')
+    })
+
   return `Image scan started for ${imageName}`
 }

--- a/backend/src/services/specification.ts
+++ b/backend/src/services/specification.ts
@@ -494,7 +494,14 @@ export const webhookInterfaceSchema = z.object({
   token: z.string().openapi({ example: 'abcd' }),
   insecureSSL: z.boolean().openapi({ example: false }),
   events: z.array(z.string()).openapi({
-    example: ['createRelease', 'updateRelease', 'createReviewResponse', 'createAccessRequest', 'importModel'],
+    example: [
+      'createRelease',
+      'updateRelease',
+      'createReviewResponse',
+      'createAccessRequest',
+      'importModel',
+      'scanComplete',
+    ],
   }),
   active: z.boolean().openapi({ example: true }),
 

--- a/backend/src/services/webhook.ts
+++ b/backend/src/services/webhook.ts
@@ -1,11 +1,13 @@
 import fetch, { HeadersInit } from 'node-fetch'
 
+import { ArtefactScanResult } from '../connectors/artefactScanning/Base.js'
 import { ModelAction } from '../connectors/authorisation/actions.js'
 import authorisation from '../connectors/authorisation/index.js'
 import { AccessRequestDoc } from '../models/AccessRequest.js'
 import { ModelTransferDoc } from '../models/ModelTransfer.js'
-import { ReleaseDoc } from '../models/Release.js'
+import { ImageRef, ReleaseDoc } from '../models/Release.js'
 import { ReviewInterface } from '../models/Review.js'
+import { ArtefactKindKeys } from '../models/Scan.js'
 import { UserInterface } from '../models/User.js'
 import WebhookModel, { WebhookEventKeys, WebhookInterface } from '../models/Webhook.js'
 import { Forbidden, NotFound } from '../utils/error.js'
@@ -73,11 +75,23 @@ export async function removeWebhook(user: UserInterface, modelId: string, webhoo
   }
 }
 
+export type ScanWebhookResult = Omit<ArtefactScanResult, 'additionalInfo'> & { layerDigest?: string }
+
+export type ScanCompleteWebhookContent = {
+  scan: {
+    modelId: string
+    artefactKind: ArtefactKindKeys
+    artefact: { id: string; name: string } | ImageRef
+    results: ScanWebhookResult[]
+  }
+}
+
 type WebhookContent =
   | { release: ReleaseDoc }
   | { review: ReviewInterface }
   | { accessRequest: AccessRequestDoc }
   | { transfer: ModelTransferDoc }
+  | ScanCompleteWebhookContent
 
 /**
  * Sends webhooks in an `await`able manner.

--- a/backend/test/routes/model/webhook/postWebhook.spec.ts
+++ b/backend/test/routes/model/webhook/postWebhook.spec.ts
@@ -10,6 +10,16 @@ vi.mock('../../../../src/services/webhook.js', () => ({
 }))
 
 describe('routes > webhook > postWebhook', () => {
+  test('schema accepts scan completion events', () => {
+    const fixture = createFixture(postWebhookSchema)
+    const result = postWebhookSchema.safeParse({
+      ...fixture,
+      body: { ...fixture.body, events: ['scanComplete'] },
+    })
+
+    expect(result.success).toBe(true)
+  })
+
   test('200 > ok', async () => {
     const fixture = createFixture(postWebhookSchema)
     const res = await testPost(`/api/v2/model/${fixture.params.modelId}/webhooks`, fixture)

--- a/backend/test/services/scan.spec.ts
+++ b/backend/test/services/scan.spec.ts
@@ -14,6 +14,11 @@ import { getTypedModelMock } from '../testUtils/setupMongooseModelMocks.js'
 vi.mock('../../src/connectors/artefactScanning/index.js')
 vi.mock('../../src/utils/transactions.js')
 
+const webhookMocks = vi.hoisted(() => ({
+  dispatchWebhooks: vi.fn(),
+}))
+vi.mock('../../src/services/webhook.js', () => webhookMocks)
+
 const ScanModelMock = getTypedModelMock('ScanModel')
 
 const configMock = vi.hoisted(
@@ -130,7 +135,7 @@ const registryAuthMocks = vi.hoisted(() => ({
 vi.mock('../../src/routes/v1/registryAuth.js', () => registryAuthMocks)
 
 const testFileId = '73859F8D26679D2E52597326'
-const mockFile = { _id: 'file123', name: 'file.txt', size: 1 } as any
+const mockFile = { _id: 'file123', modelId: 'model123', name: 'file.txt', size: 1 } as any
 
 describe('services > scan', () => {
   describe('scanFile', () => {
@@ -157,6 +162,25 @@ describe('services > scan', () => {
           upsert: true,
         },
       })
+    })
+
+    test('dispatches a webhook after all file scans complete', async () => {
+      await runScans({ file: mockFile })
+
+      expect(webhookMocks.dispatchWebhooks).toHaveBeenCalledOnce()
+      expect(webhookMocks.dispatchWebhooks).toHaveBeenCalledWith(
+        'model123',
+        'scanComplete',
+        'Scan completed for file file.txt',
+        {
+          scan: {
+            modelId: 'model123',
+            artefactKind: ArtefactKind.FILE,
+            artefact: { id: 'file123', name: 'file.txt' },
+            results: [expect.objectContaining({ toolName: 'Test', state: ArtefactScanState.Complete })],
+          },
+        },
+      )
     })
 
     test('sets scan state to Error when scanner throws', async () => {
@@ -322,6 +346,39 @@ describe('services > scan', () => {
   })
 
   describe('rerunImageScanNoAuth', () => {
+    test('dispatches one webhook after all image layers complete', async () => {
+      imageMocks.getImageLayers.mockResolvedValueOnce([{ digest: 'sha256:layer1' }, { digest: 'sha256:layer2' }])
+      ScanModelMock.find.mockResolvedValueOnce([])
+      fileScanningMock.startScans.mockReturnValue([
+        {
+          state: ArtefactScanState.Complete,
+          toolName: 'imageScan',
+          lastRunAt: new Date(),
+          artefactKind: ArtefactKind.IMAGE,
+        },
+      ])
+
+      await rerunImageScanNoAuth({ repository: 'model123', name: 'image', tag: 'latest' } as any, 'token')
+
+      await vi.waitFor(() => expect(webhookMocks.dispatchWebhooks).toHaveBeenCalledOnce())
+      expect(webhookMocks.dispatchWebhooks).toHaveBeenCalledWith(
+        'model123',
+        'scanComplete',
+        'Scan completed for image model123/image:latest',
+        {
+          scan: {
+            modelId: 'model123',
+            artefactKind: ArtefactKind.IMAGE,
+            artefact: { repository: 'model123', name: 'image', tag: 'latest' },
+            results: expect.arrayContaining([
+              expect.objectContaining({ layerDigest: 'sha256:layer1', state: ArtefactScanState.Complete }),
+              expect.objectContaining({ layerDigest: 'sha256:layer2', state: ArtefactScanState.Complete }),
+            ]),
+          },
+        },
+      )
+    })
+
     test('success no auth', async () => {
       ScanModelMock.find.mockResolvedValueOnce([])
 

--- a/frontend/pages/docs/users/programmatically-using-bailo/webhooks.mdx
+++ b/frontend/pages/docs/users/programmatically-using-bailo/webhooks.mdx
@@ -49,6 +49,7 @@ A Bailo model's webhook can be triggered by the following events:
 - **createReviewResponse** - Fires when a reviewer submits a response (approval or change request)
 - **createAccessRequest** - Fires when a user submits an access request for the model
 - **importModel** - Fires when a mirrored model completes an import of all data and artefacts.
+- **scanComplete** - Fires after all configured scanners finish scanning a file or all layers of a Docker image.
 
 ## Request format
 
@@ -121,6 +122,36 @@ The body of the webhook's request varies depending on the type of event.
   "createdBy": "user",
   "createdAt": "2025-01-21T12:00:00.000Z",
   "updatedAt": "2025-01-21T12:00:00.000Z"
+}
+```
+
+### scanComplete
+
+The scan completion payload includes final scanner states and summaries. Raw scanner output is not included. For Docker
+images, each result includes the layer digest so results can be associated with the layer that was scanned.
+
+```json
+{
+  "event": "scanComplete",
+  "description": "Scan completed for file model.bin",
+  "scan": {
+    "modelId": "model-abc123",
+    "artefactKind": "file",
+    "artefact": {
+      "id": "0123456789abcdef01234567",
+      "name": "model.bin"
+    },
+    "results": [
+      {
+        "toolName": "ClamAV",
+        "scannerVersion": "1.4.3",
+        "state": "complete",
+        "summary": [],
+        "lastRunAt": "2026-09-07T09:00:00.000Z",
+        "artefactKind": "file"
+      }
+    ]
+  }
 }
 ```
 


### PR DESCRIPTION
##### Checklist

- [x] `npm run lint && npm run build` passes
- [x] `npm run style` makes no changes
- [ ] `npm run test` succeeds both unit and integration testing.

### Affected core subsystem(s)

Backend artefact scanning and webhooks; webhook user documentation.

### Description of change

Adds a `scanComplete` webhook event for model artefacts.

- Files emit one event after all configured file scanners reach a final state.
- Docker images emit one event only after every image layer has finished scanning.
- Payloads include scanner state, summary, scanner version and last-run time; image results also include the layer digest.
- Raw scanner `additionalInfo` is intentionally excluded from webhook payloads.
- Existing scanning endpoints remain fire-and-forget.
- Webhook API examples and user documentation now include the new event.

Closes #3772.

### Validation

- Regression tests fail on `main` before the change and pass after it.
- Targeted backend tests: 27/27 passed.
- Backend Prettier, ESLint and TypeScript build passed.
- Frontend Prettier, ESLint and production build passed.
- Frontend unit tests: 159/159 passed with `TZ=UTC`.
- Documentation style checks passed using the same GNU `realpath` behaviour as CI/Linux.
- Full backend suite with `TZ=UTC`: 1,416/1,417 tests passed. The only failure was an unrelated existing v3 review-response route test returning 404 once; that test passed 5/5 when rerun in isolation.
- `git diff --check` passed.
