### PR TITLE
feat: expose detailed file scan output

### DIFF
--- a/backend/src/services/specification.ts
+++ b/backend/src/services/specification.ts
@@ -204,6 +204,7 @@ export const fileWithScanInterfaceSchema = z.object({
         scannerVersion: true,
         state: true,
         summary: true,
+        additionalInfo: true,
         lastRunAt: true,
         _id: true,
         id: true,

--- a/backend/test/routes/model/file/getFiles.spec.ts
+++ b/backend/test/routes/model/file/getFiles.spec.ts
@@ -2,6 +2,7 @@ import { describe, expect, test, vi } from 'vitest'
 
 import audit from '../../../../src/connectors/audit/__mocks__/index.js'
 import { getFilesSchema } from '../../../../src/routes/v2/model/file/getFiles.js'
+import { fileWithScanInterfaceSchema } from '../../../../src/services/specification.js'
 import { createFixture, testGet } from '../../../testUtils/routes.js'
 
 vi.mock('../../../../src/connectors/audit/index.js')
@@ -14,6 +15,48 @@ const fileMock = vi.hoisted(() => {
 vi.mock('../../../../src/services/file.js', () => fileMock)
 
 describe('routes > files > getFiles', () => {
+  test('file scan response schema retains detailed scanner output', () => {
+    const additionalInfo = {
+      summary: {
+        total_issues: 0,
+        total_issues_by_severity: {},
+        input_path: 'model.pkl',
+        absolute_path: '/tmp/model.pkl',
+        modelscan_version: '0.8.1',
+        timestamp: '2026-09-07T09:00:00.000Z',
+        scanned: { total_scanned: 1, scanned_files: ['model.pkl'] },
+        skipped: { total_skipped: 0, skipped_files: [] },
+      },
+      issues: [],
+      errors: [],
+    }
+    const result = fileWithScanInterfaceSchema.parse({
+      modelId: 'model-123',
+      name: 'model.pkl',
+      size: 1024,
+      mime: 'application/octet-stream',
+      path: '/model/model-123/files/file-123',
+      complete: true,
+      scanResults: [
+        {
+          artefactKind: 'file',
+          fileId: 'file-123',
+          toolName: 'ModelScan',
+          scannerVersion: '0.8.1',
+          state: 'complete',
+          additionalInfo,
+          lastRunAt: '2026-09-07T09:00:00.000Z',
+          _id: '67cecbffd2a0951d1693b396',
+          id: '67cecbffd2a0951d1693b396',
+        },
+      ],
+      createdAt: '2026-09-07T09:00:00.000Z',
+      updatedAt: '2026-09-07T09:00:00.000Z',
+    })
+
+    expect(result.scanResults?.[0].additionalInfo).toEqual(additionalInfo)
+  })
+
   test('200 > ok', async () => {
     const fixture = createFixture(getFilesSchema)
     const res = await testGet(`/api/v2/model/${fixture.params.modelId}/files`)

--- a/frontend/pages/docs/users/using-scanners/file-scanning.mdx
+++ b/frontend/pages/docs/users/using-scanners/file-scanning.mdx
@@ -12,6 +12,7 @@ import rescanView from 'public/docs/bailo_file_rescan.png'
 > - How are files scanned in Bailo?
 > - What scanners are used for file scanning?
 > - How do I rescan a file?
+> - How do I view detailed scanner output?
 
 ## Using scanners
 
@@ -31,6 +32,7 @@ For scan results:
 - Go to your model and click on File Management Tab
 - Click the Scan chip, towards the right of your file
 - View scan results. Each scanning tool will have its results listed separately
+- Expand **Detailed scanner output** to inspect the structured output returned by that scanner, when available
 
 <Box sx={{ maxWidth: '75%', margin: 'auto' }}>
   <Image style={{ width: '100%', height: 'auto' }} alt='view file scanning chip' src={chipView} />

--- a/frontend/src/entry/model/scanning/ScanResultDetail.tsx
+++ b/frontend/src/entry/model/scanning/ScanResultDetail.tsx
@@ -1,9 +1,21 @@
 import BlockOutlined from '@mui/icons-material/BlockOutlined'
 import Done from '@mui/icons-material/Done'
 import ErrorIcon from '@mui/icons-material/Error'
+import ExpandMore from '@mui/icons-material/ExpandMore'
 import HourglassTop from '@mui/icons-material/HourglassTop'
 import Warning from '@mui/icons-material/Warning'
-import { Chip, List, ListItem, ListItemText, Stack, Typography } from '@mui/material'
+import {
+  Accordion,
+  AccordionDetails,
+  AccordionSummary,
+  Box,
+  Chip,
+  List,
+  ListItem,
+  ListItemText,
+  Stack,
+  Typography,
+} from '@mui/material'
 import { ReactElement } from 'react'
 import { ArtefactScanState, ClamAVSummary, ModelScanSummary, ScanResultInterface } from 'types/types'
 import { formatDateTimeString } from 'utils/dateUtils'
@@ -18,7 +30,7 @@ interface ScanResultDetailProps {
  */
 export default function ScanResultDetail({ scanResult }: ScanResultDetailProps) {
   const hasFindings = !!scanResult.summary && scanResult.summary.length > 0
-  const { state, toolName, scannerVersion, lastRunAt, summary } = scanResult
+  const { state, toolName, scannerVersion, lastRunAt, summary, additionalInfo } = scanResult
 
   const renderHeader = (): ReactElement => {
     if (hasFindings) {
@@ -132,6 +144,31 @@ export default function ScanResultDetail({ scanResult }: ScanResultDetailProps) 
         <List sx={{ listStyleType: 'disc', pl: 2, py: 0 }}>
           {summary.map((vulnerability) => renderFindingItem(vulnerability))}
         </List>
+      )}
+      {additionalInfo && (
+        <Accordion disableGutters elevation={0} sx={{ '&:before': { display: 'none' } }}>
+          <AccordionSummary expandIcon={<ExpandMore />} sx={{ px: 0 }}>
+            <Typography sx={{ fontWeight: 'bold' }}>Detailed scanner output</Typography>
+          </AccordionSummary>
+          <AccordionDetails sx={{ px: 0, pt: 0 }}>
+            <Box
+              component='pre'
+              sx={{
+                bgcolor: 'action.hover',
+                borderRadius: 1,
+                m: 0,
+                maxHeight: 320,
+                maxWidth: 640,
+                overflow: 'auto',
+                overflowWrap: 'anywhere',
+                p: 1,
+                whiteSpace: 'pre-wrap',
+              }}
+            >
+              {JSON.stringify(additionalInfo, null, 2)}
+            </Box>
+          </AccordionDetails>
+        </Accordion>
       )}
     </Stack>
   )

--- a/frontend/test/entry/model/scanning/ScanResultDetail.spec.tsx
+++ b/frontend/test/entry/model/scanning/ScanResultDetail.spec.tsx
@@ -1,0 +1,33 @@
+import { render, screen } from '@testing-library/react'
+import { describe, expect, test } from 'vitest'
+
+import ScanResultDetail from '../../../../src/entry/model/scanning/ScanResultDetail'
+import { ArtefactScanState } from '../../../../types/types'
+
+describe('ScanResultDetail', () => {
+  test('shows detailed scanner output when it is available', () => {
+    render(
+      <ScanResultDetail
+        scanResult={
+          {
+            _id: 'scan-123',
+            state: ArtefactScanState.Complete,
+            toolName: 'ModelScan',
+            scannerVersion: '0.8.1',
+            summary: [],
+            additionalInfo: {
+              errors: [],
+              issues: [{ description: 'Suspicious module', severity: 'HIGH' }],
+            },
+            lastRunAt: '2026-09-07T09:00:00.000Z',
+            createdAt: new Date('2026-09-07T09:00:00.000Z'),
+            updatedAt: new Date('2026-09-07T09:00:00.000Z'),
+          } as any
+        }
+      />,
+    )
+
+    expect(screen.getByText('Detailed scanner output')).toBeDefined()
+    expect(screen.getByText(/Suspicious module/)).toBeDefined()
+  })
+})


### PR DESCRIPTION
##### Checklist

- [x] `npm run lint && npm run build` passes
- [x] `npm run style` makes no changes
- [x] `npm run test` succeeds both unit and integration testing.

### Affected core subsystem(s)

Backend file scan API specification; frontend file scanning results and documentation.

### Description of change

Exposes the detailed scanner output Bailo already stores for file scans and makes it available from the file scanning UI.

- Retains `additionalInfo` in the documented file scan response schema instead of stripping it from the public contract.
- Adds an expandable `Detailed scanner output` section to individual scan results when structured scanner output is available.
- Keeps the normal scan summary compact; detailed output is only shown on demand.
- Updates the file scanning documentation with the new detail view.
- Keeps the existing file-view authorisation boundary unchanged.

This addresses the detailed-output retrieval and display gap described in #2348. A separate configurable minimum-role threshold for detailed scan output is not introduced by this change.

### Validation

- Regression tests fail on `main` before the change and pass after it.
- Targeted backend file route tests: 3/3 passed.
- New frontend `ScanResultDetail` regression test passed.
- Full backend suite: 1,415/1,415 passed with `TZ=UTC`.
- Full frontend suite: 160/160 passed with `TZ=UTC`.
- Exact root `npm run lint`, `npm run build`, and `npm run test` passed.
- `npm run style` made no changes.
- Documentation style checks passed.
- `git diff --check` passed.
