### PR TITLE
feat: download release files as archive

### DIFF
--- a/backend/src/routes/v2/model/file/getDownloadReleaseFiles.ts
+++ b/backend/src/routes/v2/model/file/getDownloadReleaseFiles.ts
@@ -1,0 +1,176 @@
+import path from 'node:path'
+import { PassThrough, pipeline as pipelineCallback, Readable, Writable } from 'node:stream'
+import { pipeline } from 'node:stream/promises'
+import zlib from 'node:zlib'
+
+import { create } from 'content-disposition'
+import { Request, Response } from 'express'
+import { Pack, pack } from 'tar-stream'
+
+import { AuditInfo } from '../../../../connectors/audit/Base.js'
+import audit from '../../../../connectors/audit/index.js'
+import { z } from '../../../../lib/zod.js'
+import { type FileWithScanResultsAggregate } from '../../../../models/File.js'
+import { authoriseFileDownloads, downloadFile, getFilesByIds } from '../../../../services/file.js'
+import log from '../../../../services/log.js'
+import { getReleaseBySemver } from '../../../../services/release.js'
+import { registerPath } from '../../../../services/specification.js'
+import { HttpHeader } from '../../../../types/enums.js'
+import { BailoError } from '../../../../types/error.js'
+import { Forbidden } from '../../../../utils/error.js'
+import { parse } from '../../../../utils/validate.js'
+
+const cacheControl = 'no-store'
+const archiveContentType = 'application/gzip'
+
+const paramsSchema = z.object({
+  modelId: z.string(),
+  semver: z.string(),
+})
+
+export const getDownloadReleaseFilesSchema = z.object({ params: paramsSchema })
+
+registerPath({
+  method: 'get',
+  path: '/api/v2/model/{modelId}/release/{semver}/files/download',
+  tags: ['file'],
+  description: 'Download all files associated with a release as a streamed tar.gz archive.',
+  schema: getDownloadReleaseFilesSchema,
+  responses: {
+    200: {
+      description: 'A tar.gz archive containing all files associated with the release.',
+      content: {
+        [archiveContentType]: {
+          schema: z.string().openapi({ format: 'binary' }),
+        },
+      },
+    },
+  },
+})
+
+type TarEntrySink = ReturnType<Pack['entry']>
+
+function asNodeReadable(stream: Pack): Readable {
+  return stream as unknown as Readable
+}
+
+function asNodeWritable(stream: TarEntrySink): Writable {
+  return stream as unknown as Writable
+}
+
+function createArchiveEntryName(file: FileWithScanResultsAggregate, usedNames: Set<string>) {
+  const baseName = path.posix.basename(file.name.replaceAll('\\', '/')) || file.id
+  if (!usedNames.has(baseName)) {
+    usedNames.add(baseName)
+    return baseName
+  }
+
+  const parsed = path.posix.parse(baseName)
+  let suffix = 2
+  let candidate = `${parsed.name}-${suffix}${parsed.ext}`
+  while (usedNames.has(candidate)) {
+    suffix += 1
+    candidate = `${parsed.name}-${suffix}${parsed.ext}`
+  }
+  usedNames.add(candidate)
+  return candidate
+}
+
+function createArchiveStream(user: Request['user'], files: FileWithScanResultsAggregate[]) {
+  const tarStream = pack()
+  const gzipStream = zlib.createGzip({ level: zlib.constants.Z_BEST_SPEED })
+  const output = new PassThrough()
+  const usedNames = new Set<string>()
+
+  void pipeline(asNodeReadable(tarStream), gzipStream, output).catch((error) => {
+    output.destroy(error as Error)
+  })
+
+  void (async () => {
+    try {
+      for (const file of files) {
+        const fileStream = await downloadFile(user, file.id)
+        const entry = tarStream.entry({
+          name: createArchiveEntryName(file, usedNames),
+          size: file.size,
+          mode: 0o644,
+          type: 'file',
+        })
+        await pipeline(fileStream, asNodeWritable(entry))
+      }
+      tarStream.finalize()
+    } catch (error) {
+      tarStream.destroy(error as Error)
+      output.destroy(error as Error)
+    }
+  })()
+
+  return output
+}
+
+export const getDownloadReleaseFiles = [
+  async (req: Request, res: Response): Promise<void> => {
+    req.audit = AuditInfo.ViewFile
+    const {
+      params: { modelId, semver },
+    } = parse(req, getDownloadReleaseFilesSchema)
+
+    const release = await getReleaseBySemver(req.user, modelId, semver)
+    const files = await getFilesByIds(req.user, modelId, release.fileIds)
+
+    if (files.length !== release.fileIds.length) {
+      throw Forbidden('You do not have permission to download every file in this release.', {
+        userDn: req.user.dn,
+        modelId,
+        semver,
+      })
+    }
+
+    await authoriseFileDownloads(req.user, modelId, files)
+    for (const file of files) {
+      await audit.onViewFile(req, file)
+    }
+
+    const stream = createArchiveStream(req.user, files)
+    let headersCommitted = false
+
+    stream.once('error', (err: unknown) => {
+      const error: BailoError = {
+        code: 500,
+        name: 'Release archive download error',
+        message: 'Error occurred whilst streaming release archive',
+        status: 500,
+        cause: err instanceof Error ? err.message : String(err),
+        context: { modelId, semver },
+      }
+
+      if (!headersCommitted && !res.headersSent) {
+        res.status(500).json(error)
+      } else {
+        res.destroy(err as Error)
+      }
+      log.error({ error })
+    })
+
+    stream.once('readable', () => {
+      if (headersCommitted) {
+        return
+      }
+      headersCommitted = true
+      res.set(HttpHeader.CONTENT_DISPOSITION, create(`${modelId}-${semver}.tar.gz`, { type: 'attachment' }))
+      res.set(HttpHeader.CONTENT_TYPE, archiveContentType)
+      res.set(HttpHeader.CACHE_CONTROL, cacheControl)
+      res.status(200)
+    })
+
+    res.once('close', () => {
+      if (!stream.readableEnded && !stream.destroyed) {
+        stream.destroy()
+      }
+    })
+
+    pipelineCallback(stream, res, () => {
+      /* NOOP: stream errors are handled above. */
+    })
+  },
+]

--- a/backend/src/routes/v2/routes.ts
+++ b/backend/src/routes/v2/routes.ts
@@ -20,6 +20,7 @@ import { postAccessRequestComment } from './model/accessRequest/postAccessReques
 import { deleteModel } from './model/deleteModel.js'
 import { deleteFile } from './model/file/deleteFile.js'
 import { getDownloadFile } from './model/file/getDownloadFile.js'
+import { getDownloadReleaseFiles } from './model/file/getDownloadReleaseFiles.js'
 import { getFiles } from './model/file/getFiles.js'
 import { patchFile } from './model/file/patchFile.js'
 import { postFinishMultipartUpload } from './model/file/postFinishMultipartUpload.js'
@@ -120,6 +121,8 @@ router.post('/model/:modelId/import-model-card-text', ...postImportModelCardText
 router.post('/model/:modelId/releases', ...postRelease)
 router.get('/model/:modelId/releases', ...getReleases)
 router.get('/model/:modelId/release/:semver', ...getRelease)
+router.get('/model/:modelId/release/:semver/files/download', ...getDownloadReleaseFiles)
+router.get('/token/model/:modelId/release/:semver/files/download', ...getDownloadReleaseFiles)
 router.get('/model/:modelId/release/:semver/file/:fileName/download', ...getDownloadFile)
 // This is a temporary workaround to split out the URL to disable authorisation.
 router.get('/token/model/:modelId/release/:semver/file/:fileName/download', ...getDownloadFile)

--- a/backend/src/services/file.ts
+++ b/backend/src/services/file.ts
@@ -190,6 +190,20 @@ export async function finishUploadMultipartFile(
   return ret
 }
 
+export async function authoriseFileDownloads(
+  user: UserInterface,
+  modelId: string,
+  files: FileWithScanResultsAggregate[],
+) {
+  const model = await getModelById(user, modelId)
+  const auths = await authorisation.files(user, model, files, FileAction.Download)
+  const denied = auths.find((auth) => !auth.success)
+
+  if (denied) {
+    throw Forbidden(denied.info, { userDn: user.dn, fileId: denied.id, modelId })
+  }
+}
+
 export async function downloadFile(user: UserInterface, fileId: string, range?: { start: number; end: number }) {
   const file = await getFileById(user, fileId)
   const model = await getModelById(user, file.modelId)

--- a/backend/test/routes/model/file/getDownloadReleaseFiles.spec.ts
+++ b/backend/test/routes/model/file/getDownloadReleaseFiles.spec.ts
@@ -1,0 +1,94 @@
+import { Readable } from 'node:stream'
+import { gunzipSync } from 'node:zlib'
+
+import { extract } from 'tar-stream'
+import { describe, expect, test, vi } from 'vitest'
+
+import audit from '../../../../src/connectors/audit/__mocks__/index.js'
+import { testGet } from '../../../testUtils/routes.js'
+
+vi.mock('../../../../src/connectors/audit/index.js')
+
+const files = [
+  { id: 'file-a', name: '../alpha.txt', size: 5, updatedAt: new Date('2026-09-07T09:00:00Z') },
+  { id: 'file-b', name: 'beta.txt', size: 4, updatedAt: new Date('2026-09-07T09:00:00Z') },
+]
+
+const fileMock = vi.hoisted(() => ({
+  authoriseFileDownloads: vi.fn(),
+  downloadFile: vi.fn((_user, fileId: string) =>
+    Promise.resolve(Readable.from([fileId === 'file-a' ? 'alpha' : 'beta'])),
+  ),
+  getFilesByIds: vi.fn(() => files),
+}))
+vi.mock('../../../../src/services/file.js', () => fileMock)
+
+const releaseMock = vi.hoisted(() => ({
+  getReleaseBySemver: vi.fn(() => ({ fileIds: ['file-a', 'file-b'] })),
+}))
+vi.mock('../../../../src/services/release.js', () => releaseMock)
+
+function binaryParser(res, callback) {
+  const chunks: Buffer[] = []
+  res.on('data', (chunk) => chunks.push(Buffer.from(chunk)))
+  res.on('end', () => callback(null, Buffer.concat(chunks)))
+}
+
+async function listTarEntries(archive: Buffer) {
+  const entries = new Map<string, string>()
+  const untar = extract()
+  const complete = new Promise<void>((resolve, reject) => {
+    untar.on('entry', (header, stream, next) => {
+      const chunks: Buffer[] = []
+      stream.on('data', (chunk) => chunks.push(Buffer.from(chunk as Uint8Array)))
+      stream.on('end', () => {
+        entries.set(header.name, Buffer.concat(chunks).toString('utf8'))
+        next()
+      })
+      stream.resume()
+    })
+    untar.on('finish', resolve)
+    untar.on('error', reject)
+  })
+  untar.end(gunzipSync(archive))
+  await complete
+  return entries
+}
+
+describe('routes > files > getDownloadReleaseFiles', () => {
+  test('downloads all files in a release as a tar.gz archive', async () => {
+    const res = await testGet('/api/v2/model/model-123/release/1.2.3/files/download').buffer(true).parse(binaryParser)
+
+    expect(res.statusCode).toBe(200)
+    expect(res.headers['content-type']).toContain('application/gzip')
+    expect(res.headers['content-disposition']).toContain('model-123-1.2.3.tar.gz')
+
+    const entries = await listTarEntries(res.body)
+    expect(Object.fromEntries(entries)).toEqual({ 'alpha.txt': 'alpha', 'beta.txt': 'beta' })
+    expect(fileMock.authoriseFileDownloads).toHaveBeenCalledWith(expect.anything(), 'model-123', files)
+    expect(fileMock.downloadFile).toHaveBeenCalledTimes(2)
+    expect(audit.onViewFile).toHaveBeenCalledTimes(2)
+  })
+
+  test('rejects before streaming when not every release file is visible', async () => {
+    fileMock.getFilesByIds.mockReturnValueOnce([files[0]])
+
+    const res = await testGet('/api/v2/model/model-123/release/1.2.3/files/download')
+
+    expect(res.statusCode).toBe(403)
+    expect(fileMock.authoriseFileDownloads).not.toHaveBeenCalled()
+    expect(fileMock.downloadFile).not.toHaveBeenCalled()
+  })
+
+  test('returns a server error when an archive stream cannot be created', async () => {
+    fileMock.downloadFile.mockRejectedValueOnce(new Error('storage unavailable'))
+
+    const res = await testGet('/api/v2/model/model-123/release/1.2.3/files/download')
+
+    expect(res.statusCode).toBe(500)
+    expect(res.body).toMatchObject({
+      name: 'Release archive download error',
+      message: 'Error occurred whilst streaming release archive',
+    })
+  })
+})

--- a/backend/test/services/file.spec.ts
+++ b/backend/test/services/file.spec.ts
@@ -7,6 +7,7 @@ import { FileAction } from '../../src/connectors/authorisation/actions.js'
 import authorisation from '../../src/connectors/authorisation/index.js'
 import { ArtefactKind } from '../../src/models/Scan.js'
 import {
+  authoriseFileDownloads,
   downloadFile,
   finishUploadMultipartFile,
   getFilesByIds,
@@ -687,6 +688,26 @@ describe('services > file', () => {
 
     const files = await getFilesByIds(user, modelId, fileIds)
     expect(files).toStrictEqual([])
+  })
+
+  test('authoriseFileDownloads > success', async () => {
+    const user = { dn: 'testUser' } as any
+    const modelId = 'testModelId'
+    const files = [{ id: testFileId, _id: { toString: vi.fn(() => testFileId) } }] as any
+    vi.mocked(authorisation.files).mockResolvedValueOnce([{ success: true, id: testFileId }])
+
+    await authoriseFileDownloads(user, modelId, files)
+
+    expect(authorisation.files).toHaveBeenCalledWith(user, expect.anything(), files, FileAction.Download)
+  })
+
+  test('authoriseFileDownloads > rejects when any file cannot be downloaded', async () => {
+    const user = { dn: 'testUser' } as any
+    const modelId = 'testModelId'
+    const files = [{ id: testFileId, _id: { toString: vi.fn(() => testFileId) } }] as any
+    vi.mocked(authorisation.files).mockResolvedValueOnce([{ success: false, info: 'Download denied.', id: testFileId }])
+
+    await expect(authoriseFileDownloads(user, modelId, files)).rejects.toThrow(/^Download denied\./)
   })
 
   test('downloadFile > success', async () => {

--- a/frontend/pages/docs/users/using-a-model/downloading-files.mdx
+++ b/frontend/pages/docs/users/using-a-model/downloading-files.mdx
@@ -13,6 +13,7 @@ import downloadfile3 from 'public/docs/bailo_file_download_release_page.png'
 > - How do I download files from a model in Bailo?
 > - Where can I find files to download?
 > - What are the different ways to download files?
+> - How do I download all files from a release at once?
 
 Files can be downloaded from three locations in Bailo. The File Management tab provides access to all files, while the
 Releases tab and individual release pages show only files attached to releases.
@@ -40,6 +41,10 @@ Download release-associated files from the **Releases** tab using the download l
 </Box>
 
 The screenshot above shows the Releases tab with download links next to each file in each release.
+
+Expand the files section for a release and select **Download all files** to download all files in that release as a
+single `tar.gz` archive. The archive is streamed as it is created, so Bailo does not need to build the entire archive in
+memory.
 
 ## From a specific release page
 

--- a/frontend/src/entry/model/releases/ReleaseAssetsAccordion.tsx
+++ b/frontend/src/entry/model/releases/ReleaseAssetsAccordion.tsx
@@ -1,5 +1,6 @@
 import ArrowDropDown from '@mui/icons-material/ArrowDropDown'
-import { Accordion, AccordionDetails, AccordionSummary, Box, Stack, Typography } from '@mui/material'
+import Download from '@mui/icons-material/Download'
+import { Accordion, AccordionDetails, AccordionSummary, Box, Button, Stack, Typography } from '@mui/material'
 import { memoize } from 'lodash-es'
 import { useContext, useState } from 'react'
 import Paginate from 'src/common/Paginate'
@@ -7,6 +8,7 @@ import ArtefactScanningInfoContext from 'src/contexts/artefactScanningInfoContex
 import UiConfigContext from 'src/contexts/uiConfigContext'
 import FileDisplay from 'src/entry/model/files/FileDisplay'
 import CodeLine from 'src/entry/model/registry/CodeLine'
+import Link from 'src/Link'
 import { ArtefactKind, EntryInterface, ReleaseInterface } from 'types/types'
 import { plural } from 'utils/stringUtils'
 
@@ -65,29 +67,39 @@ export default function ReleaseAssetsAccordion({
           </AccordionSummary>
           <AccordionDetails>
             {expanded === 'files' && (
-              <Paginate
-                list={release.files}
-                defaultSortProperty='createdAt'
-                searchFilterProperty='name'
-                searchPlaceholderText='Search by filename'
-                emptyListText='No files found'
-                sortingProperties={[
-                  { value: 'name', title: 'Name', iconKind: 'text' },
-                  { value: 'size', title: 'Size', iconKind: 'size' },
-                  {
-                    value: 'createdAt',
-                    title: 'Date uploaded',
-                    iconKind: 'date',
-                  },
-                  {
-                    value: 'updatedAt',
-                    title: 'Date updated',
-                    iconKind: 'date',
-                  },
-                ]}
-              >
-                {FileRowItem}
-              </Paginate>
+              <Stack spacing={2}>
+                <Button
+                  component={Link}
+                  href={`/api/v2/model/${model.id}/release/${release.semver}/files/download`}
+                  startIcon={<Download />}
+                  sx={{ alignSelf: 'flex-start' }}
+                >
+                  Download all files
+                </Button>
+                <Paginate
+                  list={release.files}
+                  defaultSortProperty='createdAt'
+                  searchFilterProperty='name'
+                  searchPlaceholderText='Search by filename'
+                  emptyListText='No files found'
+                  sortingProperties={[
+                    { value: 'name', title: 'Name', iconKind: 'text' },
+                    { value: 'size', title: 'Size', iconKind: 'size' },
+                    {
+                      value: 'createdAt',
+                      title: 'Date uploaded',
+                      iconKind: 'date',
+                    },
+                    {
+                      value: 'updatedAt',
+                      title: 'Date updated',
+                      iconKind: 'date',
+                    },
+                  ]}
+                >
+                  {FileRowItem}
+                </Paginate>
+              </Stack>
             )}
           </AccordionDetails>
         </Accordion>

--- a/frontend/test/entry/model/releases/ReleaseAssetsAccordion.spec.tsx
+++ b/frontend/test/entry/model/releases/ReleaseAssetsAccordion.spec.tsx
@@ -1,0 +1,27 @@
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { describe, expect, it, vi } from 'vitest'
+
+import ReleaseAssetsAccordion from '../../../../src/entry/model/releases/ReleaseAssetsAccordion'
+import { EntryInterface, ReleaseInterface } from '../../../../types/types'
+
+vi.mock('../../../../src/common/Paginate', () => ({ default: () => null }))
+vi.mock('../../../../src/entry/model/files/FileDisplay', () => ({ default: () => null }))
+
+describe('ReleaseAssetsAccordion', () => {
+  it('offers a single archive download for all release files', async () => {
+    const user = userEvent.setup()
+    const model = { id: 'model-123' } as EntryInterface
+    const release = {
+      semver: '1.2.3',
+      files: [{ _id: 'file-a', name: 'alpha.txt' }],
+      images: [],
+    } as unknown as ReleaseInterface
+
+    render(<ReleaseAssetsAccordion model={model} release={release} mode='readonly' />)
+    await user.click(screen.getByText('Show 1 file'))
+
+    const link = screen.getByRole('link', { name: 'Download all files' })
+    expect(link.getAttribute('href')).toBe('/api/v2/model/model-123/release/1.2.3/files/download')
+  })
+})


### PR DESCRIPTION
Fixes #3322.

##### Checklist

- [x] `npm run lint && npm run build` passes
- [x] `npm run style` makes no changes
- [x] `npm run test` succeeds both unit and integration testing.

### Affected core subsystem(s)

Release file downloads, file authorisation, release assets UI and user documentation.

### Description of change

Adds a bulk download option for all files attached to a release.

The new API endpoint streams release files as a `tar.gz` archive using the existing file download path rather than buffering whole files in memory. Download permission is checked for every file before streaming starts, archive entry names are flattened and de-duplicated to avoid unsafe or conflicting paths, and individual file download auditing is preserved.

The release files accordion now includes a **Download all files** action, with matching user documentation.

Regression coverage verifies archive contents, permission preflight, safe entry naming, stream failures and the frontend download link. Full validation passed with 1,419 backend tests and 160 frontend tests.
