### PR TITLE
feat: add access request discovery

### DIFF
--- a/backend/src/services/accessRequest.ts
+++ b/backend/src/services/accessRequest.ts
@@ -171,9 +171,14 @@ export async function findAccessRequests(
   }
 
   if (mine) {
-    query['metadata.overview.entities'] = {
-      $in: await authentication.getEntities(user),
-    }
+    query.$or = [
+      { createdBy: user.dn },
+      {
+        'metadata.overview.entities': {
+          $in: await authentication.getEntities(user),
+        },
+      },
+    ]
   }
 
   const stages: PipelineStage[] = [{ $match: query }]

--- a/backend/test/services/accessRequest.spec.ts
+++ b/backend/test/services/accessRequest.spec.ts
@@ -158,6 +158,23 @@ describe('services > accessRequest', () => {
     expect(accessRequests).toEqual([{ id: 'a' }])
   })
 
+  test('findAccessRequests > mine includes requests created by or assigned to the user', async () => {
+    const user = { dn: 'testUser' } as UserInterface
+    AccessRequestModelMock.aggregate.mockResolvedValueOnce([])
+
+    await findAccessRequests(user, [], '', true, false)
+
+    expect(AccessRequestModelMock.aggregate).toHaveBeenCalledWith(
+      expect.arrayContaining([
+        {
+          $match: {
+            $or: [{ createdBy: 'testUser' }, { 'metadata.overview.entities': { $in: ['user:testUser'] } }],
+          },
+        },
+      ]),
+    )
+  })
+
   test('findAccessRequests > all filters', async () => {
     mockAuthentication.hasRole.mockReturnValueOnce(false)
     AccessRequestModelMock.aggregate.mockResolvedValueOnce([

--- a/frontend/actions/accessRequest.ts
+++ b/frontend/actions/accessRequest.ts
@@ -28,7 +28,7 @@ export function useGetAccessRequests(
   adminAccess?: boolean,
 ) {
   const queryParams = {
-    ...(modelIds.length > 0 && { modelIds }),
+    ...(modelIds.length > 0 && { modelId: modelIds }),
     ...(schemaId.length && { schemaId }),
     ...(mine && { mine }),
     ...(adminAccess && { adminAccess }),

--- a/frontend/pages/access.tsx
+++ b/frontend/pages/access.tsx
@@ -1,0 +1,18 @@
+import { Box, Stack, Typography } from '@mui/material'
+import MyAccessRequests from 'src/accessRequests/MyAccessRequests'
+import Title from 'src/common/Title'
+
+export default function Access() {
+  return (
+    <>
+      <Title text='Your access' />
+      <Stack spacing={1} sx={{ px: 2, pb: 1 }}>
+        <Typography component='h1' color='primary' variant='h6'>
+          Your access requests
+        </Typography>
+        <Box>Access requests you created, or that include you or one of your groups as an access entity.</Box>
+      </Stack>
+      <MyAccessRequests />
+    </>
+  )
+}

--- a/frontend/pages/docs/users/using-a-model/requesting-access.mdx
+++ b/frontend/pages/docs/users/using-a-model/requesting-access.mdx
@@ -56,4 +56,9 @@ The screenshot above shows the access request form with fields to fill in.
 Once this request has been approved by the necessary role(s), you will be able to download Release artefacts and pull
 Docker images associated with the model.
 
+## Finding your access requests
+
+Select **Your access** in the navigation to see access requests you created or that name you or one of your groups as an
+access entity. Each item links back to its model and shows the existing review status for the request.
+
 export default ({ children }) => <DocsWrapper>{children}</DocsWrapper>

--- a/frontend/src/accessRequests/MyAccessRequests.tsx
+++ b/frontend/src/accessRequests/MyAccessRequests.tsx
@@ -1,0 +1,70 @@
+import { Container, Stack, Typography } from '@mui/material'
+import { useGetAccessRequests } from 'actions/accessRequest'
+import { useGetModel } from 'actions/entry'
+import { memoize } from 'lodash-es'
+import Paginate from 'src/common/Paginate'
+import renderQueryState from 'src/common/renderQueryState'
+import AccessRequestDisplay from 'src/entry/model/accessRequests/AccessRequestDisplay'
+import Link from 'src/Link'
+import { AccessRequestInterface } from 'types/types'
+
+type AccessRequestListItem = AccessRequestInterface & {
+  key: string
+  searchText: string
+}
+
+function AccessRequestWithModel({ accessRequest }: { accessRequest: AccessRequestInterface }) {
+  const { entry, isEntryLoading, isEntryError } = useGetModel(accessRequest.modelId)
+  const modelLabel = entry?.name ?? accessRequest.modelId
+
+  return (
+    <Stack spacing={1}>
+      <Typography variant='subtitle2'>
+        Model:{' '}
+        {isEntryLoading || isEntryError || !entry ? (
+          modelLabel
+        ) : (
+          <Link href={`/model/${accessRequest.modelId}`}>{modelLabel}</Link>
+        )}
+      </Typography>
+      <AccessRequestDisplay accessRequest={accessRequest} />
+    </Stack>
+  )
+}
+
+export default function MyAccessRequests() {
+  const { accessRequests, isAccessRequestsLoading, isAccessRequestsError } = useGetAccessRequests([], '', true)
+
+  const queryState = renderQueryState([isAccessRequestsError], isAccessRequestsLoading)
+  if (queryState) {
+    return queryState
+  }
+
+  const list: AccessRequestListItem[] = accessRequests.map((accessRequest) => ({
+    ...accessRequest,
+    key: accessRequest.id,
+    searchText: [accessRequest.metadata.overview.name, accessRequest.modelId, accessRequest.createdBy].join(' '),
+  }))
+
+  const AccessRequestListRow = memoize(({ data }: { data: AccessRequestListItem }) => (
+    <AccessRequestWithModel accessRequest={data} />
+  ))
+
+  return (
+    <Container maxWidth='lg' sx={{ my: 2 }}>
+      <Paginate
+        list={list}
+        emptyListText='No access requests found for your account'
+        sortingProperties={[
+          { value: 'createdAt', title: 'Date created', iconKind: 'date' },
+          { value: 'updatedAt', title: 'Date updated', iconKind: 'date' },
+        ]}
+        searchPlaceholderText='Search access requests'
+        defaultSortProperty='updatedAt'
+        searchFilterProperty='searchText'
+      >
+        {AccessRequestListRow}
+      </Paginate>
+    </Container>
+  )
+}

--- a/frontend/src/wrapper/SideNavigation.tsx
+++ b/frontend/src/wrapper/SideNavigation.tsx
@@ -8,6 +8,7 @@ import KeyboardDoubleArrowLeft from '@mui/icons-material/KeyboardDoubleArrowLeft
 import KeyboardDoubleArrowRight from '@mui/icons-material/KeyboardDoubleArrowRight'
 import LinkIcon from '@mui/icons-material/Link'
 import ListAltIcon from '@mui/icons-material/ListAlt'
+import VpnKey from '@mui/icons-material/VpnKey'
 import { Divider, List, ListItem, ListItemButton, ListItemIcon, Stack, Toolbar, useMediaQuery } from '@mui/material'
 import MuiDrawer from '@mui/material/Drawer'
 import { styled, useTheme } from '@mui/material/styles'
@@ -157,6 +158,15 @@ export default function SideNavigation({
                   title='Review'
                   icon={<ListAltIcon />}
                   badgeCount={reviewCount}
+                />
+                <NavMenuItem
+                  href='/access'
+                  selectedPage={page}
+                  primaryText='Your access'
+                  drawerOpen={drawerOpen}
+                  menuPage='access'
+                  title='Your access requests'
+                  icon={<VpnKey />}
                 />
                 <Divider aria-hidden='true' />
                 <NavMenuItem

--- a/frontend/test/accessRequests/MyAccessRequests.spec.tsx
+++ b/frontend/test/accessRequests/MyAccessRequests.spec.tsx
@@ -1,0 +1,46 @@
+import { render, screen } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+
+import MyAccessRequests from '../../src/accessRequests/MyAccessRequests'
+
+vi.mock('actions/accessRequest', () => ({
+  useGetAccessRequests: vi.fn(() => ({
+    accessRequests: [
+      {
+        _id: 'request-1',
+        id: 'request-1',
+        modelId: 'model-123',
+        schemaId: 'schema-1',
+        deleted: false,
+        metadata: { overview: { name: 'Research access', entities: ['user:test'] } },
+        createdBy: 'user:test',
+        createdAt: '2026-09-01T09:00:00.000Z',
+        updatedAt: '2026-09-02T09:00:00.000Z',
+      },
+    ],
+    isAccessRequestsLoading: false,
+    isAccessRequestsError: undefined,
+  })),
+}))
+
+vi.mock('actions/entry', () => ({
+  useGetModel: vi.fn(() => ({
+    entry: { id: 'model-123', name: 'Example model' },
+    isEntryLoading: false,
+    isEntryError: undefined,
+  })),
+}))
+
+vi.mock('../../src/entry/model/accessRequests/AccessRequestDisplay', () => ({
+  default: ({ accessRequest }) => <div>{accessRequest.metadata.overview.name}</div>,
+}))
+
+describe('MyAccessRequests', () => {
+  it('shows the current user access request with a link to its model', () => {
+    render(<MyAccessRequests />)
+
+    expect(screen.getByText('Research access')).toBeDefined()
+    const modelLink = screen.getByRole('link', { name: 'Example model' })
+    expect(modelLink.getAttribute('href')).toBe('/model/model-123')
+  })
+})

--- a/frontend/test/actions/accessRequest.spec.ts
+++ b/frontend/test/actions/accessRequest.spec.ts
@@ -1,0 +1,23 @@
+import useSWR from 'swr'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { useGetAccessRequests } from '../../actions/accessRequest'
+
+vi.mock('swr', () => ({
+  default: vi.fn(() => ({ data: undefined, isLoading: false, error: undefined, mutate: vi.fn() })),
+}))
+
+describe('actions > accessRequest', () => {
+  beforeEach(() => {
+    vi.mocked(useSWR).mockClear()
+  })
+
+  it('uses the API modelId query key when filtering by model', () => {
+    useGetAccessRequests(['model-a', 'model-b'], '', true)
+
+    expect(useSWR).toHaveBeenCalledWith(
+      '/api/v2/access-requests/search?modelId=model-a&modelId=model-b&mine=true',
+      expect.any(Function),
+    )
+  })
+})


### PR DESCRIPTION
##### Checklist

- [x] `npm run lint && npm run build` passes
- [x] `npm run style` makes no changes
- [x] `npm run test` succeeds both unit and integration testing.

### Affected core subsystem(s)

Access management, frontend navigation and user documentation.

### Description of change

Adds a consumer-facing **Your access** page so users can find access requests they created or that include them or one of their groups as an access entity.

The page links each request back to its model and reuses the existing access-request review status display. This also fixes two gaps in the existing global access-request search path:

- `mine=true` now includes requests created by the current user as well as requests targeting one of their entities;
- the frontend model filter now sends the API's `modelId` query key instead of `modelIds`.

Regression tests demonstrate both search defects before the fix, and the new consumer list has frontend coverage. Documentation now points users to the new navigation item.

Closes #2346.

Validation:

- backend: 1,415 tests passed
- frontend: 161 tests passed
- root `npm run check-style`, `npm run lint`, `npm run build` and `npm run test` passed
- changed files pass CSpell
