### PR TITLE
Fix Python downloads with reserved filename characters

### DIFF
--- a/lib/python/src/bailo/core/client.py
+++ b/lib/python/src/bailo/core/client.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from io import BytesIO
 from json import JSONDecodeError
 from typing import Any
+from urllib.parse import quote
 
 import requests
 
@@ -527,6 +528,7 @@ class Client:
         :param filename: The filename trying to download from
         :return: Response object
         """
+        filename = quote(filename, safe="")
         if isinstance(self.agent, TokenAgent):
             return self.agent.get(
                 f"{self.url}/v2/token/model/{model_id}/release/{semver}/file/{filename}/download",

--- a/lib/python/tests/test_download_filename.py
+++ b/lib/python/tests/test_download_filename.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+
+from urllib.parse import urlsplit
+
+import pytest
+from bailo.core.agent import Agent, TokenAgent
+from bailo.core.client import Client
+from requests_mock import ANY
+
+
+@pytest.mark.parametrize("token_auth", [False, True], ids=["standard", "token"])
+@pytest.mark.parametrize(
+    ("filename", "encoded"),
+    [
+        ("model.bin", "model.bin"),
+        ("model#final.bin", "model%23final.bin"),
+        ("model?final.bin", "model%3Ffinal.bin"),
+        ("model%23final.bin", "model%2523final.bin"),
+        ("model final.bin", "model%20final.bin"),
+        ("modèle.bin", "mod%C3%A8le.bin"),
+    ],
+)
+def test_download_filename_is_a_single_url_path_segment(requests_mock, token_auth, filename, encoded):
+    agent = TokenAgent(access_key="test-access", secret_key="test-secret") if token_auth else Agent()
+    client = Client("https://example.com", agent=agent)
+    requests_mock.get(ANY, content=b"model contents")
+    prefix = "/api/v2/token" if token_auth else "/api/v2"
+
+    with agent.session:
+        response = client.get_download_by_filename("test-model", "1.0.0", filename)
+
+    assert response.content == b"model contents"
+    requested = urlsplit(requests_mock.last_request.url)
+    assert requested.path == f"{prefix}/model/test-model/release/1.0.0/file/{encoded}/download"
+    assert requested.query == ""
+    assert requested.fragment == ""


### PR DESCRIPTION
## Summary
Fixes #4213.

Percent-encode download filenames as a single path segment before constructing the URL. This preserves literal `#`, `?`, and percent escapes for both standard and token authentication, including `Release.download()`.

Streaming, timeout, and authentication behaviour are unchanged. No dependencies added.

## Validation
- 12 request-level regression cases, including reserved characters, plain names, spaces, and Unicode. Six cases failed before the fix.
- Full Python unit suite: **139 passed**; integration/MLflow tests remain deselected by the existing configuration.
- Ruff lint and formatting checks passed.
