### PR TITLE
Create linked access requests for multiple models

### DIFF
--- a/backend/src/models/AccessRequest.ts
+++ b/backend/src/models/AccessRequest.ts
@@ -20,6 +20,7 @@ export interface AccessRequestMetadata {
 export interface AccessRequestInterface {
   id: string
   modelId: string
+  groupId?: string
 
   schemaId: string
   metadata: AccessRequestMetadata
@@ -41,6 +42,7 @@ const AccessRequestSchema = new Schema<AccessRequestDoc>(
   {
     id: { type: String, unique: true, required: true },
     modelId: { type: String, required: true },
+    groupId: { type: String },
 
     schemaId: { type: String, required: true },
     metadata: { type: Schema.Types.Mixed, required: true },
@@ -55,6 +57,7 @@ const AccessRequestSchema = new Schema<AccessRequestDoc>(
 
 AccessRequestSchema.plugin(softDeletionPlugin)
 AccessRequestSchema.index({ modelId: 1 })
+AccessRequestSchema.index({ groupId: 1 }, { sparse: true })
 
 const AccessRequestModel = model<AccessRequestDoc>('v2_Access_Request', AccessRequestSchema)
 

--- a/backend/src/routes/v2/model/accessRequest/getAccessRequestGroup.ts
+++ b/backend/src/routes/v2/model/accessRequest/getAccessRequestGroup.ts
@@ -1,0 +1,40 @@
+import { Request, Response } from 'express'
+
+import { AuditInfo } from '../../../../connectors/audit/Base.js'
+import audit from '../../../../connectors/audit/index.js'
+import { z } from '../../../../lib/zod.js'
+import { AccessRequestInterface } from '../../../../models/AccessRequest.js'
+import { getAccessRequestGroup as findGroup } from '../../../../services/accessRequest.js'
+import { accessRequestInterfaceSchema, registerPath } from '../../../../services/specification.js'
+import { parse } from '../../../../utils/validate.js'
+
+export const getAccessRequestGroupSchema = z.object({
+  params: z.object({ modelId: z.string(), accessRequestId: z.string() }),
+})
+
+registerPath({
+  method: 'get',
+  path: '/api/v2/model/{modelId}/access-request/{accessRequestId}/group',
+  tags: ['access-request'],
+  description:
+    'List visible access requests created in the same group. Each model and request has its own visibility checks.',
+  schema: getAccessRequestGroupSchema,
+  responses: {
+    200: {
+      description: 'Visible requests in the group, or an empty list for an ungrouped request.',
+      content: { 'application/json': { schema: z.object({ accessRequests: z.array(accessRequestInterfaceSchema) }) } },
+    },
+  },
+})
+
+export const getAccessRequestGroup = [
+  async (req: Request, res: Response<{ accessRequests: AccessRequestInterface[] }>): Promise<void> => {
+    req.audit = AuditInfo.ViewAccessRequests
+    const {
+      params: { modelId, accessRequestId },
+    } = parse(req, getAccessRequestGroupSchema)
+    const accessRequests = await findGroup(req.user, modelId, accessRequestId)
+    await audit.onViewAccessRequests(req, accessRequests)
+    res.json({ accessRequests })
+  },
+]

--- a/backend/src/routes/v2/model/accessRequest/postAccessRequestGroup.ts
+++ b/backend/src/routes/v2/model/accessRequest/postAccessRequestGroup.ts
@@ -1,0 +1,60 @@
+import { Request, Response } from 'express'
+
+import { AuditInfo } from '../../../../connectors/audit/Base.js'
+import audit from '../../../../connectors/audit/index.js'
+import { z } from '../../../../lib/zod.js'
+import { AccessRequestGroupResult, createAccessRequestGroup } from '../../../../services/accessRequest.js'
+import { accessRequestInterfaceSchema, registerPath } from '../../../../services/specification.js'
+import { parse } from '../../../../utils/validate.js'
+import { accessRequestMetadata } from './postAccessRequest.js'
+
+export const postAccessRequestGroupSchema = z.object({
+  body: z
+    .object({
+      modelIds: z
+        .array(z.string().min(1))
+        .min(2)
+        .max(20)
+        .refine((ids) => new Set(ids).size === ids.length, 'Models must be unique'),
+      schemaId: z.string().min(1),
+      metadata: accessRequestMetadata,
+    })
+    .strict(),
+})
+
+registerPath({
+  method: 'post',
+  path: '/api/v2/access-request-groups',
+  tags: ['access-request'],
+  description:
+    'Create independent, linked access requests from one form. Returns successful requests and failed model IDs; a partial result does not roll back successful requests.',
+  schema: postAccessRequestGroupSchema,
+  responses: {
+    200: {
+      description: 'Per-model creation results. Check failedModelIds even when the response is successful.',
+      content: {
+        'application/json': {
+          schema: z.object({
+            groupId: z.string().uuid(),
+            accessRequests: z.array(accessRequestInterfaceSchema),
+            failedModelIds: z.array(z.string()),
+          }),
+        },
+      },
+    },
+  },
+})
+
+export const postAccessRequestGroup = [
+  async (req: Request, res: Response<AccessRequestGroupResult>): Promise<void> => {
+    req.audit = AuditInfo.CreateAccessRequest
+    const {
+      body: { modelIds, ...info },
+    } = parse(req, postAccessRequestGroupSchema)
+    const result = await createAccessRequestGroup(req.user, modelIds, info)
+    for (const request of result.accessRequests) {
+      await audit.onCreateAccessRequest(req, request)
+    }
+    res.json(result)
+  },
+]

--- a/backend/src/routes/v2/routes.ts
+++ b/backend/src/routes/v2/routes.ts
@@ -12,11 +12,13 @@ import { getEntityLookup } from './entities/getEntityLookup.js'
 import { deleteAccessRequest } from './model/accessRequest/deleteAccessRequest.js'
 import { getAccessRequest } from './model/accessRequest/getAccessRequest.js'
 import { getAccessRequestCurrentUserPermissions } from './model/accessRequest/getAccessRequestCurrentUserPermissions.js'
+import { getAccessRequestGroup } from './model/accessRequest/getAccessRequestGroup.js'
 import { getAccessRequests } from './model/accessRequest/getAccessRequests.js'
 import { getModelAccessRequests } from './model/accessRequest/getModelAccessRequests.js'
 import { patchAccessRequest } from './model/accessRequest/patchAccessRequest.js'
 import { postAccessRequest } from './model/accessRequest/postAccessRequest.js'
 import { postAccessRequestComment } from './model/accessRequest/postAccessRequestComment.js'
+import { postAccessRequestGroup } from './model/accessRequest/postAccessRequestGroup.js'
 import { deleteModel } from './model/deleteModel.js'
 import { deleteFile } from './model/file/deleteFile.js'
 import { getDownloadFile } from './model/file/getDownloadFile.js'
@@ -129,6 +131,8 @@ router.delete('/model/:modelId/release/:semver', ...deleteRelease)
 router.post('/model/:modelId/release/:semver/review', ...postReleaseReviewResponse)
 
 router.post('/model/:modelId/access-requests', ...postAccessRequest)
+router.post('/access-request-groups', ...postAccessRequestGroup)
+router.get('/model/:modelId/access-request/:accessRequestId/group', ...getAccessRequestGroup)
 router.get('/model/:modelId/access-requests', getModelAccessRequests)
 router.get('/access-requests/search', getAccessRequests)
 router.get('/model/:modelId/access-request/:accessRequestId', ...getAccessRequest)

--- a/backend/src/services/accessRequest.ts
+++ b/backend/src/services/accessRequest.ts
@@ -1,3 +1,5 @@
+import { randomUUID } from 'node:crypto'
+
 import { ClientSession, PipelineStage, Types } from 'mongoose'
 
 import { Roles } from '../connectors/authentication/constants.js'
@@ -10,6 +12,7 @@ import ResponseModel, { ResponseKind } from '../models/Response.js'
 import ReviewModel from '../models/Review.js'
 import { UserInterface } from '../models/User.js'
 import { WebhookEvent } from '../models/Webhook.js'
+import { isBailoError } from '../types/error.js'
 import { AccessRequestUserPermissions } from '../types/types.js'
 import { toEntity } from '../utils/entity.js'
 import { BadReq, Forbidden, InternalError, NotFound } from '../utils/error.js'
@@ -27,6 +30,7 @@ export async function createAccessRequest(
   user: UserInterface,
   modelId: string,
   accessRequestInfo: CreateAccessRequestParams,
+  groupId?: string,
 ) {
   // Check the model exists and the user can view it before creating an access request
   const model = await getModelById(user, modelId)
@@ -55,6 +59,7 @@ export async function createAccessRequest(
     modelId,
     comments: [],
     ...accessRequestInfo,
+    ...(groupId && { groupId }),
   })
 
   const auth = await authorisation.accessRequest(user, model, accessRequest, AccessRequestAction.Create)
@@ -79,6 +84,62 @@ export async function createAccessRequest(
   )
 
   return accessRequest
+}
+
+export interface AccessRequestGroupResult {
+  groupId: string
+  accessRequests: AccessRequestDoc[]
+  failedModelIds: string[]
+}
+
+/** Each target is authorised and reviewed separately; report partial successes explicitly. */
+export async function createAccessRequestGroup(
+  user: UserInterface,
+  modelIds: string[],
+  accessRequestInfo: CreateAccessRequestParams,
+): Promise<AccessRequestGroupResult> {
+  if (modelIds.length < 2 || modelIds.length > 20 || new Set(modelIds).size !== modelIds.length) {
+    throw BadReq('Select between 2 and 20 different models.')
+  }
+  const groupId = randomUUID()
+  const accessRequests: AccessRequestDoc[] = []
+  const failedModelIds: string[] = []
+  for (const modelId of modelIds) {
+    try {
+      accessRequests.push(await createAccessRequest(user, modelId, accessRequestInfo, groupId))
+    } catch (error) {
+      log.warn({ error, modelId, groupId }, 'Could not create one of the grouped access requests')
+      failedModelIds.push(modelId)
+    }
+  }
+  return { groupId, accessRequests, failedModelIds }
+}
+
+/** Group membership does not grant visibility of another model or access request. */
+export async function getAccessRequestGroup(user: UserInterface, modelId: string, accessRequestId: string) {
+  const anchor = await getAccessRequestById(user, accessRequestId)
+  if (anchor.modelId !== modelId) {
+    throw NotFound('The requested access request was not found.', { accessRequestId })
+  }
+  if (!anchor.groupId) {
+    return []
+  }
+  const related = await AccessRequestModel.find({ groupId: anchor.groupId })
+  const visible: AccessRequestDoc[] = []
+  for (const request of related) {
+    try {
+      const model = await getModelById(user, request.modelId)
+      const auth = await authorisation.accessRequest(user, model, request, AccessRequestAction.View)
+      if (auth.success) {
+        visible.push(request)
+      }
+    } catch (error) {
+      if (!isBailoError(error) || ![403, 404].includes(error.code)) {
+        throw error
+      }
+    }
+  }
+  return visible
 }
 
 export async function removeAccessRequests(user: UserInterface, accessRequestIds: string[], session?: ClientSession) {

--- a/backend/src/services/specification.ts
+++ b/backend/src/services/specification.ts
@@ -337,6 +337,7 @@ export const responseInterfaceSchema = z.object({
 export const accessRequestInterfaceSchema = z.object({
   id: z.string().openapi({ example: 'looking-at-pictures-zyxwvu' }),
   modelId: z.string().openapi({ example: 'yolo-v4-abcdef' }),
+  groupId: z.string().uuid().optional(),
 
   schemaId: z.string().openapi({ example: 'minimal-access-request-v1' }),
   metadata: z.object({

--- a/backend/test/routes/model/accessRequest/accessRequestGroup.spec.ts
+++ b/backend/test/routes/model/accessRequest/accessRequestGroup.spec.ts
@@ -1,0 +1,77 @@
+import { beforeEach, describe, expect, test, vi } from 'vitest'
+
+import audit from '../../../../src/connectors/audit/__mocks__/index.js'
+import { createAccessRequestGroup, getAccessRequestGroup } from '../../../../src/services/accessRequest.js'
+import { testGet, testPost } from '../../../testUtils/routes.js'
+
+vi.mock('../../../../src/connectors/audit/index.js')
+vi.mock('../../../../src/services/accessRequest.js', () => ({
+  createAccessRequestGroup: vi.fn(),
+  getAccessRequestGroup: vi.fn(),
+}))
+const body = {
+  modelIds: ['first', 'second'],
+  schemaId: 'schema',
+  metadata: { overview: { name: 'Research', entities: ['user:test'] } },
+}
+const requests = [
+  { id: 'request-first', modelId: 'first' },
+  { id: 'request-second', modelId: 'second' },
+]
+
+beforeEach(() => {
+  vi.mocked(createAccessRequestGroup).mockResolvedValue({
+    groupId: 'group',
+    accessRequests: requests as any,
+    failedModelIds: [],
+  })
+  vi.mocked(getAccessRequestGroup).mockResolvedValue(requests as any)
+})
+
+describe('access request group routes', () => {
+  test('creates and audits each successful request', async () => {
+    const res = await testPost('/api/v2/access-request-groups', { body })
+    expect(res.statusCode).toBe(200)
+    expect(res.body.accessRequests).toEqual(requests)
+    expect(createAccessRequestGroup).toHaveBeenCalledWith(expect.anything(), body.modelIds, {
+      schemaId: body.schemaId,
+      metadata: body.metadata,
+    })
+    expect(audit.onCreateAccessRequest).toHaveBeenCalledTimes(2)
+  })
+
+  test('returns partial failures and audits successful records only', async () => {
+    vi.mocked(createAccessRequestGroup).mockResolvedValue({
+      groupId: 'group',
+      accessRequests: requests.slice(0, 1) as any,
+      failedModelIds: ['second'],
+    })
+    const res = await testPost('/api/v2/access-request-groups', { body })
+    expect(res.statusCode).toBe(200)
+    expect(res.body.failedModelIds).toEqual(['second'])
+    expect(audit.onCreateAccessRequest).toHaveBeenCalledTimes(1)
+  })
+
+  test.each([
+    { ...body, modelIds: ['first'] },
+    { ...body, modelIds: ['first', 'first'] },
+    { ...body, modelIds: Array.from({ length: 21 }, (_, index) => String(index)) },
+    { ...body, modelIds: ['first', ''] },
+    { ...body, metadata: {} },
+    { ...body, groupId: 'injected-group' },
+    { ...body, createdBy: 'another-user' },
+  ])('rejects malformed or forged input %j', async (input) => {
+    const res = await testPost('/api/v2/access-request-groups', { body: input })
+    expect(res.statusCode).toBe(400)
+    expect(createAccessRequestGroup).not.toHaveBeenCalled()
+    expect(audit.onCreateAccessRequest).not.toHaveBeenCalled()
+  })
+
+  test('lists and audits the authorised group members', async () => {
+    const res = await testGet('/api/v2/model/first/access-request/request-first/group')
+    expect(res.statusCode).toBe(200)
+    expect(getAccessRequestGroup).toHaveBeenCalledWith(expect.anything(), 'first', 'request-first')
+    expect(res.body.accessRequests).toEqual(requests)
+    expect(audit.onViewAccessRequests).toHaveBeenCalledWith(expect.anything(), requests)
+  })
+})

--- a/backend/test/services/accessRequestGroup.spec.ts
+++ b/backend/test/services/accessRequestGroup.spec.ts
@@ -1,0 +1,175 @@
+import { beforeEach, describe, expect, test, vi } from 'vitest'
+
+import authorisation from '../../src/connectors/authorisation/index.js'
+import { EntryKind } from '../../src/models/Model.js'
+import { UserInterface } from '../../src/models/User.js'
+import {
+  createAccessRequest,
+  createAccessRequestGroup,
+  getAccessRequestGroup,
+} from '../../src/services/accessRequest.js'
+import { Forbidden, InternalError, NotFound } from '../../src/utils/error.js'
+import { getTypedModelMock } from '../testUtils/setupMongooseModelMocks.js'
+
+vi.mock('../../src/connectors/authorisation/index.js')
+const models = vi.hoisted(() => ({ getModelById: vi.fn() }))
+const schemas = vi.hoisted(() => ({ getSchemaById: vi.fn(), validateContentAgainstSchema: vi.fn() }))
+const reviews = vi.hoisted(() => ({ createAccessRequestReviews: vi.fn() }))
+const webhooks = vi.hoisted(() => ({ dispatchWebhooks: vi.fn() }))
+vi.mock('../../src/services/model.js', () => models)
+vi.mock('../../src/services/schema.js', () => schemas)
+vi.mock('../../src/services/review.js', () => reviews)
+vi.mock('../../src/services/webhook.js', () => webhooks)
+const records = getTypedModelMock('AccessRequestModel')
+const user = { dn: 'requester' } as UserInterface
+const info = {
+  schemaId: 'access-schema',
+  metadata: { overview: { name: 'Shared purpose', entities: ['user:requester'] } },
+}
+
+beforeEach(() => {
+  models.getModelById.mockImplementation(async (_user, id) => ({ id, kind: EntryKind.Model }))
+  schemas.getSchemaById.mockResolvedValue({ hidden: false })
+  schemas.validateContentAgainstSchema.mockResolvedValue({ valid: true, errors: [] })
+})
+
+describe('createAccessRequestGroup', () => {
+  test('creates distinct requests with one server-generated group and separate reviews', async () => {
+    const result = await createAccessRequestGroup(user, ['first', 'second'], info)
+    expect(result.groupId).toMatch(/^[0-9a-f-]{36}$/)
+    expect(result.failedModelIds).toEqual([])
+    expect(result.accessRequests.map((request) => request.modelId)).toEqual(['first', 'second'])
+    expect(new Set(result.accessRequests.map((request) => request.id)).size).toBe(2)
+    expect(result.accessRequests.every((request) => request.groupId === result.groupId)).toBe(true)
+    expect(records.save).toHaveBeenCalledTimes(2)
+    expect(reviews.createAccessRequestReviews).toHaveBeenCalledTimes(2)
+    expect(webhooks.dispatchWebhooks).toHaveBeenCalledTimes(2)
+    expect(authorisation.accessRequest).toHaveBeenCalledTimes(2)
+    for (const request of result.accessRequests) {
+      expect(request.metadata).toEqual(info.metadata)
+      expect(reviews.createAccessRequestReviews).toHaveBeenCalledWith(
+        expect.objectContaining({ id: request.modelId }),
+        request,
+      )
+    }
+  })
+
+  test('reports inaccessible targets without dropping successful requests', async () => {
+    models.getModelById.mockImplementation(async (_user, id) => {
+      if (id === 'private') {
+        throw Forbidden('Private model')
+      }
+      return { id, kind: EntryKind.Model }
+    })
+    const result = await createAccessRequestGroup(user, ['first', 'private', 'last'], info)
+    expect(result.failedModelIds).toEqual(['private'])
+    expect(result.accessRequests.map((request) => request.modelId)).toEqual(['first', 'last'])
+    expect(records.save).toHaveBeenCalledTimes(2)
+    expect(reviews.createAccessRequestReviews).toHaveBeenCalledTimes(2)
+  })
+
+  test('reports write failures and continues with later models', async () => {
+    records.save.mockRejectedValueOnce(new Error('database unavailable'))
+    const result = await createAccessRequestGroup(user, ['first', 'second'], info)
+    expect(result.failedModelIds).toEqual(['first'])
+    expect(result.accessRequests.map((request) => request.modelId)).toEqual(['second'])
+    expect(reviews.createAccessRequestReviews).toHaveBeenCalledTimes(1)
+    expect(webhooks.dispatchWebhooks).toHaveBeenCalledTimes(1)
+  })
+
+  test('does not create requests when schema validation fails', async () => {
+    schemas.validateContentAgainstSchema.mockResolvedValue({ valid: false, errors: ['Missing field'] })
+    const result = await createAccessRequestGroup(user, ['first', 'second'], info)
+    expect(result.accessRequests).toEqual([])
+    expect(result.failedModelIds).toEqual(['first', 'second'])
+    expect(records.save).not.toHaveBeenCalled()
+  })
+
+  test('preserves access-request authorisation independently of model visibility', async () => {
+    vi.mocked(authorisation.accessRequest).mockResolvedValueOnce({ success: false, id: 'first', info: 'Denied' })
+    const result = await createAccessRequestGroup(user, ['first', 'second'], info)
+    expect(result.failedModelIds).toEqual(['first'])
+    expect(records.save).toHaveBeenCalledTimes(1)
+  })
+
+  test('creates a new group for each submission', async () => {
+    const first = await createAccessRequestGroup(user, ['first', 'second'], info)
+    const second = await createAccessRequestGroup(user, ['first', 'second'], info)
+    expect(first.groupId).not.toBe(second.groupId)
+  })
+
+  test('leaves existing single-model creation ungrouped', async () => {
+    const result = await createAccessRequest(user, 'first', info)
+    expect(result.groupId).toBeUndefined()
+  })
+
+  test.each([[], ['one'], ['one', 'one'], Array.from({ length: 21 }, (_, index) => String(index))])(
+    'rejects an invalid target list %j',
+    async (...ids) => {
+      await expect(createAccessRequestGroup(user, ids, info)).rejects.toThrow('between 2 and 20')
+      expect(models.getModelById).not.toHaveBeenCalled()
+      expect(records.save).not.toHaveBeenCalled()
+    },
+  )
+})
+
+describe('getAccessRequestGroup', () => {
+  const anchor = { id: 'anchor', modelId: 'first', groupId: 'group', metadata: info.metadata }
+  const other = { id: 'other', modelId: 'second', groupId: 'group', metadata: info.metadata }
+
+  beforeEach(() => {
+    records.findOne.mockResolvedValue(anchor as any)
+    records.find.mockResolvedValue([anchor, other])
+  })
+
+  test('checks every related model and request before returning the group', async () => {
+    expect(await getAccessRequestGroup(user, 'first', 'anchor')).toEqual([anchor, other])
+    expect(records.find).toHaveBeenCalledWith({ groupId: 'group' })
+    expect(models.getModelById).toHaveBeenCalledWith(user, 'second')
+    expect(authorisation.accessRequest).toHaveBeenCalledWith(
+      user,
+      expect.objectContaining({ id: 'second' }),
+      other,
+      'access_request:view',
+    )
+  })
+
+  test.each([Forbidden('Private'), NotFound('Deleted')])('omits unavailable related models', async (error) => {
+    models.getModelById.mockImplementation(async (_user, id) => {
+      if (id === 'second') {
+        throw error
+      }
+      return { id, kind: EntryKind.Model }
+    })
+    expect(await getAccessRequestGroup(user, 'first', 'anchor')).toEqual([anchor])
+  })
+
+  test('omits a related request when its request-level permission fails', async () => {
+    vi.mocked(authorisation.accessRequest).mockImplementation(async (_user, _model, request) =>
+      request.id === 'other' ? { success: false, id: request.id, info: 'Denied' } : { success: true, id: request.id },
+    )
+    expect(await getAccessRequestGroup(user, 'first', 'anchor')).toEqual([anchor])
+  })
+
+  test('does not hide operational errors as an empty group', async () => {
+    models.getModelById.mockResolvedValueOnce({ id: 'first' }).mockRejectedValueOnce(InternalError('database error'))
+    await expect(getAccessRequestGroup(user, 'first', 'anchor')).rejects.toThrow('database error')
+  })
+
+  test('does not enumerate a group through an inaccessible anchor', async () => {
+    vi.mocked(authorisation.accessRequest).mockResolvedValueOnce({ success: false, id: 'anchor', info: 'Denied' })
+    await expect(getAccessRequestGroup(user, 'first', 'anchor')).rejects.toThrow('Denied')
+    expect(records.find).not.toHaveBeenCalled()
+  })
+
+  test('rejects an anchor from a different URL model', async () => {
+    await expect(getAccessRequestGroup(user, 'wrong', 'anchor')).rejects.toThrow('not found')
+    expect(records.find).not.toHaveBeenCalled()
+  })
+
+  test('returns no group for legacy single-model requests', async () => {
+    records.findOne.mockResolvedValue({ ...anchor, groupId: undefined } as any)
+    expect(await getAccessRequestGroup(user, 'first', 'anchor')).toEqual([])
+    expect(records.find).not.toHaveBeenCalled()
+  })
+})

--- a/frontend/actions/accessRequest.ts
+++ b/frontend/actions/accessRequest.ts
@@ -118,3 +118,29 @@ export function postAccessRequestComment(modelId: string, accessRequestId: strin
     body: JSON.stringify({ comment }),
   })
 }
+
+export interface AccessRequestGroupResult {
+  groupId: string
+  accessRequests: AccessRequestInterface[]
+  failedModelIds: string[]
+}
+
+export function postAccessRequestGroup(modelIds: string[], schemaId: string, form: Record<string, unknown>) {
+  return fetch('/api/v2/access-request-groups', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ modelIds, schemaId, metadata: form }),
+  })
+}
+
+export function useGetAccessRequestGroup(accessRequest: AccessRequestInterface) {
+  const { data, isLoading, error } = useSWR<{ accessRequests: AccessRequestInterface[] }, ErrorInfo>(
+    accessRequest.groupId ? `/api/v2/model/${accessRequest.modelId}/access-request/${accessRequest.id}/group` : null,
+    fetcher,
+  )
+  return {
+    accessRequests: data?.accessRequests ?? emptyAccessRequestList,
+    isLoading,
+    error,
+  }
+}

--- a/frontend/pages/docs/users/using-a-model/requesting-access.mdx
+++ b/frontend/pages/docs/users/using-a-model/requesting-access.mdx
@@ -11,6 +11,7 @@ import createAccessRequest from 'public/docs/bailo_create_access_request.png'
 > **Common questions this page answers:**
 >
 > - How do I request access to a model?
+> - Can I use one form to request access to several models?
 > - What is an access request?
 > - What happens after I submit an access request?
 
@@ -50,6 +51,25 @@ The screenshot above shows the access request schema selection dialog.
 </Box>
 
 The screenshot above shows the access request form with fields to fill in.
+
+## Requesting access to several models
+
+Use **Also request access to** on the form to select additional models you can view in the current Bailo instance. You
+can include up to 20 models in one submission, including the model you started from. The same schema and form answers
+are used to create a separate access request for each model, with its own reviewers and approval decision.
+
+The result page links to the requests that were created. A failure for one model does not remove the successful
+requests. When some models fail, start a new request for only those models; do not resubmit the entire group. If the
+connection is interrupted, check your existing requests before submitting again because some requests may already be
+saved.
+
+Request and review pages show a **Grouped request** section with links to other requests from that submission. Group
+membership does not grant access to another model or request: only requests you are allowed to view are shown. Editing,
+approving or deleting one request does not change the others. Bulk review decisions are not supported.
+
+The API equivalent is `POST /api/v2/access-request-groups` with `modelIds`, `schemaId` and `metadata`. Always check both
+`accessRequests` and `failedModelIds` in its response, even when the HTTP status is 200. Group identifiers are generated
+by the server.
 
 ## Review process
 

--- a/frontend/pages/model/[modelId]/access-request/[accessRequestId].tsx
+++ b/frontend/pages/model/[modelId]/access-request/[accessRequestId].tsx
@@ -6,6 +6,7 @@ import { useState } from 'react'
 import CopyToClipboardButton from 'src/common/CopyToClipboardButton'
 import Loading from 'src/common/Loading'
 import Title from 'src/common/Title'
+import AccessRequestGroupLinks from 'src/entry/model/accessRequests/AccessRequestGroupLinks'
 import EditableAccessRequestForm from 'src/entry/model/accessRequests/EditableAccessRequestForm'
 import ReleaseAccessRequestReviewSummary from 'src/entry/model/reviews/ReleaseAccessRequestReviewSummary'
 import ReviewBanner from 'src/entry/model/reviews/ReviewBanner'
@@ -68,6 +69,7 @@ export default function AccessRequest() {
                     />
                   </Stack>
                 </Stack>
+                <AccessRequestGroupLinks accessRequest={accessRequest} />
                 <ReleaseAccessRequestReviewSummary accessRequest={accessRequest} includeResponsesSummary={false} />
                 {accessRequest && (
                   <EditableAccessRequestForm accessRequest={accessRequest} isEdit={isEdit} onIsEditChange={setIsEdit} />

--- a/frontend/pages/model/[modelId]/access-request/[accessRequestId]/review.tsx
+++ b/frontend/pages/model/[modelId]/access-request/[accessRequestId]/review.tsx
@@ -9,6 +9,7 @@ import Loading from 'src/common/Loading'
 import ReviewWithComment from 'src/common/ReviewWithComment'
 import Title from 'src/common/Title'
 import UserDisplay from 'src/common/UserDisplay'
+import AccessRequestGroupLinks from 'src/entry/model/accessRequests/AccessRequestGroupLinks'
 import EditableAccessRequestForm from 'src/entry/model/accessRequests/EditableAccessRequestForm'
 import MultipleErrorWrapper from 'src/errors/MultipleErrorWrapper'
 import Link from 'src/Link'
@@ -107,6 +108,7 @@ export default function AccessRequestReview() {
               </Typography>
               <Button onClick={() => setIsOpenAccessRequestDialogOpen(true)}>View access request</Button>
             </Stack>
+            <AccessRequestGroupLinks accessRequest={accessRequest} />
             <ReviewWithComment
               onSubmit={handleSubmit}
               reviews={reviews}

--- a/frontend/pages/model/[modelId]/access-request/new.tsx
+++ b/frontend/pages/model/[modelId]/access-request/new.tsx
@@ -1,7 +1,7 @@
 import dayjs from '@dayjs'
 import ArrowBack from '@mui/icons-material/ArrowBack'
 import { Button, Container, Paper, Stack, Typography } from '@mui/material'
-import { postAccessRequest } from 'actions/accessRequest'
+import { AccessRequestGroupResult, postAccessRequest, postAccessRequestGroup } from 'actions/accessRequest'
 import { useGetModel } from 'actions/entry'
 import { useGetSchema } from 'actions/schema'
 import { useGetCurrentUser } from 'actions/user'
@@ -9,6 +9,7 @@ import { useRouter } from 'next/router'
 import { useEffect, useMemo, useState } from 'react'
 import Loading from 'src/common/Loading'
 import Title from 'src/common/Title'
+import AccessRequestModels from 'src/entry/model/accessRequests/AccessRequestModels'
 import MultipleErrorWrapper from 'src/errors/MultipleErrorWrapper'
 import JsonSchemaForm from 'src/Form/JsonSchemaForm'
 import Link from 'src/Link'
@@ -27,8 +28,15 @@ export default function NewAccessRequest() {
 
   const [splitSchema, setSplitSchema] = useState<SplitSchemaNoRender>({ reference: '', steps: [] })
   const [submissionErrorText, setSubmissionErrorText] = useState('')
+  const [additionalModelIds, setAdditionalModelIds] = useState<string[]>([])
+  const [groupResult, setGroupResult] = useState<AccessRequestGroupResult>()
   const [submitButtonLoading, setSubmitButtonLoading] = useState(false)
   const [formValidationErrorState, setFormValidationErrorState] = useState(false)
+
+  useEffect(() => {
+    setAdditionalModelIds([])
+    setGroupResult(undefined)
+  }, [modelId, schemaId])
 
   const isLoading = useMemo(
     () => isSchemaLoading || isModelLoading || isCurrentUserLoading,
@@ -55,6 +63,9 @@ export default function NewAccessRequest() {
   }, [schema, model, currentUser])
 
   async function onSubmit() {
+    if (submitButtonLoading || groupResult) {
+      return
+    }
     setSubmissionErrorText('')
     setSubmitButtonLoading(true)
     setFormValidationErrorState(false)
@@ -88,16 +99,27 @@ export default function NewAccessRequest() {
       setSubmitButtonLoading(false)
       return
     }
-    const res = await postAccessRequest(modelId, schemaId, data)
-
-    if (!res.ok) {
-      setSubmissionErrorText(await getErrorMessage(res))
+    try {
+      const res = additionalModelIds.length
+        ? await postAccessRequestGroup([modelId, ...additionalModelIds], schemaId, data)
+        : await postAccessRequest(modelId, schemaId, data)
+      if (!res.ok) {
+        setSubmissionErrorText(await getErrorMessage(res))
+        return
+      }
+      const body = await res.json()
+      if (additionalModelIds.length) {
+        setGroupResult(body)
+      } else {
+        router.push(`/model/${modelId}/access-request/${body.accessRequest.id}`)
+      }
+    } catch {
+      setSubmissionErrorText(
+        'The request status could not be confirmed. Check your existing access requests before submitting again.',
+      )
+    } finally {
       setSubmitButtonLoading(false)
-      return
     }
-
-    const body = await res.json()
-    router.push(`/model/${modelId}/access-request/${body.accessRequest.id}`)
   }
 
   const error = MultipleErrorWrapper(`Unable to load access request page`, {
@@ -126,6 +148,12 @@ export default function NewAccessRequest() {
                     Select a different schema
                   </Button>
                 </Link>
+                <AccessRequestModels
+                  modelId={model.id}
+                  selectedIds={additionalModelIds}
+                  onChange={setAdditionalModelIds}
+                  disabled={submitButtonLoading || !!groupResult}
+                />
                 <JsonSchemaForm
                   splitSchema={splitSchema}
                   setSplitSchema={setSplitSchema}
@@ -143,11 +171,33 @@ export default function NewAccessRequest() {
                     variant='contained'
                     onClick={onSubmit}
                     loading={submitButtonLoading}
+                    disabled={!!groupResult}
                     data-test='createAccessRequestButton'
                   >
                     Submit
                   </Button>
                   <MessageAlert message={submissionErrorText} severity='error' />
+                  {groupResult && (
+                    <Stack spacing={1} sx={{ width: '100%' }}>
+                      <Typography component='h2' variant='h6'>
+                        Access request results
+                      </Typography>
+                      <Typography>
+                        {groupResult.accessRequests.length} requests created. Each request requires its own review.
+                      </Typography>
+                      {groupResult.accessRequests.map((request) => (
+                        <Link key={request.id} href={`/model/${request.modelId}/access-request/${request.id}`}>
+                          View request for {request.modelId}
+                        </Link>
+                      ))}
+                      {groupResult.failedModelIds.length > 0 && (
+                        <MessageAlert
+                          message={`No request was created for: ${groupResult.failedModelIds.join(', ')}. Successful requests remain saved. Start a new request for the unsuccessful models only.`}
+                          severity='warning'
+                        />
+                      )}
+                    </Stack>
+                  )}
                 </Stack>
               </Stack>
             )}

--- a/frontend/src/entry/model/accessRequests/AccessRequestDisplay.tsx
+++ b/frontend/src/entry/model/accessRequests/AccessRequestDisplay.tsx
@@ -1,4 +1,4 @@
-import { Box, Card, Grid, Stack, Typography } from '@mui/material'
+import { Box, Card, Chip, Grid, Stack, Typography } from '@mui/material'
 import CopyToClipboardButton from 'src/common/CopyToClipboardButton'
 import UserDisplay from 'src/common/UserDisplay'
 import ReleaseAccessRequestReviewSummary from 'src/entry/model/reviews/ReleaseAccessRequestReviewSummary'
@@ -52,6 +52,7 @@ export default function AccessRequestDisplay({ accessRequest }: AccessRequestDis
                   {accessRequest.metadata.overview.name}
                 </Typography>
               </Link>
+              {accessRequest.groupId && <Chip label='Grouped request' size='small' />}
               <CopyToClipboardButton
                 textToCopy={accessRequest.id}
                 notificationText='Copied access request ID to clipboard'

--- a/frontend/src/entry/model/accessRequests/AccessRequestGroupLinks.tsx
+++ b/frontend/src/entry/model/accessRequests/AccessRequestGroupLinks.tsx
@@ -1,0 +1,34 @@
+import { Stack, Typography } from '@mui/material'
+import { useGetAccessRequestGroup } from 'actions/accessRequest'
+import Loading from 'src/common/Loading'
+import Link from 'src/Link'
+import MessageAlert from 'src/MessageAlert'
+import { AccessRequestInterface } from 'types/types'
+
+export default function AccessRequestGroupLinks({ accessRequest }: { accessRequest: AccessRequestInterface }) {
+  const { accessRequests, isLoading, error } = useGetAccessRequestGroup(accessRequest)
+  if (!accessRequest.groupId) {
+    return null
+  }
+  const others = accessRequests.filter((request) => request.id !== accessRequest.id)
+  return (
+    <Stack spacing={1}>
+      <Typography component='h2' variant='subtitle2'>
+        Grouped request
+      </Typography>
+      <Typography variant='body2'>
+        Each model is reviewed separately. Only requests you can view are listed below.
+      </Typography>
+      {isLoading && <Loading />}
+      {error && <MessageAlert message='Related access requests could not be loaded.' severity='warning' />}
+      {!isLoading && !error && others.length === 0 && (
+        <Typography variant='body2'>No other requests in this group are visible to you.</Typography>
+      )}
+      {others.map((request) => (
+        <Link key={request.id} href={`/model/${request.modelId}/access-request/${request.id}`}>
+          Request for {request.modelId}
+        </Link>
+      ))}
+    </Stack>
+  )
+}

--- a/frontend/src/entry/model/accessRequests/AccessRequestModels.tsx
+++ b/frontend/src/entry/model/accessRequests/AccessRequestModels.tsx
@@ -1,0 +1,51 @@
+import { Autocomplete, Stack, TextField } from '@mui/material'
+import { useListEntries } from 'actions/entry'
+import MessageAlert from 'src/MessageAlert'
+import { EntryKind } from 'types/types'
+
+interface AccessRequestModelsProps {
+  modelId: string
+  selectedIds: string[]
+  onChange: (ids: string[]) => void
+  disabled?: boolean
+}
+
+export default function AccessRequestModels({
+  modelId,
+  selectedIds,
+  onChange,
+  disabled = false,
+}: AccessRequestModelsProps) {
+  const { entries, isEntriesLoading, isEntriesError } = useListEntries([EntryKind.MODEL, EntryKind.MIRRORED_MODEL])
+  const options = entries.filter((entry) => !entry.peerId && entry.id !== modelId)
+  return (
+    <Stack spacing={1}>
+      <Autocomplete
+        multiple
+        filterSelectedOptions
+        options={options}
+        value={options.filter((entry) => selectedIds.includes(entry.id))}
+        getOptionLabel={(entry) => entry.name}
+        getOptionKey={(entry) => entry.id}
+        isOptionEqualToValue={(option, value) => option.id === value.id}
+        getOptionDisabled={(option) => selectedIds.length >= 19 && !selectedIds.includes(option.id)}
+        onChange={(_, selected) => onChange(selected.map((entry) => entry.id))}
+        disabled={disabled || isEntriesLoading || !!isEntriesError}
+        loading={isEntriesLoading}
+        renderInput={(params) => (
+          <TextField
+            {...params}
+            label='Also request access to'
+            helperText='Optional. Select up to 19 additional models. Each model has its own request and review.'
+          />
+        )}
+      />
+      {isEntriesError && (
+        <MessageAlert
+          message='Additional models could not be loaded. You can still request access to this model.'
+          severity='warning'
+        />
+      )}
+    </Stack>
+  )
+}

--- a/frontend/test/entry/model/accessRequests/AccessRequestGroups.spec.tsx
+++ b/frontend/test/entry/model/accessRequests/AccessRequestGroups.spec.tsx
@@ -1,0 +1,197 @@
+import { ThemeProvider } from '@mui/material/styles'
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { postAccessRequest, postAccessRequestGroup, useGetAccessRequestGroup } from 'actions/accessRequest'
+import { useGetModel, useListEntries } from 'actions/entry'
+import { useGetSchema } from 'actions/schema'
+import { useGetCurrentUser } from 'actions/user'
+import { useRouter } from 'next/router'
+import NewAccessRequest from 'pages/model/[modelId]/access-request/new'
+import { ReactNode } from 'react'
+import AccessRequestGroupLinks from 'src/entry/model/accessRequests/AccessRequestGroupLinks'
+import AccessRequestModels from 'src/entry/model/accessRequests/AccessRequestModels'
+import { lightTheme } from 'src/theme'
+import { AccessRequestInterface } from 'types/types'
+import { getStepsData } from 'utils/formUtils'
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
+
+vi.mock('actions/accessRequest', () => ({
+  postAccessRequest: vi.fn(),
+  postAccessRequestGroup: vi.fn(),
+  useGetAccessRequestGroup: vi.fn(),
+}))
+vi.mock('actions/entry', () => ({ useGetModel: vi.fn(), useListEntries: vi.fn() }))
+vi.mock('actions/schema', () => ({ useGetSchema: vi.fn() }))
+vi.mock('actions/user', () => ({ useGetCurrentUser: vi.fn() }))
+vi.mock('next/router', () => ({ useRouter: vi.fn() }))
+vi.mock('src/Form/JsonSchemaForm', () => ({ default: () => <div>Request form</div> }))
+vi.mock('utils/formUtils', () => ({
+  getStepsFromSchema: () => [],
+  getStepsData: vi.fn(),
+  setStepValidate: vi.fn(),
+  validateForm: () => true,
+}))
+
+const push = vi.fn()
+const entries = [
+  { id: 'first', name: 'First model' },
+  { id: 'second', name: 'Second model' },
+]
+const first = { id: 'request-first', modelId: 'first', groupId: 'group' } as AccessRequestInterface
+const second = { id: 'request-second', modelId: 'second', groupId: 'group' } as AccessRequestInterface
+const data = { overview: { name: 'Shared purpose', entities: ['user:requester'] } }
+function show(component: ReactNode) {
+  return render(<ThemeProvider theme={lightTheme}>{component}</ThemeProvider>)
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  vi.mocked(useRouter).mockReturnValue({ query: { modelId: 'first', schemaId: 'schema' }, push } as any)
+  vi.mocked(useListEntries).mockReturnValue({ entries, isEntriesLoading: false, isEntriesError: undefined } as any)
+  vi.mocked(useGetModel).mockReturnValue({ entry: { id: 'first', card: {} }, isEntryLoading: false } as any)
+  vi.mocked(useGetSchema).mockReturnValue({ schema: { id: 'schema' }, isSchemaLoading: false } as any)
+  vi.mocked(useGetCurrentUser).mockReturnValue({ currentUser: { dn: 'requester' }, isCurrentUserLoading: false } as any)
+  vi.mocked(getStepsData).mockReturnValue(data)
+  vi.mocked(useGetAccessRequestGroup).mockReturnValue({
+    accessRequests: [first, second],
+    isLoading: false,
+    error: undefined,
+  })
+  vi.mocked(postAccessRequest).mockResolvedValue(
+    new Response(JSON.stringify({ accessRequest: first }), { status: 200 }),
+  )
+  vi.mocked(postAccessRequestGroup).mockResolvedValue(
+    new Response(JSON.stringify({ groupId: 'group', accessRequests: [first, second], failedModelIds: [] }), {
+      status: 200,
+    }),
+  )
+})
+afterEach(cleanup)
+
+function addSecondModel() {
+  fireEvent.mouseDown(screen.getByRole('combobox'))
+  fireEvent.click(screen.getByRole('option', { name: 'Second model' }))
+}
+
+describe('additional model selector', () => {
+  test('excludes the current model and returns additional IDs', () => {
+    const changed = vi.fn()
+    show(<AccessRequestModels modelId='first' selectedIds={[]} onChange={changed} />)
+    fireEvent.mouseDown(screen.getByRole('combobox'))
+    expect(screen.queryByRole('option', { name: 'First model' })).toBeNull()
+    fireEvent.click(screen.getByRole('option', { name: 'Second model' }))
+    expect(changed).toHaveBeenCalledWith(['second'])
+  })
+
+  test('does not submit a remote peer model to the local endpoint', () => {
+    vi.mocked(useListEntries).mockReturnValue({
+      entries: [...entries, { id: 'remote', name: 'Remote model', peerId: 'peer' }],
+      isEntriesLoading: false,
+    } as any)
+    show(<AccessRequestModels modelId='first' selectedIds={[]} onChange={vi.fn()} />)
+    fireEvent.mouseDown(screen.getByRole('combobox'))
+    expect(screen.queryByRole('option', { name: 'Remote model' })).toBeNull()
+    expect(screen.getByRole('option', { name: 'Second model' })).toBeDefined()
+  })
+
+  test('limits the group to nineteen additional models', () => {
+    const options = Array.from({ length: 20 }, (_, index) => ({ id: String(index), name: `Model ${index}` }))
+    vi.mocked(useListEntries).mockReturnValue({ entries: options, isEntriesLoading: false } as any)
+    show(
+      <AccessRequestModels
+        modelId='first'
+        selectedIds={options.slice(0, 19).map((entry) => entry.id)}
+        onChange={vi.fn()}
+      />,
+    )
+    fireEvent.mouseDown(screen.getByRole('combobox'))
+    expect(screen.getByRole('option', { name: 'Model 19' }).getAttribute('aria-disabled')).toBe('true')
+  })
+
+  test('disables additional selection while entries are loading', () => {
+    vi.mocked(useListEntries).mockReturnValue({ entries: [], isEntriesLoading: true } as any)
+    show(<AccessRequestModels modelId='first' selectedIds={[]} onChange={vi.fn()} />)
+    expect((screen.getByRole('combobox') as HTMLInputElement).disabled).toBe(true)
+  })
+
+  test('shows an error without preventing single-model requests', () => {
+    vi.mocked(useListEntries).mockReturnValue({ entries: [], isEntriesLoading: false, isEntriesError: {} } as any)
+    show(<AccessRequestModels modelId='first' selectedIds={[]} onChange={vi.fn()} />)
+    expect(screen.getByText(/You can still request access to this model/)).toBeDefined()
+  })
+})
+
+describe('group links', () => {
+  test('shows other visible requests, excluding the current request', () => {
+    show(<AccessRequestGroupLinks accessRequest={first} />)
+    expect(screen.getByRole('link', { name: 'Request for second' }).getAttribute('href')).toBe(
+      '/model/second/access-request/request-second',
+    )
+    expect(screen.queryByRole('link', { name: 'Request for first' })).toBeNull()
+    expect(screen.getByText('Grouped request')).toBeDefined()
+  })
+
+  test('does not imply how many inaccessible requests exist', () => {
+    vi.mocked(useGetAccessRequestGroup).mockReturnValue({ accessRequests: [first], isLoading: false, error: undefined })
+    show(<AccessRequestGroupLinks accessRequest={first} />)
+    expect(screen.getByText('No other requests in this group are visible to you.')).toBeDefined()
+    expect(screen.queryByRole('link')).toBeNull()
+  })
+
+  test('leaves legacy requests unchanged', () => {
+    const { container } = show(<AccessRequestGroupLinks accessRequest={{ ...first, groupId: undefined }} />)
+    expect(container.textContent).toBe('')
+  })
+
+  test('reports errors without calling a failed group empty', () => {
+    vi.mocked(useGetAccessRequestGroup).mockReturnValue({ accessRequests: [], isLoading: false, error: {} as any })
+    show(<AccessRequestGroupLinks accessRequest={first} />)
+    expect(screen.getByText('Related access requests could not be loaded.')).toBeDefined()
+    expect(screen.queryByText('No other requests in this group are visible to you.')).toBeNull()
+  })
+})
+
+describe('grouped request submission', () => {
+  test('preserves single-model submission and navigation', async () => {
+    show(<NewAccessRequest />)
+    fireEvent.click(screen.getByRole('button', { name: 'Submit' }))
+    await waitFor(() => expect(postAccessRequest).toHaveBeenCalledWith('first', 'schema', data))
+    expect(postAccessRequestGroup).not.toHaveBeenCalled()
+    await waitFor(() => expect(push).toHaveBeenCalledWith('/model/first/access-request/request-first'))
+  })
+
+  test('submits one group and displays all created links', async () => {
+    show(<NewAccessRequest />)
+    addSecondModel()
+    fireEvent.click(screen.getByRole('button', { name: 'Submit' }))
+    await waitFor(() => expect(postAccessRequestGroup).toHaveBeenCalledWith(['first', 'second'], 'schema', data))
+    expect(postAccessRequest).not.toHaveBeenCalled()
+    await waitFor(() => expect(screen.getByRole('link', { name: 'View request for second' })).toBeDefined())
+    expect((screen.getByRole('button', { name: 'Submit' }) as HTMLButtonElement).disabled).toBe(true)
+    expect(push).not.toHaveBeenCalled()
+  })
+
+  test('preserves partial successes and prevents a whole-group resubmission', async () => {
+    vi.mocked(postAccessRequestGroup).mockResolvedValue(
+      new Response(JSON.stringify({ groupId: 'group', accessRequests: [first], failedModelIds: ['second'] }), {
+        status: 200,
+      }),
+    )
+    show(<NewAccessRequest />)
+    addSecondModel()
+    fireEvent.click(screen.getByRole('button', { name: 'Submit' }))
+    await waitFor(() => expect(screen.getByText(/No request was created for: second/)).toBeDefined())
+    expect(screen.getByRole('link', { name: 'View request for first' })).toBeDefined()
+    fireEvent.click(screen.getByRole('button', { name: 'Submit' }))
+    expect(postAccessRequestGroup).toHaveBeenCalledTimes(1)
+  })
+
+  test('handles an uncertain network outcome without claiming failure or success', async () => {
+    vi.mocked(postAccessRequestGroup).mockRejectedValue(new Error('Connection lost'))
+    show(<NewAccessRequest />)
+    addSecondModel()
+    fireEvent.click(screen.getByRole('button', { name: 'Submit' }))
+    await waitFor(() => expect(screen.getByText(/Check your existing access requests/)).toBeDefined())
+    expect(push).not.toHaveBeenCalled()
+    expect(screen.queryByText('Access request results')).toBeNull()
+  })
+})

--- a/frontend/types/types.ts
+++ b/frontend/types/types.ts
@@ -546,6 +546,7 @@ export interface AccessRequestInterface {
   _id: string
   id: string
   modelId: string
+  groupId?: string
   schemaId: string
   deleted: boolean
   metadata: AccessRequestMetadata


### PR DESCRIPTION
### Description of change

Fixes #2347.

Create linked access requests for up to 20 local models from one form. Each model keeps its own authorisation checks, request, reviewers and decision. Request and review pages link to other group members the viewer can access.

Creation returns explicit per-model results. Successful requests remain saved when another target fails; the UI shows both outcomes and prevents resubmitting the whole group. Existing single-model requests are unchanged.

### Validation

1,443 backend tests and 172 frontend tests pass, including 42 new service, API and UI cases. Both production builds, TypeScript, changed-file ESLint/Prettier, documentation style and OpenAPI generation pass. Docker, Kubernetes, live MongoDB and Cypress integration checks were not run.

### Checklist

- [x] I have reviewed all code in this PR, and confirm that all content meets the requirements set out in the [contribution guidance](./CONTRIBUTING.md).
