### PR TITLE
Allow individual file access for model-card images

### DIFF
--- a/backend/src/connectors/authorisation/base.ts
+++ b/backend/src/connectors/authorisation/base.ts
@@ -376,6 +376,7 @@ export class BasicAuthorisationConnector {
         if (
           ([FileAction.Download] as FileActionKeys[]).includes(action) &&
           !model.settings.ungovernedAccess &&
+          file.ungovernedAccess !== true &&
           !hasApprovedAccessRequest &&
           (await missingRequiredRole(user, model, ['owner', 'contributor', 'consumer']))
         ) {

--- a/backend/src/models/File.ts
+++ b/backend/src/models/File.ts
@@ -17,6 +17,7 @@ export interface FileInterface {
   path: string
 
   complete: boolean
+  ungovernedAccess?: boolean
 
   tags: string[]
 
@@ -48,6 +49,7 @@ const FileSchema = new Schema<FileInterfaceDoc>(
     tags: [{ type: String }],
 
     complete: { type: Boolean, default: false },
+    ungovernedAccess: { type: Boolean, default: false },
   },
   {
     timestamps: true,

--- a/backend/src/routes/v2/model/file/patchFile.ts
+++ b/backend/src/routes/v2/model/file/patchFile.ts
@@ -22,6 +22,7 @@ export const patchFileSchema = z.object({
     metadata: z.object({}).optional(),
     name: z.string().optional(),
     mime: z.string().optional(),
+    ungovernedAccess: z.boolean().optional(),
   }),
 })
 

--- a/backend/src/services/file.ts
+++ b/backend/src/services/file.ts
@@ -12,7 +12,7 @@ import {
   putObjectStream,
   startMultipartUpload,
 } from '../clients/s3.js'
-import { FileAction } from '../connectors/authorisation/actions.js'
+import { FileAction, ModelAction } from '../connectors/authorisation/actions.js'
 import authorisation from '../connectors/authorisation/index.js'
 import FileModel, {
   FileInterface,
@@ -411,7 +411,7 @@ export async function updateFile(
   user: UserInterface,
   modelId: string,
   fileId: string,
-  patchFileParams: Partial<Pick<FileInterface, 'tags' | 'name' | 'mime'>>,
+  patchFileParams: Partial<Pick<FileInterface, 'tags' | 'name' | 'mime' | 'ungovernedAccess'>>,
 ) {
   let file: FileWithScanResultsAggregate
   try {
@@ -427,12 +427,24 @@ export async function updateFile(
     throw BadReq('Cannot find requested model', { modelId: modelId })
   }
 
+  if (file.modelId !== modelId) {
+    throw NotFound('The requested file was not found in this model.', { modelId, fileId })
+  }
+
+  // Changing download access requires the same permission as changing model access.
+  if (patchFileParams.ungovernedAccess !== undefined) {
+    const accessAuth = await authorisation.model(user, model, ModelAction.Update)
+    if (!accessAuth.success) {
+      throw Forbidden(accessAuth.info, { userDn: user.dn, modelId, fileId })
+    }
+  }
+
   const patchFileAuth = await authorisation.file(user, model, file, FileAction.Update)
   if (!patchFileAuth.success) {
     throw Forbidden(patchFileAuth.info, { userDn: user.dn, modelId, file })
   }
 
-  const updatedFile = await FileModel.findOneAndUpdate({ _id: fileId }, patchFileParams, { new: true })
+  const updatedFile = await FileModel.findOneAndUpdate({ _id: fileId, modelId }, patchFileParams, { new: true })
   if (!updatedFile) {
     throw BadReq('There was a problem updating the file', { modelId, fileId, patchFileParams })
   }

--- a/backend/src/services/specification.ts
+++ b/backend/src/services/specification.ts
@@ -194,6 +194,7 @@ export const fileWithScanInterfaceSchema = z.object({
   path: z.string().openapi({ example: '/model/yolo-v4-abcdef/files/abcdef' }),
 
   complete: z.boolean().openapi({ example: true }),
+  ungovernedAccess: z.boolean().optional().openapi({ example: false }),
 
   scanResults: z
     .array(

--- a/backend/test/connectors/authorisation/base.spec.ts
+++ b/backend/test/connectors/authorisation/base.spec.ts
@@ -803,6 +803,60 @@ describe('connectors > authorisation > base', () => {
     })
   })
 
+  describe('file download access overrides', () => {
+    const publicModel = { id: 'model', visibility: 'public', settings: { ungovernedAccess: false } } as ModelDoc
+
+    test.each([true, false, undefined])(
+      'only an explicit opt-in bypasses the access request (%s)',
+      async (ungovernedAccess) => {
+        const connector = new BasicAuthorisationConnector()
+        mockAccessRequestService.getModelAccessRequestsForUser.mockResolvedValue([])
+        mockResponseService.checkAccessRequestsApproved.mockResolvedValue(false)
+        mockModelService.getModelSystemRoles.mockResolvedValue([])
+        ReviewRoleModelMock.find.mockResolvedValue([])
+        const file = { _id: { toString: () => 'image' }, ungovernedAccess } as any
+        const result = await connector.file(user, publicModel, file, FileAction.Download)
+        expect(result.success).toBe(ungovernedAccess === true)
+      },
+    )
+
+    test('does not bypass a token restriction', async () => {
+      mockAccessRequestService.getModelAccessRequestsForUser.mockResolvedValue([])
+      mockTokenService.validateTokenForModel.mockResolvedValueOnce({
+        success: false,
+        info: 'Token cannot read files',
+      } as any)
+      const file = { _id: { toString: () => 'image' }, ungovernedAccess: true } as any
+      const result = await new BasicAuthorisationConnector().file(user, publicModel, file, FileAction.Download)
+      expect(result.success).toBe(false)
+      expect(mockTokenService.validateTokenForModel).toHaveBeenCalledWith(user.token, 'model', 'file:read')
+    })
+
+    test.each([FileAction.Update, FileAction.Delete, FileAction.Upload])(
+      'does not grant write action %s',
+      async (action) => {
+        mockAccessRequestService.getModelAccessRequestsForUser.mockResolvedValue([])
+        mockModelService.getModelSystemRoles.mockResolvedValue([])
+        ReviewRoleModelMock.find.mockResolvedValue([])
+        const file = { _id: { toString: () => 'image' }, ungovernedAccess: true } as any
+        const result = await new BasicAuthorisationConnector().file(user, publicModel, file, action)
+        expect(result.success).toBe(false)
+      },
+    )
+
+    test('turning off the file override retains model-wide ungoverned access', async () => {
+      mockAccessRequestService.getModelAccessRequestsForUser.mockResolvedValue([])
+      const file = { _id: { toString: () => 'image' }, ungovernedAccess: false } as any
+      const result = await new BasicAuthorisationConnector().file(
+        user,
+        { ...publicModel, settings: { ungovernedAccess: true } } as ModelDoc,
+        file,
+        FileAction.Download,
+      )
+      expect(result.success).toBe(true)
+    })
+  })
+
   test('files > update when missing roles', async () => {
     const connector = new BasicAuthorisationConnector()
     mockAccessRequestService.getModelAccessRequestsForUser.mockResolvedValue([])

--- a/backend/test/routes/model/file/patchFile.spec.ts
+++ b/backend/test/routes/model/file/patchFile.spec.ts
@@ -2,6 +2,7 @@ import { describe, expect, test, vi } from 'vitest'
 
 import audit from '../../../../src/connectors/audit/__mocks__/index.js'
 import { patchFileSchema } from '../../../../src/routes/v2/model/file/patchFile.js'
+import { updateFile } from '../../../../src/services/file.js'
 import { createFixture, testPatch } from '../../../testUtils/routes.js'
 
 vi.mock('../../../../src/connectors/audit/index.js')
@@ -19,6 +20,22 @@ describe('routes > file > patchFile', () => {
 
     expect(res.statusCode).toBe(200)
     expect(res.body).matchSnapshot()
+  })
+
+  test.each([true, false])(
+    'passes an explicit boolean access change (%s) to the service and audits it',
+    async (ungovernedAccess) => {
+      const response = await testPatch('/api/v2/model/model/file/file', { body: { ungovernedAccess } })
+      expect(response.statusCode).toBe(200)
+      expect(updateFile).toHaveBeenCalledWith(expect.anything(), 'model', 'file', { ungovernedAccess })
+      expect(audit.onUpdateFile).toHaveBeenCalled()
+    },
+  )
+
+  test.each(['true', 'false', 1, null])('rejects a non-boolean access flag %j', async (ungovernedAccess) => {
+    const response = await testPatch('/api/v2/model/model/file/file', { body: { ungovernedAccess } })
+    expect(response.statusCode).toBe(400)
+    expect(updateFile).not.toHaveBeenCalled()
   })
 
   test('audit > expected call', async () => {

--- a/backend/test/services/file.spec.ts
+++ b/backend/test/services/file.spec.ts
@@ -3,7 +3,7 @@ import { Readable } from 'node:stream'
 import { describe, expect, test, vi } from 'vitest'
 
 import { ArtefactScanResult } from '../../src/connectors/artefactScanning/Base.js'
-import { FileAction } from '../../src/connectors/authorisation/actions.js'
+import { FileAction, ModelAction } from '../../src/connectors/authorisation/actions.js'
 import authorisation from '../../src/connectors/authorisation/index.js'
 import { ArtefactKind } from '../../src/models/Scan.js'
 import {
@@ -734,15 +734,66 @@ describe('services > file', () => {
     expect(size).toBe(42)
   })
 
+  describe('individual file access', () => {
+    const user = { dn: 'testUser' } as any
+    const file = { modelId: 'testModelId', _id: { toString: () => testFileId } }
+
+    test.each([true, false])('checks model-edit permission when changing access to %s', async (ungovernedAccess) => {
+      FileModelMock.aggregate.mockResolvedValue([file])
+      await updateFile(user, file.modelId, testFileId, { ungovernedAccess })
+      expect(authorisation.model).toHaveBeenCalledWith(user, expect.anything(), ModelAction.Update)
+      expect(FileModelMock.findOneAndUpdate).toHaveBeenCalledWith(
+        { _id: testFileId, modelId: file.modelId },
+        { ungovernedAccess },
+        { new: true },
+      )
+    })
+
+    test.each([true, false])('refuses a contributor changing access to %s', async (ungovernedAccess) => {
+      FileModelMock.aggregate.mockResolvedValue([file])
+      vi.mocked(authorisation.model).mockResolvedValue({
+        success: false,
+        id: 'testModelId',
+        info: 'Owner permission required',
+      })
+      await expect(updateFile(user, file.modelId, testFileId, { tags: ['image'], ungovernedAccess })).rejects.toThrow(
+        'Owner permission required',
+      )
+      expect(FileModelMock.findOneAndUpdate).not.toHaveBeenCalled()
+    })
+
+    test('does not change normal tag-editing permissions', async () => {
+      FileModelMock.aggregate.mockResolvedValue([file])
+      await updateFile(user, file.modelId, testFileId, { tags: ['image'] })
+      expect(authorisation.model).not.toHaveBeenCalledWith(user, expect.anything(), ModelAction.Update)
+      expect(authorisation.file).toHaveBeenCalledWith(user, expect.anything(), file, FileAction.Update)
+    })
+
+    test('cannot use ownership of a different model to change file access', async () => {
+      FileModelMock.aggregate.mockResolvedValue([file])
+      await expect(updateFile(user, 'other-model', testFileId, { ungovernedAccess: true })).rejects.toThrow(
+        'not found in this model',
+      )
+      expect(FileModelMock.findOneAndUpdate).not.toHaveBeenCalled()
+    })
+
+    test('sharing does not bypass model visibility when downloading', async () => {
+      FileModelMock.aggregate.mockResolvedValue([{ ...file, ungovernedAccess: true }])
+      modelMocks.getModelById.mockRejectedValueOnce(new Error('Private model'))
+      await expect(downloadFile(user, testFileId)).rejects.toThrow('Private model')
+      expect(s3Mocks.getObjectStream).not.toHaveBeenCalled()
+    })
+  })
+
   test('updateFile > success', async () => {
     const user = { dn: 'testUser' } as any
     const modelId = 'testModelId'
 
-    FileModelMock.aggregate.mockResolvedValue([{ modelId: 'testModel', _id: { toString: vi.fn(() => testFileId) } }])
+    FileModelMock.aggregate.mockResolvedValue([{ modelId: 'testModelId', _id: { toString: vi.fn(() => testFileId) } }])
 
     const result = await updateFile(user, modelId, testFileId, { tags: ['test1'] })
 
-    expect(result.modelId).toBe('testModel')
+    expect(result.modelId).toBe('testModelId')
     expect(result.id).toBeUndefined()
     expect(FileModelMock.findOneAndUpdate).toHaveBeenCalledOnce()
   })
@@ -751,7 +802,7 @@ describe('services > file', () => {
     const user = { dn: 'testUser' } as any
     const modelId = 'testModelId'
 
-    FileModelMock.aggregate.mockResolvedValue([{ modelId: 'testModel', _id: { toString: vi.fn(() => testFileId) } }])
+    FileModelMock.aggregate.mockResolvedValue([{ modelId: 'testModelId', _id: { toString: vi.fn(() => testFileId) } }])
 
     const result = await updateFile(user, modelId, testFileId, {
       tags: ['test1'],
@@ -759,10 +810,10 @@ describe('services > file', () => {
       mime: 'text/plain',
     })
 
-    expect(result.modelId).toBe('testModel')
+    expect(result.modelId).toBe('testModelId')
     expect(result.id).toBeUndefined()
     expect(FileModelMock.findOneAndUpdate).toHaveBeenCalledWith(
-      { _id: testFileId },
+      { _id: testFileId, modelId },
       {
         tags: ['test1'],
         name: 'my-file-renamed.txt',
@@ -790,7 +841,7 @@ describe('services > file', () => {
     const modelId = 'testModelId'
 
     FileModelMock.aggregate.mockResolvedValueOnce([
-      { modelId: 'testModel', _id: { toString: vi.fn(() => testFileId) } },
+      { modelId: 'testModelId', _id: { toString: vi.fn(() => testFileId) } },
     ])
     modelMocks.getModelById.mockResolvedValueOnce(modelMocks.getModelById()).mockRejectedValueOnce('Error')
 
@@ -805,7 +856,7 @@ describe('services > file', () => {
     const modelId = 'testModelId'
 
     FileModelMock.aggregate.mockResolvedValueOnce([
-      { modelId: 'testModel', _id: { toString: vi.fn(() => testFileId) } },
+      { modelId: 'testModelId', _id: { toString: vi.fn(() => testFileId) } },
     ])
     vi.mocked(authorisation.file).mockResolvedValueOnce({ success: true, id: '' }).mockResolvedValue({
       info: 'You do not have permission to upload a file to this model.',
@@ -824,7 +875,7 @@ describe('services > file', () => {
     const modelId = 'testModelId'
 
     FileModelMock.aggregate.mockResolvedValueOnce([
-      { modelId: 'testModel', _id: { toString: vi.fn(() => testFileId) } },
+      { modelId: 'testModelId', _id: { toString: vi.fn(() => testFileId) } },
     ])
     FileModelMock.findOneAndUpdate.mockResolvedValueOnce(null)
 

--- a/frontend/actions/file.ts
+++ b/frontend/actions/file.ts
@@ -70,13 +70,17 @@ export async function postFileForModelId(
   }
 }
 
-export async function patchFile(modelId: string, fileId: string, metadata: Pick<FileInterface, 'tags'>) {
+export async function patchFile(
+  modelId: string,
+  fileId: string,
+  metadata: Partial<Pick<FileInterface, 'tags' | 'ungovernedAccess'>>,
+) {
   try {
     const response = await axios({
       method: 'patch',
       url: `/api/v2/model/${modelId}/file/${fileId}`,
       headers: { 'Content-Type': 'application/json' },
-      data: { tags: metadata.tags },
+      data: { tags: metadata.tags, ungovernedAccess: metadata.ungovernedAccess },
     })
     return { status: response.status, data: response.data }
   } catch (error) {

--- a/frontend/pages/docs/users/models/model-card/model-card.mdx
+++ b/frontend/pages/docs/users/models/model-card/model-card.mdx
@@ -104,4 +104,28 @@ Every edit to the model card creates a new version that is preserved in the mode
 - [Understanding Reviews](../../reviews/understanding-reviews) - The review process
 - [Roles & Permissions](../../../reference/roles-and-permissions) - Detailed role reference
 
+## Images stored in model files
+
+Owners can make individual files available without approving an access request for all model files. Upload the image
+from the model's Files tab, select **Allow downloads without an access request**, and confirm the change. Only enable
+this for files that are suitable for everyone who can view the model.
+
+Use the file's download link in a Markdown field on the model card:
+
+```markdown
+![Description of the image](/api/v2/model/MODEL_ID/file/FILE_ID/download)
+```
+
+Replace `MODEL_ID` and `FILE_ID` with the values in the uploaded file's link. Viewers still need to be signed in and
+able to view the model. API clients still need their normal model and file-read permissions. Other files retain their
+existing access rules.
+
+Owners can select **Require normal file access** to remove the file-specific exception. Model-wide ungoverned access,
+existing access requests and collaborator permissions still apply. New and existing files are restricted by default
+unless either a file exception or the normal model access rules permit downloading them.
+
+The same setting is available through `PATCH /api/v2/model/{modelId}/file/{fileId}` using `{"ungovernedAccess": true}`
+or `{"ungovernedAccess": false}`. Changing it requires permission to edit the model as well as the file. A contributor's
+ability to edit file tags alone does not grant this permission.
+
 export default ({ children }) => <DocsWrapper>{children}</DocsWrapper>

--- a/frontend/src/entry/model/files/FileAccessSetting.tsx
+++ b/frontend/src/entry/model/files/FileAccessSetting.tsx
@@ -1,0 +1,80 @@
+import { Button, Stack, Typography } from '@mui/material'
+import { patchFile } from 'actions/file'
+import { useContext, useState } from 'react'
+import ConfirmationDialogue from 'src/common/ConfirmationDialogue'
+import UserPermissionsContext from 'src/contexts/userPermissionsContext'
+import MessageAlert from 'src/MessageAlert'
+import { FileInterface } from 'types/types'
+
+interface FileAccessSettingProps {
+  file: FileInterface
+  onChange: () => void
+}
+
+export default function FileAccessSetting({ file, onChange }: FileAccessSettingProps) {
+  const { userPermissions } = useContext(UserPermissionsContext)
+  const [open, setOpen] = useState(false)
+  const [saving, setSaving] = useState(false)
+  const [error, setError] = useState('')
+  const shared = file.ungovernedAccess === true
+
+  async function save() {
+    if (saving) {
+      return
+    }
+    setSaving(true)
+    setError('')
+    try {
+      const result = await patchFile(file.modelId, file._id, { ungovernedAccess: !shared })
+      if (!result.status || result.status < 200 || result.status >= 300) {
+        setError(typeof result.data === 'string' ? result.data : 'Unable to change file access. Please try again.')
+        return
+      }
+      setOpen(false)
+      onChange()
+    } catch {
+      setError('Unable to change file access. Please try again.')
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  return (
+    <Stack spacing={1}>
+      {shared && (
+        <Typography variant='caption'>This file can be downloaded by anyone who can view this model.</Typography>
+      )}
+      {userPermissions.editEntry.hasPermission && (
+        <Button
+          size='small'
+          sx={{ width: 'fit-content' }}
+          onClick={() => {
+            setError('')
+            setOpen(true)
+          }}
+        >
+          {shared ? 'Require normal file access' : 'Allow downloads without an access request'}
+        </Button>
+      )}
+      <ConfirmationDialogue
+        open={open}
+        title={shared ? 'Restore normal file access' : 'Allow access to this file'}
+        dialogMessage={
+          shared
+            ? 'This file will follow the normal model access rules. Model-wide ungoverned access and existing access grants will still apply.'
+            : 'Anyone who can view this model will be able to download this file without an access request. Other files will keep their existing access rules.'
+        }
+        onConfirm={save}
+        onCancel={() => {
+          if (!saving) {
+            setOpen(false)
+          }
+        }}
+        confirmLoading={saving}
+        confirmDisabled={saving}
+      >
+        <MessageAlert message={error} severity='error' />
+      </ConfirmationDialogue>
+    </Stack>
+  )
+}

--- a/frontend/src/entry/model/files/FileDisplay.tsx
+++ b/frontend/src/entry/model/files/FileDisplay.tsx
@@ -39,6 +39,7 @@ import {
 import ConfirmationDialogue from 'src/common/ConfirmationDialogue'
 import Restricted from 'src/common/Restricted'
 import ArtefactScanningInfoContext from 'src/contexts/artefactScanningInfoContext'
+import FileAccessSetting from 'src/entry/model/files/FileAccessSetting'
 import AssociatedReleasesDialog from 'src/entry/model/releases/AssociatedReleasesDialog'
 import AssociatedReleasesList from 'src/entry/model/releases/AssociatedReleasesList'
 import EntryTagSelector from 'src/entry/model/releases/EntryTagSelector'
@@ -433,6 +434,13 @@ export default function FileDisplay({
               </>
             )}
           </Stack>
+          <FileAccessSetting
+            file={file}
+            onChange={() => {
+              mutateModelFiles()
+              mutator?.()
+            }}
+          />
         </Stack>
       )}
       <AssociatedReleasesDialog

--- a/frontend/test/actions/fileAccess.spec.ts
+++ b/frontend/test/actions/fileAccess.spec.ts
@@ -1,0 +1,30 @@
+import { patchFile } from 'actions/file'
+import axios from 'axios'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('axios', () => ({ default: vi.fn() }))
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  vi.mocked(axios).mockResolvedValue({ status: 200, data: {} })
+})
+
+describe('file access API client', () => {
+  it.each([true, false])('sends access flag %s without losing false values', async (ungovernedAccess) => {
+    await patchFile('model', 'file', { ungovernedAccess })
+    expect(axios).toHaveBeenCalledWith(
+      expect.objectContaining({
+        method: 'patch',
+        url: '/api/v2/model/model/file/file',
+        data: { tags: undefined, ungovernedAccess },
+      }),
+    )
+  })
+
+  it('preserves the existing tag-only request', async () => {
+    await patchFile('model', 'file', { tags: ['image'] })
+    expect(axios).toHaveBeenCalledWith(
+      expect.objectContaining({ data: { tags: ['image'], ungovernedAccess: undefined } }),
+    )
+  })
+})

--- a/frontend/test/entry/model/files/FileAccessSetting.spec.tsx
+++ b/frontend/test/entry/model/files/FileAccessSetting.spec.tsx
@@ -1,0 +1,85 @@
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { patchFile } from 'actions/file'
+import UserPermissionsContext from 'src/contexts/userPermissionsContext'
+import FileAccessSetting from 'src/entry/model/files/FileAccessSetting'
+import { defaultUserPermissions } from 'src/hooks/UserPermissionsHook'
+import { FileInterface } from 'types/types'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('actions/file', () => ({ patchFile: vi.fn() }))
+
+afterEach(cleanup)
+beforeEach(() => {
+  vi.clearAllMocks()
+  vi.mocked(patchFile).mockResolvedValue({ status: 200, data: {} })
+})
+
+function show(allowed: boolean, ungovernedAccess?: boolean) {
+  const onChange = vi.fn()
+  const file = { modelId: 'model', _id: 'file', ungovernedAccess } as FileInterface
+  render(
+    <UserPermissionsContext.Provider
+      value={{
+        userPermissions: {
+          ...defaultUserPermissions,
+          editEntry: allowed ? { hasPermission: true } : { hasPermission: false, info: 'Denied' },
+        },
+      }}
+    >
+      <FileAccessSetting file={file} onChange={onChange} />
+    </UserPermissionsContext.Provider>,
+  )
+  return onChange
+}
+
+describe('file access setting', () => {
+  it('requires confirmation before enabling downloads', async () => {
+    const onChange = show(true)
+    fireEvent.click(screen.getByRole('button', { name: 'Allow downloads without an access request' }))
+    expect(patchFile).not.toHaveBeenCalled()
+    expect(screen.getByText(/Other files will keep their existing access rules/)).toBeDefined()
+    fireEvent.click(screen.getByRole('button', { name: 'Confirm' }))
+    await waitFor(() => expect(patchFile).toHaveBeenCalledWith('model', 'file', { ungovernedAccess: true }))
+    await waitFor(() => expect(onChange).toHaveBeenCalledOnce())
+  })
+
+  it('cancels without changing access', () => {
+    show(true, false)
+    fireEvent.click(screen.getByRole('button', { name: 'Allow downloads without an access request' }))
+    fireEvent.click(screen.getByRole('button', { name: 'Cancel' }))
+    expect(patchFile).not.toHaveBeenCalled()
+  })
+
+  it('restores normal access explicitly without overriding model-wide grants', async () => {
+    show(true, true)
+    fireEvent.click(screen.getByRole('button', { name: 'Require normal file access' }))
+    expect(screen.getByText(/Model-wide ungoverned access and existing access grants will still apply/)).toBeDefined()
+    fireEvent.click(screen.getByRole('button', { name: 'Confirm' }))
+    await waitFor(() => expect(patchFile).toHaveBeenCalledWith('model', 'file', { ungovernedAccess: false }))
+  })
+
+  it.each([true, false, undefined])('never shows edit controls without permission (%s)', (value) => {
+    show(false, value)
+    expect(screen.queryByRole('button')).toBeNull()
+    expect(Boolean(screen.queryByText(/downloaded by anyone/))).toBe(value === true)
+  })
+
+  it('shows server errors without applying an optimistic permission change', async () => {
+    vi.mocked(patchFile).mockResolvedValue({ status: 403, data: 'Owner permission required' })
+    const onChange = show(true)
+    fireEvent.click(screen.getByRole('button', { name: 'Allow downloads without an access request' }))
+    fireEvent.click(screen.getByRole('button', { name: 'Confirm' }))
+    await waitFor(() => expect(screen.getByText('Owner permission required')).toBeDefined())
+    expect(onChange).not.toHaveBeenCalled()
+    expect(screen.getByRole('dialog')).toBeDefined()
+  })
+
+  it('handles a lost connection without claiming the update succeeded', async () => {
+    vi.mocked(patchFile).mockRejectedValue(new Error('Disconnected'))
+    const onChange = show(true)
+    fireEvent.click(screen.getByRole('button', { name: 'Allow downloads without an access request' }))
+    fireEvent.click(screen.getByRole('button', { name: 'Confirm' }))
+    await waitFor(() => expect(screen.getByText('Unable to change file access. Please try again.')).toBeDefined())
+    expect(onChange).not.toHaveBeenCalled()
+  })
+})

--- a/frontend/types/types.ts
+++ b/frontend/types/types.ts
@@ -105,6 +105,7 @@ export interface FileInterface {
   path: string
 
   complete: boolean
+  ungovernedAccess?: boolean
 
   // Older files may not have scans run against them
   scanResults?: AvScanResult[]


### PR DESCRIPTION
### Description of change

Fixes #2551 using the individual-file access option. Model owners can allow downloads of a selected file without an access request, so an uploaded image can be embedded in a model card. Authentication, model visibility and token permissions still apply; other files retain their existing rules.

The UI asks for confirmation before changing access. The service checks model-edit permission and verifies that the file belongs to the specified model. Removing the file exception restores normal access rules, including any model-wide grants.

Validation:
- 1,435 backend tests and 170 frontend tests passed.
- Both production builds, TypeScript checks, changed-file ESLint/Prettier and documentation style checks passed.
- Access-control and target-model regression tests fail with the original service/authorisation code and pass with the changes.
- OpenAPI generation passed; API and model-card usage are documented.

Full deployment and signed-in browser/Cypress testing were not performed.

### Checklist

- [ ] Contributor review of the complete change before merging.
